### PR TITLE
feat: implement warpRoute for ERC721

### DIFF
--- a/src/consts/tokens.ts
+++ b/src/consts/tokens.ts
@@ -13,12 +13,12 @@ export const tokenList: WarpTokenConfig = [
     logoURI: '/logos/weth.png', // See public/logos/
   },
   {
-    type: "collateral",
+    type: 'collateral',
     chainId: 5,
-    address: "0xd03483b978461b3162CE9e4c80835b9E81E07018",
-    hypCollateralAddress: "0x1d30DD33886dE2914D610aDE55C55f5d145743AC",
-    name: "MyToken",
-    symbol: "MTK",
+    address: '0xd03483b978461b3162CE9e4c80835b9E81E07018',
+    hypCollateralAddress: '0x1d30DD33886dE2914D610aDE55C55f5d145743AC',
+    name: 'MyToken',
+    symbol: 'MTK',
     decimals: 0,
     isERC721: true,
   },

--- a/src/consts/tokens.ts
+++ b/src/consts/tokens.ts
@@ -16,7 +16,7 @@ export const tokenList: WarpTokenConfig = [
     type: 'collateral',
     chainId: 5,
     address: '0xd03483b978461b3162CE9e4c80835b9E81E07018',
-    hypCollateralAddress: '0x1d30DD33886dE2914D610aDE55C55f5d145743AC',
+    hypCollateralAddress: '0x9a01dd4dD90dBc27a756Dce5B564D6468795ee14',
     name: 'MyToken',
     symbol: 'MTK',
     decimals: 0,

--- a/src/consts/tokens.ts
+++ b/src/consts/tokens.ts
@@ -11,6 +11,17 @@ export const tokenList: WarpTokenConfig = [
     symbol: 'WETH',
     decimals: 18,
     logoURI: '/logos/weth.png', // See public/logos/
+    isERC721: false,
+  },
+  {
+    type: "collateral",
+    chainId: 5,
+    address: "0xd03483b978461b3162CE9e4c80835b9E81E07018",
+    hypCollateralAddress: "0x1d30DD33886dE2914D610aDE55C55f5d145743AC",
+    name: "MyToken",
+    symbol: "MTK",
+    decimals: 0,
+    isERC721: true,
   },
   // Example native token
   // {

--- a/src/consts/tokens.ts
+++ b/src/consts/tokens.ts
@@ -11,7 +11,6 @@ export const tokenList: WarpTokenConfig = [
     symbol: 'WETH',
     decimals: 18,
     logoURI: '/logos/weth.png', // See public/logos/
-    isERC721: false,
   },
   {
     type: "collateral",

--- a/src/features/contracts/hypToken.ts
+++ b/src/features/contracts/hypToken.ts
@@ -31,35 +31,35 @@ export function getTokenRouterContract(
   }
 }
 
-function getHypErc20CollateralContract(
+export function getHypErc20CollateralContract(
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
 ) {
   return HypERC20Collateral__factory.connect(contractAddress, signerOrProvider);
 }
 
-function getHypErc721CollateralContract(
+export function getHypErc721CollateralContract(
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
 ) {
   return HypERC721Collateral__factory.connect(contractAddress, signerOrProvider);
 }
 
-function getHypErc20Contract(
+export function getHypErc20Contract(
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
 ) {
   return HypERC20__factory.connect(contractAddress, signerOrProvider);
 }
 
-function getHypErc721Contract(
+export function getHypErc721Contract(
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
 ) {
   return HypERC721__factory.connect(contractAddress, signerOrProvider);
 }
 
-function getHypNativeContract(
+export function getHypNativeContract(
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
 ) {

--- a/src/features/contracts/hypToken.ts
+++ b/src/features/contracts/hypToken.ts
@@ -3,21 +3,30 @@ import { Signer, providers } from 'ethers';
 import {
   HypERC20Collateral__factory,
   HypERC20__factory,
+  HypERC721Collateral__factory,
+  HypERC721__factory,
   HypNative__factory,
   TokenType,
 } from '@hyperlane-xyz/hyperlane-token';
 
-// Get the connected HypERC20Collateral, HypNative, or HypERC20 contract
+// Get the connected HypERC20Collateral, HypERC721Collateral, HypNative, HypERC20, HypERC721 contract
 export function getTokenRouterContract(
   type: TokenType,
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
+  isERC721: boolean | false,
 ) {
   if (type === TokenType.collateral) {
+    if (isERC721) {
+      return getHypErc721CollateralContract(contractAddress, signerOrProvider);
+    }
     return getHypErc20CollateralContract(contractAddress, signerOrProvider);
   } else if (type === TokenType.native) {
     return getHypNativeContract(contractAddress, signerOrProvider);
   } else if (type === TokenType.synthetic) {
+    if (isERC721) {
+      return getHypErc721Contract(contractAddress, signerOrProvider);
+    }
     return getHypErc20Contract(contractAddress, signerOrProvider);
   } else {
     throw new Error(`Unsupported token type: ${type}}`);
@@ -31,11 +40,25 @@ function getHypErc20CollateralContract(
   return HypERC20Collateral__factory.connect(contractAddress, signerOrProvider);
 }
 
+function getHypErc721CollateralContract(
+  contractAddress: Address,
+  signerOrProvider: Signer | providers.Provider,
+) {
+  return HypERC721Collateral__factory.connect(contractAddress, signerOrProvider);
+}
+
 function getHypErc20Contract(
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
 ) {
   return HypERC20__factory.connect(contractAddress, signerOrProvider);
+}
+
+function getHypErc721Contract(
+  contractAddress: Address,
+  signerOrProvider: Signer | providers.Provider,
+) {
+  return HypERC721__factory.connect(contractAddress, signerOrProvider);
 }
 
 function getHypNativeContract(

--- a/src/features/contracts/hypToken.ts
+++ b/src/features/contracts/hypToken.ts
@@ -14,20 +14,18 @@ export function getTokenRouterContract(
   type: TokenType,
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
-  isERC721: boolean | false,
+  isERC721: boolean,
 ) {
   if (type === TokenType.collateral) {
-    if (isERC721) {
-      return getHypErc721CollateralContract(contractAddress, signerOrProvider);
-    }
-    return getHypErc20CollateralContract(contractAddress, signerOrProvider);
+    return isERC721
+      ? getHypErc721CollateralContract(contractAddress, signerOrProvider)
+      : getHypErc20CollateralContract(contractAddress, signerOrProvider);
   } else if (type === TokenType.native) {
     return getHypNativeContract(contractAddress, signerOrProvider);
   } else if (type === TokenType.synthetic) {
-    if (isERC721) {
-      return getHypErc721Contract(contractAddress, signerOrProvider);
-    }
-    return getHypErc20Contract(contractAddress, signerOrProvider);
+    return isERC721
+      ? getHypErc721Contract(contractAddress, signerOrProvider)
+      : getHypErc20Contract(contractAddress, signerOrProvider)
   } else {
     throw new Error(`Unsupported token type: ${type}}`);
   }

--- a/src/features/contracts/hypToken.ts
+++ b/src/features/contracts/hypToken.ts
@@ -25,7 +25,7 @@ export function getTokenRouterContract(
   } else if (type === TokenType.synthetic) {
     return isERC721
       ? getHypErc721Contract(contractAddress, signerOrProvider)
-      : getHypErc20Contract(contractAddress, signerOrProvider)
+      : getHypErc20Contract(contractAddress, signerOrProvider);
   } else {
     throw new Error(`Unsupported token type: ${type}}`);
   }

--- a/src/features/contracts/token.ts
+++ b/src/features/contracts/token.ts
@@ -1,10 +1,18 @@
 import { Signer, providers } from 'ethers';
 
 import { ERC20Upgradeable__factory } from '@hyperlane-xyz/core';
+import { ERC721__factory } from '@hyperlane-xyz/hyperlane-token';
 
 export function getErc20Contract(
   contractAddress: Address,
   signerOrProvider: Signer | providers.Provider,
 ) {
   return ERC20Upgradeable__factory.connect(contractAddress, signerOrProvider);
+}
+
+export function getErc721Contract(
+  contractAddress: Address,
+  signerOrProvider: Signer | providers.Provider,
+) {
+  return ERC721__factory.connect(contractAddress, signerOrProvider);
 }

--- a/src/features/tokens/SelectOrInputTokenIds.tsx
+++ b/src/features/tokens/SelectOrInputTokenIds.tsx
@@ -5,9 +5,9 @@ import { TextField } from '../../components/input/TextField';
 import { TransferFormValues } from '../transfer/types';
 
 import { SelectTokenIdField } from './SelectTokenIdField';
-import { useContractSupportsTokenByOwner } from './useTokenBalance';
+import { useContractSupportsTokenByOwner, useOwnerOfErc721 } from './useTokenBalance';
 
-export default function SelectOrInputTokenIds() {
+export default function SelectOrInputTokenIds({ disabled }: { disabled: boolean }) {
   const { address } = useAccount();
   const {
     values: { originChainId, tokenAddress },
@@ -20,8 +20,24 @@ export default function SelectOrInputTokenIds() {
   );
 
   return isContractAllowToGetTokenIds ? (
-    <SelectTokenIdField name="amount" chainId={originChainId} tokenAddress={tokenAddress} />
+    <SelectTokenIdField
+      name="amount"
+      disabled={disabled}
+      chainId={originChainId}
+      tokenAddress={tokenAddress}
+    />
   ) : (
+    <InputTokenId disabled={disabled} />
+  );
+}
+
+function InputTokenId({ disabled }: { disabled: boolean }) {
+  const {
+    values: { originChainId, tokenAddress, amount },
+  } = useFormikContext<TransferFormValues>();
+  useOwnerOfErc721(originChainId, tokenAddress, amount);
+
+  return (
     <div className="relative w-full">
       <TextField
         name="amount"
@@ -29,6 +45,7 @@ export default function SelectOrInputTokenIds() {
         classes="w-full"
         type="number"
         step="any"
+        disabled={disabled}
       />
     </div>
   );

--- a/src/features/tokens/SelectOrInputTokenIds.tsx
+++ b/src/features/tokens/SelectOrInputTokenIds.tsx
@@ -3,12 +3,18 @@ import { useAccount } from 'wagmi';
 
 import { TextField } from '../../components/input/TextField';
 import { TransferFormValues } from '../transfer/types';
-import { getTokenRoute, RoutesMap } from './routes';
 
 import { SelectTokenIdField } from './SelectTokenIdField';
+import { RoutesMap, getTokenRoute } from './routes';
 import { useContractSupportsTokenByOwner, useOwnerOfErc721 } from './useTokenBalance';
 
-export default function SelectOrInputTokenIds({ disabled, tokenRoutes }: { disabled: boolean, tokenRoutes: RoutesMap }) {
+export default function SelectOrInputTokenIds({
+  disabled,
+  tokenRoutes,
+}: {
+  disabled: boolean;
+  tokenRoutes: RoutesMap;
+}) {
   const { address } = useAccount();
   const {
     values: { originChainId, tokenAddress, destinationChainId },
@@ -17,10 +23,10 @@ export default function SelectOrInputTokenIds({ disabled, tokenRoutes }: { disab
   const route = getTokenRoute(originChainId, destinationChainId, tokenAddress, tokenRoutes);
 
   const currentTokenAddress = !route
-  ? ''
-  : route.baseChainId === originChainId
-  ? tokenAddress
-  : route.originTokenAddress;
+    ? ''
+    : route.baseChainId === originChainId
+    ? tokenAddress
+    : route.originTokenAddress;
 
   const { isContractAllowToGetTokenIds } = useContractSupportsTokenByOwner(
     originChainId,
@@ -40,7 +46,7 @@ export default function SelectOrInputTokenIds({ disabled, tokenRoutes }: { disab
   );
 }
 
-function InputTokenId({ disabled, tokenAddress }: { disabled: boolean, tokenAddress: Address }) {
+function InputTokenId({ disabled, tokenAddress }: { disabled: boolean; tokenAddress: Address }) {
   const {
     values: { originChainId, amount },
   } = useFormikContext<TransferFormValues>();

--- a/src/features/tokens/SelectOrInputTokenIds.tsx
+++ b/src/features/tokens/SelectOrInputTokenIds.tsx
@@ -5,7 +5,7 @@ import { TextField } from '../../components/input/TextField';
 import { TransferFormValues } from '../transfer/types';
 
 import { SelectTokenIdField } from './SelectTokenIdField';
-import { useGetIsContractHaveTokenOfOwnerByIndex } from './useTokenBalance';
+import { useContractSupportsTokenByOwner } from './useTokenBalance';
 
 export default function SelectOrInputTokenIds() {
   const { address } = useAccount();
@@ -13,7 +13,7 @@ export default function SelectOrInputTokenIds() {
     values: { originChainId, tokenAddress },
   } = useFormikContext<TransferFormValues>();
 
-  const { isContractAllowToGetTokenIds } = useGetIsContractHaveTokenOfOwnerByIndex(
+  const { isContractAllowToGetTokenIds } = useContractSupportsTokenByOwner(
     originChainId,
     tokenAddress,
     address,

--- a/src/features/tokens/SelectOrInputTokenIds.tsx
+++ b/src/features/tokens/SelectOrInputTokenIds.tsx
@@ -1,0 +1,41 @@
+import { useFormikContext } from 'formik';
+import { useEffect, useState } from 'react';
+import { useAccount } from 'wagmi';
+
+import { TextField } from '../../components/input/TextField';
+import { TransferFormValues } from '../transfer/types';
+
+import { SelectTokenIdField } from './SelectTokenIdField';
+import { isContractHaveTokenOfOwnerByIndex } from './useTokenBalance';
+
+export default function SelectOrInputTokenIds() {
+  const { address } = useAccount();
+  const {
+    values: { originChainId, tokenAddress },
+  } = useFormikContext<TransferFormValues>();
+
+  const [isContractAllowToGetTokenIds, setIsContractAllowToGetTokenIds] = useState(false);
+
+  useEffect(() => {
+    const checkTokenIds = async (chainId: ChainId, tokenAddress: Address, address: Address) => {
+      const isAllow = await isContractHaveTokenOfOwnerByIndex(chainId, tokenAddress, address);
+      setIsContractAllowToGetTokenIds(isAllow);
+    };
+
+    if (address) checkTokenIds(originChainId, tokenAddress, address);
+  }, [originChainId, tokenAddress, address]);
+
+  return isContractAllowToGetTokenIds ? (
+    <SelectTokenIdField name="amount" chainId={originChainId} tokenAddress={tokenAddress} />
+  ) : (
+    <div className="relative w-full">
+      <TextField
+        name="amount"
+        placeholder="Input Token Id"
+        classes="w-full"
+        type="number"
+        step="any"
+      />
+    </div>
+  );
+}

--- a/src/features/tokens/SelectOrInputTokenIds.tsx
+++ b/src/features/tokens/SelectOrInputTokenIds.tsx
@@ -1,12 +1,11 @@
 import { useFormikContext } from 'formik';
-import { useEffect, useState } from 'react';
 import { useAccount } from 'wagmi';
 
 import { TextField } from '../../components/input/TextField';
 import { TransferFormValues } from '../transfer/types';
 
 import { SelectTokenIdField } from './SelectTokenIdField';
-import { isContractHaveTokenOfOwnerByIndex } from './useTokenBalance';
+import { useGetIsContractHaveTokenOfOwnerByIndex } from './useTokenBalance';
 
 export default function SelectOrInputTokenIds() {
   const { address } = useAccount();
@@ -14,16 +13,11 @@ export default function SelectOrInputTokenIds() {
     values: { originChainId, tokenAddress },
   } = useFormikContext<TransferFormValues>();
 
-  const [isContractAllowToGetTokenIds, setIsContractAllowToGetTokenIds] = useState(false);
-
-  useEffect(() => {
-    const checkTokenIds = async (chainId: ChainId, tokenAddress: Address, address: Address) => {
-      const isAllow = await isContractHaveTokenOfOwnerByIndex(chainId, tokenAddress, address);
-      setIsContractAllowToGetTokenIds(isAllow);
-    };
-
-    if (address) checkTokenIds(originChainId, tokenAddress, address);
-  }, [originChainId, tokenAddress, address]);
+  const { isContractAllowToGetTokenIds } = useGetIsContractHaveTokenOfOwnerByIndex(
+    originChainId,
+    tokenAddress,
+    address,
+  );
 
   return isContractAllowToGetTokenIds ? (
     <SelectTokenIdField name="amount" chainId={originChainId} tokenAddress={tokenAddress} />

--- a/src/features/tokens/SelectTokenIdField.tsx
+++ b/src/features/tokens/SelectTokenIdField.tsx
@@ -1,0 +1,88 @@
+import { useField } from 'formik';
+import Image from 'next/image';
+import { useState } from 'react';
+
+import ChevronIcon from '../../images/icons/chevron-down.svg';
+import { Modal } from '../../components/layout/Modal';
+
+type Props = {
+  name: string;
+  disabled?: boolean;
+};
+
+export function SelectTokenIdField({ name, disabled }: Props) {
+  const [, , helpers] = useField<number>(name);
+  const [tokenId, setTokenId] = useState<string | undefined>(undefined)
+  const handleChange = (newTokenId: string) => {
+    helpers.setValue(parseInt(newTokenId));
+    setTokenId(newTokenId)
+  };
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const onClick = () => {
+    if (!disabled) setIsModalOpen(true);
+  };
+
+  return (
+    <div className="flex flex-col items-center">
+      <button
+        type="button"
+        className={`${styles.base}`}
+        onClick={onClick}
+      >
+        <div className="flex items-center">
+          <span className={`ml-2 ${!tokenId && "text-slate-400"}`}>{tokenId ? tokenId : "Select TokenId"}</span>
+        </div>
+        <Image src={ChevronIcon} width={12} height={8} alt="" />
+      </button>
+      <SelectTokenIdModal
+        isOpen={isModalOpen}
+        close={() => setIsModalOpen(false)}
+        onSelect={handleChange}
+      />
+    </div>
+  );
+}
+
+export function SelectTokenIdModal({
+  isOpen,
+  close,
+  onSelect,
+}: {
+  isOpen: boolean;
+  close: () => void;
+  onSelect: (tokenId: string) => void;
+}) {
+  const onSelectTokenId = (tokenId: string) => {
+    return () => {
+      onSelect(tokenId);
+      close();
+    };
+  };
+
+  // const multiProvider = getMultiProvider();
+  const chainMetadata = ["1","2","3","4"];
+
+  return (
+    <Modal isOpen={isOpen} title="Select TokenId" close={close}>
+      <div className="mt-2 flex flex-col space-y-1">
+        {chainMetadata.map((id) => (
+          <button
+            key={id}
+            className="py-1.5 px-2 text-sm flex items-center rounded hover:bg-gray-100 active:bg-gray-200 transition-all duration-200"
+            onClick={onSelectTokenId(id)}
+          >
+            <span className="ml-2">{id}</span>
+          </button>
+        ))}
+      </div>
+    </Modal>
+  );
+}
+
+const styles = {
+  base: 'mt-1.5 w-full px-2.5 py-2 flex items-center justify-between text-sm bg-white rounded border border-gray-400 outline-none transition-colors duration-500',
+  enabled: 'hover:bg-gray-50 active:bg-gray-100 focus:border-blue-500',
+  disabled: 'bg-gray-150 cursor-default',
+};

--- a/src/features/tokens/SelectTokenIdField.tsx
+++ b/src/features/tokens/SelectTokenIdField.tsx
@@ -94,7 +94,7 @@ export function SelectTokenIdModal({
           ))
         ) : (
           <div className="py-1.5 px-2 text-sm text-gray-500 transition-all duration-200">
-            No tokenIds found
+            No token ids found
           </div>
         )}
       </div>

--- a/src/features/tokens/SelectTokenIdField.tsx
+++ b/src/features/tokens/SelectTokenIdField.tsx
@@ -1,12 +1,13 @@
 import { useField } from 'formik';
 import Image from 'next/image';
 import { useState } from 'react';
-
-import ChevronIcon from '../../images/icons/chevron-down.svg';
-import { Modal } from '../../components/layout/Modal';
-import { useTokenIdBalance } from './useTokenBalance';
 import { useAccount } from 'wagmi';
+
 import { Spinner } from '../../components/animation/Spinner';
+import { Modal } from '../../components/layout/Modal';
+import ChevronIcon from '../../images/icons/chevron-down.svg';
+
+import { useTokenIdBalance } from './useTokenBalance';
 
 type Props = {
   name: string;
@@ -17,14 +18,14 @@ type Props = {
 
 export function SelectTokenIdField({ name, chainId, tokenAddress, disabled }: Props) {
   const [, , helpers] = useField<number>(name);
-  const [tokenId, setTokenId] = useState<string | undefined>(undefined)
+  const [tokenId, setTokenId] = useState<string | undefined>(undefined);
   const { address } = useAccount();
   const handleChange = (newTokenId: string) => {
     helpers.setValue(parseInt(newTokenId));
-    setTokenId(newTokenId)
+    setTokenId(newTokenId);
   };
 
-  const { isLoading, tokenIds } = useTokenIdBalance(chainId, tokenAddress, address)
+  const { isLoading, tokenIds } = useTokenIdBalance(chainId, tokenAddress, address);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -34,13 +35,11 @@ export function SelectTokenIdField({ name, chainId, tokenAddress, disabled }: Pr
 
   return (
     <div className="flex flex-col items-center">
-      <button
-        type="button"
-        className={styles.base}
-        onClick={onClick}
-      >
+      <button type="button" className={styles.base} onClick={onClick}>
         <div className="flex items-center">
-          <span className={`ml-2 ${!tokenId && "text-slate-400"}`}>{tokenId ? tokenId : "Select TokenId"}</span>
+          <span className={`ml-2 ${!tokenId && 'text-slate-400'}`}>
+            {tokenId ? tokenId : 'Select Token Id'}
+          </span>
         </div>
         <Image src={ChevronIcon} width={12} height={8} alt="" />
       </button>
@@ -63,8 +62,8 @@ export function SelectTokenIdModal({
   onSelect,
 }: {
   isOpen: boolean;
-  tokenIds: string[] | null | undefined
-  isLoading: boolean
+  tokenIds: string[] | null | undefined;
+  isLoading: boolean;
   close: () => void;
   onSelect: (tokenId: string) => void;
 }) {
@@ -76,15 +75,15 @@ export function SelectTokenIdModal({
   };
 
   return (
-    <Modal isOpen={isOpen} title="Select TokenId" close={close}>
+    <Modal isOpen={isOpen} title="Select Token Id" close={close}>
       <div className="mt-2 flex flex-col space-y-1">
         {isLoading ? (
           <div className="my-24 flex flex-col items-center">
             <Spinner />
-            <h3 className="mt-5 text-sm text-gray-500">Finding tokenIds</h3>
+            <h3 className="mt-5 text-sm text-gray-500">Finding token IDs</h3>
           </div>
-        ) : (
-          tokenIds && tokenIds.length !== 0 ? tokenIds.map((id) => (
+        ) : tokenIds && tokenIds.length !== 0 ? (
+          tokenIds.map((id) => (
             <button
               key={id}
               className="py-1.5 px-2 text-sm flex items-center rounded hover:bg-gray-100 active:bg-gray-200 transition-all duration-200"
@@ -92,9 +91,11 @@ export function SelectTokenIdModal({
             >
               <span className="ml-2">{id}</span>
             </button>
-          )) : (
-            <div className="py-1.5 px-2 text-sm text-gray-500 transition-all duration-200">No tokenIds found</div>
-          )
+          ))
+        ) : (
+          <div className="py-1.5 px-2 text-sm text-gray-500 transition-all duration-200">
+            No tokenIds found
+          </div>
         )}
       </div>
     </Modal>

--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -1,5 +1,6 @@
-import { TokenType } from '@hyperlane-xyz/hyperlane-token';
 import { useMemo, useState } from 'react';
+
+import { TokenType } from '@hyperlane-xyz/hyperlane-token';
 
 import { TokenIcon } from '../../components/icons/TokenIcon';
 import { TextInput } from '../../components/input/TextField';
@@ -82,10 +83,12 @@ export function TokenList({
       const hasRoute = hasTokenRoute(originChainId, destinationChainId, t.address, tokenRoutes);
       if (!q) return hasRoute;
       else
-        return hasRoute &&
-        (t.name.toLowerCase().includes(q) ||
-          t.symbol.toLowerCase().includes(q) ||
-          t.address.toLowerCase().includes(q));
+        return (
+          hasRoute &&
+          (t.name.toLowerCase().includes(q) ||
+            t.symbol.toLowerCase().includes(q) ||
+            t.address.toLowerCase().includes(q))
+        );
     });
   }, [searchQuery, originChainId, destinationChainId, tokenRoutes]);
 
@@ -99,8 +102,10 @@ export function TokenList({
             type="button"
             onClick={() => onSelect(t)}
           >
-            <div className='text-gray-500 text-xs text-left'>{ t.type === TokenType.native ? "Native" : t.isERC721 ? "ERC721" : "ERC20"}</div>
-            <div className='flex items-center'>
+            <div className="text-gray-500 text-xs text-left">
+              {t.type === TokenType.native ? 'Native' : t.isERC721 ? 'ERC721' : 'ERC20'}
+            </div>
+            <div className="flex items-center">
               <TokenIcon token={t} size={30} />
               <div className="ml-3 text-left">
                 <div className="text-sm w-14 truncate">{t.symbol || 'Unknown'}</div>

--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -82,21 +82,10 @@ export function TokenList({
       const hasRoute = hasTokenRoute(originChainId, destinationChainId, t.address, tokenRoutes);
       if (!q) return hasRoute;
       else
-        if(t.type === TokenType.collateral) {
-          return (
-            hasRoute &&
-            (t.name.toLowerCase().includes(q) ||
-              t.symbol.toLowerCase().includes(q) ||
-              t.address.toLowerCase().includes(q)) ||
-              t.isERC721
-          );
-        }
-        return (
-          hasRoute &&
-          (t.name.toLowerCase().includes(q) ||
-            t.symbol.toLowerCase().includes(q) ||
-            t.address.toLowerCase().includes(q))
-        );
+        return hasRoute &&
+        (t.name.toLowerCase().includes(q) ||
+          t.symbol.toLowerCase().includes(q) ||
+          t.address.toLowerCase().includes(q));
     });
   }, [searchQuery, originChainId, destinationChainId, tokenRoutes]);
 

--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -1,3 +1,4 @@
+import { TokenType } from '@hyperlane-xyz/hyperlane-token';
 import { useMemo, useState } from 'react';
 
 import { TokenIcon } from '../../components/icons/TokenIcon';
@@ -81,6 +82,15 @@ export function TokenList({
       const hasRoute = hasTokenRoute(originChainId, destinationChainId, t.address, tokenRoutes);
       if (!q) return hasRoute;
       else
+        if(t.type === TokenType.collateral) {
+          return (
+            hasRoute &&
+            (t.name.toLowerCase().includes(q) ||
+              t.symbol.toLowerCase().includes(q) ||
+              t.address.toLowerCase().includes(q)) ||
+              t.isERC721
+          );
+        }
         return (
           hasRoute &&
           (t.name.toLowerCase().includes(q) ||
@@ -95,21 +105,24 @@ export function TokenList({
       {tokens.length ? (
         tokens.map((t) => (
           <button
-            className="-mx-2 py-2 px-2 flex items-center rounded hover:bg-gray-100 active:bg-gray-200 transition-all duration-250"
+            className="-mx-2 py-2 px-2 rounded hover:bg-gray-100 active:bg-gray-200 transition-all duration-250"
             key={`${t.chainId}-${t.address}`}
             type="button"
             onClick={() => onSelect(t)}
           >
-            <TokenIcon token={t} size={30} />
-            <div className="ml-3 text-left">
-              <div className="text-sm w-14 truncate">{t.symbol || 'Unknown'}</div>
-              <div className="text-xs text-gray-500 w-14 truncate">{t.name || 'Unknown'}</div>
-            </div>
-            <div className="ml-3 text-left">
-              <div className="text-xs">
-                {isNativeToken(t.address) ? 'Native chain token' : `Address: ${t.address}`}
+            <div className='text-gray-500 text-xs text-left'>{ t.type === TokenType.native ? "Native" : t.isERC721 ? "ERC721" : "ERC20"}</div>
+            <div className='flex items-center'>
+              <TokenIcon token={t} size={30} />
+              <div className="ml-3 text-left">
+                <div className="text-sm w-14 truncate">{t.symbol || 'Unknown'}</div>
+                <div className="text-xs text-gray-500 w-14 truncate">{t.name || 'Unknown'}</div>
               </div>
-              <div className=" mt-0.5 text-xs">{`Decimals: ${t.decimals}`}</div>
+              <div className="ml-3 text-left">
+                <div className="text-xs">
+                  {isNativeToken(t.address) ? 'Native chain token' : `Address: ${t.address}`}
+                </div>
+                <div className=" mt-0.5 text-xs">{`Decimals: ${t.decimals}`}</div>
+              </div>
             </div>
           </button>
         ))

--- a/src/features/tokens/TokenSelectField.tsx
+++ b/src/features/tokens/TokenSelectField.tsx
@@ -25,9 +25,10 @@ export function TokenSelectField({
   destinationChainId,
   tokenRoutes,
   disabled,
-  setIsERC721
+  setIsERC721,
 }: Props) {
   const [field, , helpers] = useField<Address>(name);
+  const [, , amountHelpers] = useField("amount");
 
   // Keep local state for token details, but let formik manage field value
   const [token, setToken] = useState<TokenMetadata | undefined>(undefined);
@@ -35,6 +36,8 @@ export function TokenSelectField({
   const handleChange = (newToken: TokenMetadata) => {
     // Set the token address value in formik state
     helpers.setValue(newToken.address);
+    // reset amount after change token
+    amountHelpers.setValue("")
     setToken(newToken);
     setIsERC721(newToken.type === TokenType.collateral ? newToken.isERC721 : false)
   };
@@ -55,7 +58,7 @@ export function TokenSelectField({
       >
         <div className="flex items-center">
           <TokenIcon token={token} size={20} />
-          <span className="ml-2">{token?.symbol || 'Select Token'}</span>
+          <span className={`ml-2 ${!token?.symbol && "text-slate-400"}`}>{token?.symbol || 'Select Token'}</span>
         </div>
         <Image src={ChevronIcon} width={12} height={8} alt="" />
       </button>

--- a/src/features/tokens/TokenSelectField.tsx
+++ b/src/features/tokens/TokenSelectField.tsx
@@ -2,13 +2,14 @@ import { useField } from 'formik';
 import Image from 'next/image';
 import { useState } from 'react';
 
+import { TokenType } from '@hyperlane-xyz/hyperlane-token';
+
 import { TokenIcon } from '../../components/icons/TokenIcon';
 import ChevronIcon from '../../images/icons/chevron-down.svg';
 
 import { TokenListModal } from './TokenListModal';
 import { RoutesMap } from './routes';
 import { TokenMetadata } from './types';
-import { TokenType } from '@hyperlane-xyz/hyperlane-token';
 
 type Props = {
   name: string;
@@ -28,7 +29,7 @@ export function TokenSelectField({
   setIsERC721,
 }: Props) {
   const [field, , helpers] = useField<Address>(name);
-  const [, , amountHelpers] = useField("amount");
+  const [, , amountHelpers] = useField('amount');
 
   // Keep local state for token details, but let formik manage field value
   const [token, setToken] = useState<TokenMetadata | undefined>(undefined);
@@ -37,9 +38,9 @@ export function TokenSelectField({
     // Set the token address value in formik state
     helpers.setValue(newToken.address);
     // reset amount after change token
-    amountHelpers.setValue("")
+    amountHelpers.setValue('');
     setToken(newToken);
-    setIsERC721(newToken.type === TokenType.collateral ? newToken.isERC721 : false)
+    setIsERC721(newToken.type === TokenType.collateral ? newToken.isERC721 : false);
   };
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -58,7 +59,9 @@ export function TokenSelectField({
       >
         <div className="flex items-center">
           <TokenIcon token={token} size={20} />
-          <span className={`ml-2 ${!token?.symbol && "text-slate-400"}`}>{token?.symbol || 'Select Token'}</span>
+          <span className={`ml-2 ${!token?.symbol && 'text-slate-400'}`}>
+            {token?.symbol || 'Select Token'}
+          </span>
         </div>
         <Image src={ChevronIcon} width={12} height={8} alt="" />
       </button>

--- a/src/features/tokens/TokenSelectField.tsx
+++ b/src/features/tokens/TokenSelectField.tsx
@@ -8,6 +8,7 @@ import ChevronIcon from '../../images/icons/chevron-down.svg';
 import { TokenListModal } from './TokenListModal';
 import { RoutesMap } from './routes';
 import { TokenMetadata } from './types';
+import { TokenType } from '@hyperlane-xyz/hyperlane-token';
 
 type Props = {
   name: string;
@@ -15,6 +16,7 @@ type Props = {
   destinationChainId: ChainId;
   tokenRoutes: RoutesMap;
   disabled?: boolean;
+  setIsERC721: (data: boolean) => void;
 };
 
 export function TokenSelectField({
@@ -23,6 +25,7 @@ export function TokenSelectField({
   destinationChainId,
   tokenRoutes,
   disabled,
+  setIsERC721
 }: Props) {
   const [field, , helpers] = useField<Address>(name);
 
@@ -33,6 +36,7 @@ export function TokenSelectField({
     // Set the token address value in formik state
     helpers.setValue(newToken.address);
     setToken(newToken);
+    setIsERC721(newToken.type === TokenType.collateral ? newToken.isERC721 : false)
   };
 
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/features/tokens/metadata.ts
+++ b/src/features/tokens/metadata.ts
@@ -33,7 +33,7 @@ function parseTokenConfigs(configList: WarpTokenConfig): TokenMetadata[] {
         type: TokenType.collateral,
         tokenRouterAddress: token.hypCollateralAddress,
         address: token.address,
-        isERC721: token.isERC721
+        isERC721: !!token.isERC721
       });
     } else if (type == TokenType.native) {
       tokenMetadata.push({

--- a/src/features/tokens/metadata.ts
+++ b/src/features/tokens/metadata.ts
@@ -33,7 +33,7 @@ function parseTokenConfigs(configList: WarpTokenConfig): TokenMetadata[] {
         type: TokenType.collateral,
         tokenRouterAddress: token.hypCollateralAddress,
         address: token.address,
-        isERC721: !!token.isERC721
+        isERC721: !!token.isERC721,
       });
     } else if (type == TokenType.native) {
       tokenMetadata.push({

--- a/src/features/tokens/metadata.ts
+++ b/src/features/tokens/metadata.ts
@@ -33,6 +33,7 @@ function parseTokenConfigs(configList: WarpTokenConfig): TokenMetadata[] {
         type: TokenType.collateral,
         tokenRouterAddress: token.hypCollateralAddress,
         address: token.address,
+        isERC721: token.isERC721
       });
     } else if (type == TokenType.native) {
       tokenMetadata.push({

--- a/src/features/tokens/routes.ts
+++ b/src/features/tokens/routes.ts
@@ -6,8 +6,8 @@ import { utils } from '@hyperlane-xyz/utils';
 
 import { areAddressesEqual, isValidAddress, normalizeAddress } from '../../utils/addresses';
 import { logger } from '../../utils/logger';
-import { getErc20Contract, getErc721Contract } from '../contracts/token';
 import { getTokenRouterContract } from '../contracts/hypToken';
+import { getErc20Contract, getErc721Contract } from '../contracts/token';
 import { getProvider } from '../multiProvider';
 
 import { getAllTokens } from './metadata';
@@ -60,8 +60,7 @@ async function fetchRemoteTokensForCollateralToken(
   token: TokenMetadata,
 ): Promise<TokenMetadataWithHypTokens> {
   const { type, chainId, name, symbol, decimals, tokenRouterAddress } = token;
-  const isERC721 =
-      type === TokenType.collateral ? token.isERC721 : false
+  const isERC721 = type === TokenType.collateral ? token.isERC721 : false;
   logger.info('Inspecting token:', name);
   const provider = getProvider(chainId);
   const tokenRouterContract = getTokenRouterContract(type, tokenRouterAddress, provider, isERC721);
@@ -142,8 +141,7 @@ function computeTokenRoutes(tokens: TokenMetadataWithHypTokens[]) {
         tokenRouterAddress,
         decimals,
       } = token;
-      const isERC721 =
-        token.type === TokenType.collateral ? token.isERC721 : false
+      const isERC721 = token.type === TokenType.collateral ? token.isERC721 : false;
       const { chainId: syntheticChainId, address: hypTokenAddress } = hypToken;
 
       const commonRouteProps = {
@@ -178,7 +176,7 @@ function computeTokenRoutes(tokens: TokenMetadataWithHypTokens[]) {
           originTokenAddress: hypTokenAddress,
           destTokenAddress: otherHypTokenAddress,
           decimals,
-          isERC721
+          isERC721,
         });
         tokenRoutes[otherSynChainId][syntheticChainId].push({
           type: RouteType.SyntheticToSynthetic,
@@ -186,7 +184,7 @@ function computeTokenRoutes(tokens: TokenMetadataWithHypTokens[]) {
           originTokenAddress: otherHypTokenAddress,
           destTokenAddress: hypTokenAddress,
           decimals,
-          isERC721
+          isERC721,
         });
       }
     }

--- a/src/features/tokens/types.ts
+++ b/src/features/tokens/types.ts
@@ -52,7 +52,7 @@ interface NativeTokenConfig extends BaseTokenConfig {
 }
 
 export const WarpTokenConfigSchema = z.array(CollateralTokenSchema.or(NativeTokenSchema));
-export type WarpTokenConfig = Array< CollateralTokenConfig | NativeTokenConfig>;
+export type WarpTokenConfig = Array<CollateralTokenConfig | NativeTokenConfig>;
 
 /**
  * Types for use in the app after processing config

--- a/src/features/tokens/types.ts
+++ b/src/features/tokens/types.ts
@@ -7,7 +7,7 @@ const commonTokenFields = z.object({
   chainId: z.number().positive(),
   name: z.string(),
   symbol: z.string(),
-  decimals: z.number().positive(),
+  decimals: z.number().nonnegative(), // decimals = 0 when convert balanceOf ERC721
   logoURI: z.string().optional(),
 });
 type CommonTokenFields = z.infer<typeof commonTokenFields>;
@@ -30,6 +30,7 @@ const CollateralTokenSchema = commonTokenFields.extend({
   type: z.literal(TokenType.collateral),
   address: z.string(),
   hypCollateralAddress: z.string(),
+  isERC721: z.boolean(),
 });
 
 interface CollateralTokenConfig extends BaseTokenConfig {
@@ -37,6 +38,7 @@ interface CollateralTokenConfig extends BaseTokenConfig {
   type: TokenType.collateral | 'collateral';
   address: Address;
   hypCollateralAddress: Address;
+  isERC721: boolean | false;
 }
 
 const NativeTokenSchema = commonTokenFields.extend({
@@ -50,7 +52,7 @@ interface NativeTokenConfig extends BaseTokenConfig {
 }
 
 export const WarpTokenConfigSchema = z.array(CollateralTokenSchema.or(NativeTokenSchema));
-export type WarpTokenConfig = Array<CollateralTokenConfig | NativeTokenConfig>;
+export type WarpTokenConfig = Array< CollateralTokenConfig | NativeTokenConfig>;
 
 /**
  * Types for use in the app after processing config
@@ -67,6 +69,7 @@ interface BaseTokenMetadata extends CommonTokenFields {
 
 interface CollateralTokenMetadata extends BaseTokenMetadata {
   type: TokenType.collateral;
+  isERC721: boolean | false;
 }
 
 type ZeroAddress = `${typeof ethers.constants.AddressZero}`;

--- a/src/features/tokens/types.ts
+++ b/src/features/tokens/types.ts
@@ -30,7 +30,7 @@ const CollateralTokenSchema = commonTokenFields.extend({
   type: z.literal(TokenType.collateral),
   address: z.string(),
   hypCollateralAddress: z.string(),
-  isERC721: z.boolean(),
+  isERC721: z.boolean().optional(),
 });
 
 interface CollateralTokenConfig extends BaseTokenConfig {
@@ -38,7 +38,7 @@ interface CollateralTokenConfig extends BaseTokenConfig {
   type: TokenType.collateral | 'collateral';
   address: Address;
   hypCollateralAddress: Address;
-  isERC721: boolean | false;
+  isERC721?: boolean;
 }
 
 const NativeTokenSchema = commonTokenFields.extend({
@@ -69,7 +69,7 @@ interface BaseTokenMetadata extends CommonTokenFields {
 
 interface CollateralTokenMetadata extends BaseTokenMetadata {
   type: TokenType.collateral;
-  isERC721: boolean | false;
+  isERC721: boolean;
 }
 
 type ZeroAddress = `${typeof ethers.constants.AddressZero}`;

--- a/src/features/tokens/useTokenBalance.tsx
+++ b/src/features/tokens/useTokenBalance.tsx
@@ -2,7 +2,7 @@ import { QueryClient, useQuery } from '@tanstack/react-query';
 import { useAccount } from 'wagmi';
 
 import { logger } from '../../utils/logger';
-import { getErc20Contract } from '../contracts/token';
+import { getErc20Contract, getErc721Contract } from '../contracts/token';
 import { getProvider } from '../multiProvider';
 
 import { isNativeToken } from './utils';
@@ -65,3 +65,13 @@ async function fetchTokenBalance(chainId: ChainId, tokenAddress: Address, accoun
     return balance.toString();
   }
 }
+
+// async function fetchListOfERC721TokenID(chainId: ChainId, tokenAddress: Address, accountAddress: Address, total: Number) {
+//   logger.debug(`Fetching list of tokenID for account ${accountAddress} on chain ${chainId}`);
+
+//   const erc721 = getErc721Contract(tokenAddress, getProvider(chainId));
+//   await erc721.balanceOf(accountAddress)
+//   const balance = await provider.getBalance(accountAddress);
+//   logger.debug(`Native token balance: ${balance.toString()}`);
+//   return balance.toString();
+// }

--- a/src/features/tokens/useTokenBalance.tsx
+++ b/src/features/tokens/useTokenBalance.tsx
@@ -122,6 +122,17 @@ export function getCachedOwnerOf(
     | undefined;
 }
 
+export function getCachedTokenIdBalance(
+  queryClient: QueryClient,
+  chainId: ChainId,
+  tokenAddress: Address,
+  accountAddress?: Address,
+) {
+  return queryClient.getQueryData(getTokenIdKey(chainId, tokenAddress, accountAddress)) as
+    | string[]
+    | undefined;
+}
+
 export function getCachedTokenBalance(
   queryClient: QueryClient,
   chainId: ChainId,

--- a/src/features/tokens/useTokenBalance.tsx
+++ b/src/features/tokens/useTokenBalance.tsx
@@ -2,7 +2,7 @@ import { QueryClient, useQuery } from '@tanstack/react-query';
 import { useAccount } from 'wagmi';
 
 import { logger } from '../../utils/logger';
-import { getErc20Contract } from '../contracts/erc20';
+import { getErc20Contract } from '../contracts/token';
 import { getProvider } from '../multiProvider';
 
 import { isNativeToken } from './utils';

--- a/src/features/tokens/useTokenBalance.tsx
+++ b/src/features/tokens/useTokenBalance.tsx
@@ -20,12 +20,12 @@ export function getTokenIdKey(chainId: ChainId, tokenAddress: Address, accountAd
   return ['tokenId', chainId, tokenAddress, accountAddress];
 }
 
-export function getIsContractHaveTokenOfOwnerByIndexKey(
+export function contractSupportsTokenByOwnerKey(
   chainId: ChainId,
   tokenAddress: Address,
   accountAddress?: Address,
 ) {
-  return ['isContractHaveTokenOfOwnerByIndex', chainId, tokenAddress, accountAddress];
+  return ['contractSupportsTokenByOwner', chainId, tokenAddress, accountAddress];
 }
 
 export function useAccountTokenBalance(chainId: ChainId, tokenAddress: Address) {
@@ -50,7 +50,7 @@ export function useTokenBalance(chainId: ChainId, tokenAddress: Address, account
   return { isLoading, hasError, balance };
 }
 
-export function useGetIsContractHaveTokenOfOwnerByIndex(
+export function useContractSupportsTokenByOwner(
   chainId: ChainId,
   tokenAddress: Address,
   accountAddress?: Address,
@@ -60,10 +60,10 @@ export function useGetIsContractHaveTokenOfOwnerByIndex(
     isError: hasError,
     data: isContractAllowToGetTokenIds,
   } = useQuery({
-    queryKey: getIsContractHaveTokenOfOwnerByIndexKey(chainId, tokenAddress, accountAddress),
+    queryKey: contractSupportsTokenByOwnerKey(chainId, tokenAddress, accountAddress),
     queryFn: () => {
       if (!chainId || !tokenAddress || !accountAddress) return null;
-      return isContractHaveTokenOfOwnerByIndex(chainId, tokenAddress, accountAddress);
+      return contractSupportsTokenByOwner(chainId, tokenAddress, accountAddress);
     },
   });
 
@@ -141,7 +141,7 @@ export async function fetchListOfERC721TokenId(
   return result;
 }
 
-export async function isContractHaveTokenOfOwnerByIndex(
+export async function contractSupportsTokenByOwner(
   chainId: ChainId,
   tokenAddress: Address,
   accountAddress: Address,

--- a/src/features/tokens/useTokenBalance.tsx
+++ b/src/features/tokens/useTokenBalance.tsx
@@ -20,6 +20,14 @@ export function getTokenIdKey(chainId: ChainId, tokenAddress: Address, accountAd
   return ['tokenId', chainId, tokenAddress, accountAddress];
 }
 
+export function getIsContractHaveTokenOfOwnerByIndexKey(
+  chainId: ChainId,
+  tokenAddress: Address,
+  accountAddress?: Address,
+) {
+  return ['isContractHaveTokenOfOwnerByIndex', chainId, tokenAddress, accountAddress];
+}
+
 export function useAccountTokenBalance(chainId: ChainId, tokenAddress: Address) {
   const { address: accountAddress } = useAccount();
   return useTokenBalance(chainId, tokenAddress, accountAddress);
@@ -42,6 +50,26 @@ export function useTokenBalance(chainId: ChainId, tokenAddress: Address, account
   return { isLoading, hasError, balance };
 }
 
+export function useGetIsContractHaveTokenOfOwnerByIndex(
+  chainId: ChainId,
+  tokenAddress: Address,
+  accountAddress?: Address,
+) {
+  const {
+    isLoading,
+    isError: hasError,
+    data: isContractAllowToGetTokenIds,
+  } = useQuery({
+    queryKey: getIsContractHaveTokenOfOwnerByIndexKey(chainId, tokenAddress, accountAddress),
+    queryFn: () => {
+      if (!chainId || !tokenAddress || !accountAddress) return null;
+      return isContractHaveTokenOfOwnerByIndex(chainId, tokenAddress, accountAddress);
+    },
+  });
+
+  return { isLoading, hasError, isContractAllowToGetTokenIds };
+}
+
 export function useTokenIdBalance(
   chainId: ChainId,
   tokenAddress: Address,
@@ -50,7 +78,6 @@ export function useTokenIdBalance(
   const {
     isLoading,
     isError: hasError,
-    error: error,
     data: tokenIds,
   } = useQuery({
     queryKey: getTokenIdKey(chainId, tokenAddress, accountAddress),
@@ -61,7 +88,7 @@ export function useTokenIdBalance(
     refetchInterval: 7500,
   });
 
-  return { isLoading, hasError, error, tokenIds };
+  return { isLoading, hasError, tokenIds };
 }
 
 export function getCachedTokenBalance(

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -26,7 +26,6 @@ import {
   getCachedOwnerOf,
   getCachedTokenBalance,
   useAccountTokenBalance,
-  useOwnerOfErc721,
 } from '../tokens/useTokenBalance';
 
 import { TransferFormValues } from './types';
@@ -146,7 +145,7 @@ export function TransferTokenForm({ tokenRoutes }: { tokenRoutes: RoutesMap }) {
                 <SelfTokenBalance tokenRoutes={tokenRoutes} />
               </div>
               {isERC721 ? (
-                <SelectOrInputTokenIds />
+                <SelectOrInputTokenIds disabled={isReview} />
               ) : (
                 <div className="relative w-full">
                   <TextField
@@ -251,7 +250,7 @@ function TokenBalance({
 
 function useSelfTokenBalance(tokenRoutes) {
   const { values } = useFormikContext<TransferFormValues>();
-  const { originChainId, destinationChainId, tokenAddress, amount } = values;
+  const { originChainId, destinationChainId, tokenAddress } = values;
   const route = getTokenRoute(originChainId, destinationChainId, tokenAddress, tokenRoutes);
   const addressForBalance = !route
     ? ''
@@ -260,7 +259,6 @@ function useSelfTokenBalance(tokenRoutes) {
     : route.originTokenAddress;
   const decimals = !route ? STANDARD_TOKEN_DECIMALS : route.decimals;
   const { balance } = useAccountTokenBalance(originChainId, addressForBalance);
-  useOwnerOfErc721(originChainId, tokenAddress, amount);
   return {
     balance,
     decimals,

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -140,7 +140,11 @@ export function TransferTokenForm({ tokenRoutes }: { tokenRoutes: RoutesMap }) {
                 <SelfTokenBalance tokenRoutes={tokenRoutes} />
               </div>
               { isERC721 ?
-                <SelectTokenIdField name="amount"/>
+                <SelectTokenIdField
+                  name="amount"
+                  chainId={values.originChainId}
+                  tokenAddress={values.tokenAddress}
+                />
                 :
                 <div className="relative w-full">
                   <TextField

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -371,10 +371,10 @@ function validateFormValues(
   const route = getTokenRoute(originChainId, destinationChainId, tokenAddress, tokenRoutes);
 
   const currentTokenAddress = !route
-  ? ''
-  : route.baseChainId === originChainId
-  ? tokenAddress
-  : route.originTokenAddress;
+    ? ''
+    : route.baseChainId === originChainId
+    ? tokenAddress
+    : route.originTokenAddress;
 
   if (!originChainId) return { originChainId: 'Invalid origin chain' };
   if (!destinationChainId) return { destinationChainId: 'Invalid destination chain' };

--- a/src/features/transfer/types.ts
+++ b/src/features/transfer/types.ts
@@ -8,6 +8,14 @@ export interface TransferFormValues {
   recipientAddress: Address;
 }
 
+export interface ERC721TransferFormValues {
+  originChainId: ChainId;
+  destinationChainId: ChainId;
+  tokenId: string;
+  tokenAddress: Address;
+  recipientAddress: Address;
+}
+
 export enum TransferStatus {
   Preparing = 'preparing',
   CreatingApprove = 'creating-approve',
@@ -24,7 +32,7 @@ export enum TransferStatus {
 export interface TransferContext {
   status: TransferStatus;
   route: Route;
-  params: TransferFormValues;
+  params: TransferFormValues | ERC721TransferFormValues;
   originTxHash?: string;
   msgId?: string;
 }

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -12,20 +12,159 @@ import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { toWei } from '../../utils/amount';
 import { logger } from '../../utils/logger';
 import { sleep } from '../../utils/timeout';
-import { getErc20Contract } from '../contracts/erc20';
-import { getTokenRouterContract } from '../contracts/hypErc20';
+import { getErc20Contract, getErc721Contract } from '../contracts/token';
+import { getTokenRouterContract } from '../contracts/hypToken';
 import { getMultiProvider, getProvider } from '../multiProvider';
 import { useStore } from '../store';
 import { Route, RouteType, RoutesMap, getTokenRoute } from '../tokens/routes';
 import { isNativeToken } from '../tokens/utils';
 
-import { TransferFormValues, TransferStatus } from './types';
+import { TransferFormValues, ERC721TransferFormValues, TransferStatus } from './types';
 
 // Note, this doesn't use wagmi's prepare + send pattern because we're potentially sending two transactions
 // The prepare hooks are recommended to use pre-click downtime to run async calls, but since the flow
 // may require two serial txs, the prepare hooks aren't useful and complicate hook architecture considerably.
 // See https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/issues/19
 // See https://github.com/wagmi-dev/wagmi/discussions/1564
+export function useERC721Transfer(onDone?: () => void) {
+  const { transfers, addTransfer, updateTransferStatus } = useStore((s) => ({
+    transfers: s.transfers,
+    addTransfer: s.addTransfer,
+    updateTransferStatus: s.updateTransferStatus,
+  }));
+  const transferIndex = transfers.length;
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const chainId = useChainId();
+
+  // TODO implement cancel callback for when modal is closed?
+  const triggerTransactions = useCallback(
+    async (values: TransferFormValues, tokenRoutes: RoutesMap) => {
+      logger.debug('Preparing transfer transaction(s)');
+      setIsLoading(true);
+      let status: TransferStatus = TransferStatus.Preparing;
+      const erc721Values = convertToERC721TransferFormValues(values);
+      try {
+        const { tokenId, originChainId, destinationChainId, recipientAddress, tokenAddress } =
+        erc721Values;
+
+        const tokenRoute = getTokenRoute(
+          originChainId,
+          destinationChainId,
+          tokenAddress,
+          tokenRoutes,
+        );
+        if (!tokenRoute) throw new Error('No token route found between chains');
+
+        const isBaseToSynthetic = tokenRoute.type === RouteType.BaseToSynthetic;
+
+        const provider = getProvider(originChainId);
+
+        addTransfer({
+          status,
+          route: tokenRoute,
+          params: values,
+        });
+
+        if (originChainId !== chainId) {
+          await switchNetwork({
+            chainId: originChainId,
+          });
+          // Some wallets seem to require a brief pause after switch
+          await sleep(1500);
+        }
+
+        if (isTransferApproveRequired(tokenRoute, tokenAddress)) {
+          updateTransferStatus(transferIndex, (status = TransferStatus.CreatingApprove));
+          const erc721 = getErc721Contract(tokenAddress, provider);
+          const approveTxRequest = await erc721.populateTransaction.approve(
+            tokenRoute.tokenRouterAddress,
+            tokenId,
+          );
+
+          updateTransferStatus(transferIndex, (status = TransferStatus.SigningApprove));
+          const { wait: approveWait } = await sendTransaction({
+            chainId: originChainId,
+            request: approveTxRequest,
+            mode: 'recklesslyUnprepared', // See note above function
+          });
+
+          updateTransferStatus(transferIndex, (status = TransferStatus.ConfirmingApprove));
+          const approveTxReceipt = await approveWait(1);
+          logger.debug('Approve transaction confirmed, hash:', approveTxReceipt.transactionHash);
+          toastTxSuccess(
+            'Approve transaction sent!',
+            approveTxReceipt.transactionHash,
+            originChainId,
+          );
+        }
+
+        updateTransferStatus(transferIndex, (status = TransferStatus.CreatingTransfer));
+        const contractType: TokenType = !isBaseToSynthetic
+          ? TokenType.synthetic
+          : TokenType.collateral;
+        console.log({contractType})
+        const tokenRouterContract = getTokenRouterContract(
+          contractType,
+          tokenRoute.originTokenAddress,
+          provider,
+          true
+        );
+        console.log({tokenRouterContract}, {destinationChainId})
+        const gasPayment = await tokenRouterContract.quoteGasPayment(destinationChainId);
+        const msgValue = gasPayment;
+        console.log({msgValue})
+        const transferTxRequest = await tokenRouterContract.populateTransaction.transferRemote(
+          destinationChainId,
+          utils.addressToBytes32(recipientAddress),
+          tokenId,
+          {
+            value: msgValue,
+          },
+        );
+        console.log({transferTxRequest})
+
+        updateTransferStatus(transferIndex, (status = TransferStatus.SigningTransfer));
+        const { wait: transferWait, hash: originTxHash } = await sendTransaction({
+          chainId: originChainId,
+          request: transferTxRequest,
+          mode: 'recklesslyUnprepared', // See note above function
+        });
+
+        updateTransferStatus(transferIndex, (status = TransferStatus.ConfirmingTransfer));
+        const transferReceipt = await transferWait(1);
+        const msgId = tryGetMsgIdFromTransferReceipt(transferReceipt);
+
+        updateTransferStatus(transferIndex, (status = TransferStatus.ConfirmedTransfer), {
+          originTxHash,
+          msgId,
+        });
+        logger.debug('Transfer transaction confirmed, hash:', originTxHash);
+        toastTxSuccess('Remote transfer started!', originTxHash, originChainId);
+      } catch (error) {
+        logger.error(`Error at stage ${status} `, error);
+        updateTransferStatus(transferIndex, TransferStatus.Failed);
+        if (JSON.stringify(error).includes('ChainMismatchError')) {
+          // Wagmi switchNetwork call helps prevent this but isn't foolproof
+          toast.error('Wallet must be connected to origin chain');
+        } else {
+          toast.error(errorMessages[status] || 'Unable to transfer tokens.');
+        }
+      }
+
+      setIsLoading(false);
+      if (onDone) onDone();
+    },
+    [setIsLoading, onDone, chainId, addTransfer, updateTransferStatus, transferIndex],
+  );
+
+  return {
+    isLoading,
+    triggerTransactions,
+  };
+}
+
 export function useTokenTransfer(onDone?: () => void) {
   const { transfers, addTransfer, updateTransferStatus } = useStore((s) => ({
     transfers: s.transfers,
@@ -111,6 +250,7 @@ export function useTokenTransfer(onDone?: () => void) {
           contractType,
           tokenRoute.originTokenAddress,
           provider,
+          false
         );
         const gasPayment = await tokenRouterContract.quoteGasPayment(destinationChainId);
         const msgValue = contractType === TokenType.native ? gasPayment.add(weiAmount) : gasPayment;
@@ -165,6 +305,18 @@ export function useTokenTransfer(onDone?: () => void) {
 
 export function isTransferApproveRequired(route: Route, tokenAddress: string) {
   return !isNativeToken(tokenAddress) && route.type === RouteType.BaseToSynthetic;
+}
+
+function convertToERC721TransferFormValues(
+  values: TransferFormValues
+): ERC721TransferFormValues {
+  return {
+    originChainId: values.originChainId,
+    destinationChainId: values.destinationChainId,
+    tokenId: values.amount,
+    tokenAddress: values.tokenAddress,
+    recipientAddress: values.recipientAddress,
+  };
 }
 
 function tryGetMsgIdFromTransferReceipt(receipt: providers.TransactionReceipt) {

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -19,7 +19,7 @@ import { useStore } from '../store';
 import { Route, RouteType, RoutesMap, getTokenRoute } from '../tokens/routes';
 import { isNativeToken } from '../tokens/utils';
 
-import { TransferFormValues, ERC721TransferFormValues, TransferStatus } from './types';
+import { TransferFormValues, TransferStatus } from './types';
 
 // Note, this doesn't use wagmi's prepare + send pattern because we're potentially sending two transactions
 // The prepare hooks are recommended to use pre-click downtime to run async calls, but since the flow

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -12,8 +12,8 @@ import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { toWei } from '../../utils/amount';
 import { logger } from '../../utils/logger';
 import { sleep } from '../../utils/timeout';
-import { getErc20Contract, getErc721Contract } from '../contracts/token';
 import { getTokenRouterContract } from '../contracts/hypToken';
+import { getErc20Contract, getErc721Contract } from '../contracts/token';
 import { getMultiProvider, getProvider } from '../multiProvider';
 import { useStore } from '../store';
 import { Route, RouteType, RoutesMap, getTokenRoute } from '../tokens/routes';
@@ -59,8 +59,7 @@ export function useTokenTransfer(onDone?: () => void) {
 
         const isBaseToSynthetic = tokenRoute.type === RouteType.BaseToSynthetic;
         const isTokenNative = isNativeToken(tokenAddress);
-        const sendValue =
-          isERC721 ? amount : toWei(amount, tokenRoute.decimals).toString();
+        const sendValue = isERC721 ? amount : toWei(amount, tokenRoute.decimals).toString();
 
         const provider = getProvider(originChainId);
 
@@ -80,7 +79,9 @@ export function useTokenTransfer(onDone?: () => void) {
 
         if (isTransferApproveRequired(tokenRoute, tokenAddress)) {
           updateTransferStatus(transferIndex, (status = TransferStatus.CreatingApprove));
-          const tokenContract = isERC721 ? getErc721Contract(tokenAddress, provider) : getErc20Contract(tokenAddress, provider);
+          const tokenContract = isERC721
+            ? getErc721Contract(tokenAddress, provider)
+            : getErc20Contract(tokenAddress, provider);
           const approveTxRequest = await tokenContract.populateTransaction.approve(
             tokenRoute.tokenRouterAddress,
             sendValue,
@@ -113,7 +114,7 @@ export function useTokenTransfer(onDone?: () => void) {
           contractType,
           tokenRoute.originTokenAddress,
           provider,
-          false
+          false,
         );
         const gasPayment = await tokenRouterContract.quoteGasPayment(destinationChainId);
         const msgValue = contractType === TokenType.native ? gasPayment.add(sendValue) : gasPayment;


### PR DESCRIPTION
# What
- I added a config to. distinguish between ERC20 and ERC721
- if ERC721 decimals should be 0 to reuse balanceOf function from code
```
export const tokenList: WarpTokenConfig = [
  // Example collateral token
  {
    type: 'collateral',
    chainId: 5,
    address: '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6',
    hypCollateralAddress: '0x145de8760021c4ac6676376691b78038d3DE9097',
    name: 'Weth',
    symbol: 'WETH',
    decimals: 18,
    logoURI: '/logos/weth.png', // See public/logos/
    isERC721: false,
  },
  {
    type: "collateral",
    chainId: 5,
    address: "0xd03483b978461b3162CE9e4c80835b9E81E07018",
    hypCollateralAddress: "0x1d30DD33886dE2914D610aDE55C55f5d145743AC",
    name: "MyToken",
    symbol: "MTK",
    decimals: 0,       // 0 for ERC721
    isERC721: true,  // distinguish between ERC20 and ERC721
  },
....
```
# Reference
## hyperlane-deploy 
Deploy warpRoute for ERC721
https://github.com/hyperlane-xyz/hyperlane-deploy/pull/54
## Task
https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/2201
# Demo
## Transaction 

https://explorer.hyperlane.xyz/message/0xbc956a15cf84c2cad5e500a563f909350bb698fc91bbfe67ec0a47259c80f790

## Video
https://youtu.be/Azhg4nEUQCE