### PR TITLE
Rename CAIP var names for clarity

### DIFF
--- a/src/components/buttons/ConnectAwareSubmitButton.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.tsx
@@ -10,17 +10,17 @@ import { useTimeout } from '../../utils/timeout';
 import { SolidButton } from './SolidButton';
 
 interface Props {
-  caip2Id: Caip2Id;
+  chainCaip2Id: ChainCaip2Id;
   text: string;
   classes?: string;
 }
 
-export function ConnectAwareSubmitButton<FormValues = any>({ caip2Id, text, classes }: Props) {
-  const protocol = tryGetProtocolType(caip2Id) || ProtocolType.Ethereum;
+export function ConnectAwareSubmitButton<FormValues = any>({ chainCaip2Id, text, classes }: Props) {
+  const protocol = tryGetProtocolType(chainCaip2Id) || ProtocolType.Ethereum;
   const connectFns = useConnectFns();
   const connectFn = connectFns[protocol];
 
-  const account = useAccountForChain(caip2Id);
+  const account = useAccountForChain(chainCaip2Id);
   const isAccountReady = account?.isReady;
 
   const { errors, setErrors, touched, setTouched } = useFormikContext<FormValues>();

--- a/src/components/icons/ChainLogo.tsx
+++ b/src/components/icons/ChainLogo.tsx
@@ -10,17 +10,17 @@ import { logger } from '../../utils/logger';
 import { isNumeric } from '../../utils/string';
 
 type Props = Omit<ComponentProps<typeof ChainLogoInner>, 'chainId' | 'chainName'> & {
-  caip2Id?: Caip2Id;
+  chainCaip2Id?: ChainCaip2Id;
 };
 
 export function ChainLogo(props: Props) {
-  const { caip2Id, ...rest } = props;
+  const { chainCaip2Id, ...rest } = props;
   const { chainId, chainName, icon } = useMemo(() => {
-    if (!caip2Id) return {};
+    if (!chainCaip2Id) return {};
     try {
-      const { reference } = parseCaip2Id(caip2Id);
+      const { reference } = parseCaip2Id(chainCaip2Id);
       const chainId = isNumeric(reference) ? parseInt(reference, 10) : undefined;
-      const chainName = getChainDisplayName(caip2Id);
+      const chainName = getChainDisplayName(chainCaip2Id);
       const logoUri = getMultiProvider().tryGetChainMetadata(reference)?.logoURI;
       const icon = logoUri
         ? (props: { width: number; height: number; title?: string }) => (
@@ -36,7 +36,7 @@ export function ChainLogo(props: Props) {
       logger.error('Failed to parse caip2 id', error);
       return {};
     }
-  }, [caip2Id]);
+  }, [chainCaip2Id]);
 
   return <ChainLogoInner {...rest} chainId={chainId} chainName={chainName} icon={icon} />;
 }

--- a/src/components/icons/TokenIcon.tsx
+++ b/src/components/icons/TokenIcon.tsx
@@ -20,7 +20,9 @@ function _TokenIcon({ token, size = 32 }: Props) {
   const fontSize = Math.floor(size / 2);
 
   const bgColorSeed =
-    token && !imageSrc ? (Buffer.from(getTokenAddress(token.caip19Id)).at(0) || 0) % 5 : undefined;
+    token && !imageSrc
+      ? (Buffer.from(getTokenAddress(token.tokenCaip19Id)).at(0) || 0) % 5
+      : undefined;
 
   return (
     <Circle size={size} bgColorSeed={bgColorSeed} title={title}>

--- a/src/components/toast/TxSuccessToast.tsx
+++ b/src/components/toast/TxSuccessToast.tsx
@@ -4,8 +4,8 @@ import { toast } from 'react-toastify';
 import { parseCaip2Id } from '../../features/caip/chains';
 import { getMultiProvider } from '../../features/multiProvider';
 
-export function toastTxSuccess(msg: string, txHash: string, caip2Id: Caip2Id) {
-  toast.success(<TxSuccessToast msg={msg} txHash={txHash} caip2Id={caip2Id} />, {
+export function toastTxSuccess(msg: string, txHash: string, chainCaip2Id: ChainCaip2Id) {
+  toast.success(<TxSuccessToast msg={msg} txHash={txHash} chainCaip2Id={chainCaip2Id} />, {
     autoClose: 12000,
   });
 }
@@ -13,16 +13,16 @@ export function toastTxSuccess(msg: string, txHash: string, caip2Id: Caip2Id) {
 export function TxSuccessToast({
   msg,
   txHash,
-  caip2Id,
+  chainCaip2Id,
 }: {
   msg: string;
   txHash: string;
-  caip2Id: Caip2Id;
+  chainCaip2Id: ChainCaip2Id;
 }) {
   const url = useMemo(() => {
-    const { reference } = parseCaip2Id(caip2Id);
+    const { reference } = parseCaip2Id(chainCaip2Id);
     return getMultiProvider().tryGetExplorerTxUrl(reference, { hash: txHash });
-  }, [caip2Id, txHash]);
+  }, [chainCaip2Id, txHash]);
 
   return (
     <div>

--- a/src/features/caip/chains.ts
+++ b/src/features/caip/chains.ts
@@ -4,7 +4,7 @@ import { logger } from '../../utils/logger';
 
 // Based mostly on https://chainagnostic.org/CAIPs/caip-2
 // But uses different naming for the protocol
-export function getCaip2Id(protocol: ProtocolType, reference: string | number): Caip2Id {
+export function getCaip2Id(protocol: ProtocolType, reference: string | number): ChainCaip2Id {
   if (!Object.values(ProtocolType).includes(protocol)) {
     throw new Error(`Invalid chain environment: ${protocol}`);
   }
@@ -14,7 +14,7 @@ export function getCaip2Id(protocol: ProtocolType, reference: string | number): 
   return `${protocol}:${reference}`;
 }
 
-export function parseCaip2Id(id: Caip2Id) {
+export function parseCaip2Id(id: ChainCaip2Id) {
   const [_protocol, reference] = id.split(':');
   const protocol = _protocol as ProtocolType;
   if (!Object.values(ProtocolType).includes(protocol)) {
@@ -26,7 +26,7 @@ export function parseCaip2Id(id: Caip2Id) {
   return { protocol, reference };
 }
 
-export function tryParseCaip2Id(id: Caip2Id) {
+export function tryParseCaip2Id(id: ChainCaip2Id) {
   if (!id) return undefined;
   try {
     return parseCaip2Id(id);
@@ -36,25 +36,25 @@ export function tryParseCaip2Id(id: Caip2Id) {
   }
 }
 
-export function getProtocolType(id: Caip2Id) {
+export function getProtocolType(id: ChainCaip2Id) {
   const { protocol } = parseCaip2Id(id);
   return protocol;
 }
 
-export function tryGetProtocolType(id: Caip2Id) {
+export function tryGetProtocolType(id: ChainCaip2Id) {
   return tryParseCaip2Id(id)?.protocol;
 }
 
-export function getChainReference(id: Caip2Id) {
+export function getChainReference(id: ChainCaip2Id) {
   const { reference } = parseCaip2Id(id);
   return reference;
 }
 
-export function tryGetChainReference(id: Caip2Id) {
+export function tryGetChainReference(id: ChainCaip2Id) {
   return tryParseCaip2Id(id)?.reference;
 }
 
-export function getEthereumChainId(id: Caip2Id): number {
+export function getEthereumChainId(id: ChainCaip2Id): number {
   const { protocol, reference } = parseCaip2Id(id);
   if (protocol !== ProtocolType.Ethereum) {
     throw new Error(`Protocol type must be ethereum: ${id}`);

--- a/src/features/caip/tokens.ts
+++ b/src/features/caip/tokens.ts
@@ -17,36 +17,36 @@ export enum AssetNamespace {
 // Based mostly on https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md
 // But uses simpler asset namespace naming for native tokens
 export function getCaip19Id(
-  caip2Id: Caip2Id,
+  chainCaip2Id: ChainCaip2Id,
   namespace: AssetNamespace,
   address: Address,
   tokenId?: string | number,
-): Caip19Id {
+): TokenCaip19Id {
   if (!Object.values(AssetNamespace).includes(namespace)) {
     throw new Error(`Invalid asset namespace: ${namespace}`);
   }
   if (!isValidAddress(address)) {
     throw new Error(`Invalid address: ${address}`);
   }
-  return `${caip2Id}/${namespace}:${address}${tokenId ? `/${tokenId}` : ''}`;
+  return `${chainCaip2Id}/${namespace}:${address}${tokenId ? `/${tokenId}` : ''}`;
 }
 
-export function parseCaip19Id(id: Caip19Id) {
+export function parseCaip19Id(id: TokenCaip19Id) {
   const segments = id.split('/');
   if (segments.length >= 2) {
-    const caip2Id = segments[0] as Caip2Id;
+    const chainCaip2Id = segments[0] as ChainCaip2Id;
     const [namespace, address] = segments[1].split(':') as [AssetNamespace, Address];
-    if (!caip2Id || !namespace || !address) {
+    if (!chainCaip2Id || !namespace || !address) {
       throw new Error(`Invalid caip19 id: ${id}`);
     }
     const tokenId = segments.length > 2 ? segments[2] : undefined;
-    return { caip2Id, namespace, address, tokenId };
+    return { chainCaip2Id, namespace, address, tokenId };
   } else {
     throw new Error(`Invalid caip19 id: ${id}`);
   }
 }
 
-export function tryParseCaip19Id(id: Caip19Id) {
+export function tryParseCaip19Id(id: TokenCaip19Id) {
   if (!id) return undefined;
   try {
     return parseCaip19Id(id);
@@ -56,23 +56,23 @@ export function tryParseCaip19Id(id: Caip19Id) {
   }
 }
 
-export function getCaip2FromToken(id: Caip19Id): Caip2Id {
-  return parseCaip19Id(id).caip2Id;
+export function getChainIdFromToken(id: TokenCaip19Id): ChainCaip2Id {
+  return parseCaip19Id(id).chainCaip2Id;
 }
 
-export function tryGetCaip2FromToken(id: Caip19Id): Caip2Id | undefined {
-  return tryParseCaip19Id(id)?.caip2Id;
+export function tryGetChainIdFromToken(id: TokenCaip19Id): ChainCaip2Id | undefined {
+  return tryParseCaip19Id(id)?.chainCaip2Id;
 }
 
-export function getAssetNamespace(id: Caip19Id): AssetNamespace {
+export function getAssetNamespace(id: TokenCaip19Id): AssetNamespace {
   return parseCaip19Id(id).namespace as AssetNamespace;
 }
 
-export function getTokenAddress(id: Caip19Id): Address {
+export function getTokenAddress(id: TokenCaip19Id): Address {
   return parseCaip19Id(id).address;
 }
 
-export function isNativeToken(id: Caip19Id): boolean {
+export function isNativeToken(id: TokenCaip19Id): boolean {
   const { namespace } = parseCaip19Id(id);
   return namespace === AssetNamespace.native;
 }
@@ -87,7 +87,7 @@ export function getNativeTokenAddress(protocol: ProtocolType): Address {
   }
 }
 
-export function isNonFungibleToken(id: Caip19Id): boolean {
+export function isNonFungibleToken(id: TokenCaip19Id): boolean {
   const { namespace } = parseCaip19Id(id);
   return namespace === AssetNamespace.erc721;
 }

--- a/src/features/chains/ChainSelectField.tsx
+++ b/src/features/chains/ChainSelectField.tsx
@@ -12,16 +12,16 @@ import { getChainDisplayName } from './utils';
 type Props = {
   name: string;
   label: string;
-  caip2Ids: Caip2Id[];
-  onChange?: (id: Caip2Id) => void;
+  chainCaip2Ids: ChainCaip2Id[];
+  onChange?: (id: ChainCaip2Id) => void;
   disabled?: boolean;
 };
 
-export function ChainSelectField({ name, label, caip2Ids, onChange, disabled }: Props) {
-  const [field, , helpers] = useField<Caip2Id>(name);
+export function ChainSelectField({ name, label, chainCaip2Ids, onChange, disabled }: Props) {
+  const [field, , helpers] = useField<ChainCaip2Id>(name);
   const { setFieldValue } = useFormikContext<TransferFormValues>();
 
-  const handleChange = (newChainId: Caip2Id) => {
+  const handleChange = (newChainId: ChainCaip2Id) => {
     helpers.setValue(newChainId);
     // Reset other fields on chain change
     setFieldValue('tokenCaip19Id', '');
@@ -40,7 +40,7 @@ export function ChainSelectField({ name, label, caip2Ids, onChange, disabled }: 
     <div className="flex flex-col items-center">
       <div className="flex flex-col items-center justify-center rounded-full bg-gray-100 h-[5.5rem] w-[5.5rem] p-1.5">
         <div className="flex items-end h-11">
-          <ChainLogo caip2Id={field.value} size={34} />
+          <ChainLogo chainCaip2Id={field.value} size={34} />
         </div>
         <label htmlFor={name} className="mt-2 mb-1 text-sm text-gray-500 uppercase">
           {label}
@@ -53,7 +53,7 @@ export function ChainSelectField({ name, label, caip2Ids, onChange, disabled }: 
         onClick={onClick}
       >
         <div className="flex items-center">
-          <ChainLogo caip2Id={field.value} size={14} />
+          <ChainLogo chainCaip2Id={field.value} size={14} />
           <span className="ml-2">{getChainDisplayName(field.value, true)}</span>
         </div>
         <Image src={ChevronIcon} width={12} height={8} alt="" />
@@ -61,7 +61,7 @@ export function ChainSelectField({ name, label, caip2Ids, onChange, disabled }: 
       <ChainSelectListModal
         isOpen={isModalOpen}
         close={() => setIsModalOpen(false)}
-        caip2Ids={caip2Ids}
+        chainCaip2Ids={chainCaip2Ids}
         onSelect={handleChange}
       />
     </div>

--- a/src/features/chains/ChainSelectModal.tsx
+++ b/src/features/chains/ChainSelectModal.tsx
@@ -6,17 +6,17 @@ import { getChainDisplayName } from './utils';
 export function ChainSelectListModal({
   isOpen,
   close,
-  caip2Ids,
+  chainCaip2Ids,
   onSelect,
 }: {
   isOpen: boolean;
   close: () => void;
-  caip2Ids: Caip2Id[];
-  onSelect: (caip2Id: Caip2Id) => void;
+  chainCaip2Ids: ChainCaip2Id[];
+  onSelect: (chainCaip2Id: ChainCaip2Id) => void;
 }) {
-  const onSelectChain = (caip2Id: Caip2Id) => {
+  const onSelectChain = (chainCaip2Id: ChainCaip2Id) => {
     return () => {
-      onSelect(caip2Id);
+      onSelect(chainCaip2Id);
       close();
     };
   };
@@ -24,13 +24,13 @@ export function ChainSelectListModal({
   return (
     <Modal isOpen={isOpen} title="Select Chain" close={close}>
       <div className="mt-2 flex flex-col space-y-1">
-        {caip2Ids.map((c) => (
+        {chainCaip2Ids.map((c) => (
           <button
             key={c}
             className="py-1.5 px-2 text-sm flex items-center rounded hover:bg-gray-100 active:bg-gray-200 transition-all duration-200"
             onClick={onSelectChain(c)}
           >
-            <ChainLogo caip2Id={c} size={16} background={false} />
+            <ChainLogo chainCaip2Id={c} size={16} background={false} />
             <span className="ml-2">{getChainDisplayName(c, true)}</span>
           </button>
         ))}

--- a/src/features/chains/utils.ts
+++ b/src/features/chains/utils.ts
@@ -4,7 +4,7 @@ import { toTitleCase } from '../../utils/string';
 import { parseCaip2Id } from '../caip/chains';
 import { getMultiProvider } from '../multiProvider';
 
-export function getChainDisplayName(id: Caip2Id, shortName = false) {
+export function getChainDisplayName(id: ChainCaip2Id, shortName = false) {
   if (!id) return 'Unknown';
   const { reference } = parseCaip2Id(id);
   const metadata = getMultiProvider().tryGetChainMetadata(reference || 0);
@@ -13,13 +13,13 @@ export function getChainDisplayName(id: Caip2Id, shortName = false) {
   return toTitleCase(displayName || metadata.displayName || metadata.name);
 }
 
-export function isPermissionlessChain(id: Caip2Id) {
+export function isPermissionlessChain(id: ChainCaip2Id) {
   if (!id) return true;
   const { protocol, reference } = parseCaip2Id(id);
   return protocol !== ProtocolType.Ethereum || !chainIdToMetadata[reference];
 }
 
-export function hasPermissionlessChain(ids: Caip2Id[]) {
+export function hasPermissionlessChain(ids: ChainCaip2Id[]) {
   return !ids.every((c) => !isPermissionlessChain(c));
 }
 

--- a/src/features/multiProvider.ts
+++ b/src/features/multiProvider.ts
@@ -88,7 +88,7 @@ export function getMultiProvider() {
   return multiProvider;
 }
 
-export function getProvider(id: Caip2Id) {
+export function getProvider(id: ChainCaip2Id) {
   const { reference } = parseCaip2Id(id);
   return getMultiProvider().getProvider(reference);
 }

--- a/src/features/tokens/SelectOrInputTokenIds.tsx
+++ b/src/features/tokens/SelectOrInputTokenIds.tsx
@@ -23,7 +23,7 @@ export function SelectOrInputTokenIds({
 
   const route = getTokenRoute(originCaip2Id, destinationCaip2Id, tokenCaip19Id, tokenRoutes);
 
-  let activeToken = '' as Caip19Id;
+  let activeToken = '' as TokenCaip19Id;
   if (route?.type === RouteType.BaseToSynthetic) {
     // If the origin is the base chain, use the collateralized token for balance checking
     activeToken = tokenCaip19Id;
@@ -43,17 +43,23 @@ export function SelectOrInputTokenIds({
   );
 
   return isContractAllowToGetTokenIds ? (
-    <SelectTokenIdField name="amount" disabled={disabled} caip19Id={activeToken} />
+    <SelectTokenIdField name="amount" disabled={disabled} tokenCaip19Id={activeToken} />
   ) : (
-    <InputTokenId disabled={disabled} caip19Id={activeToken} />
+    <InputTokenId disabled={disabled} tokenCaip19Id={activeToken} />
   );
 }
 
-function InputTokenId({ disabled, caip19Id }: { disabled: boolean; caip19Id: Caip19Id }) {
+function InputTokenId({
+  disabled,
+  tokenCaip19Id,
+}: {
+  disabled: boolean;
+  tokenCaip19Id: TokenCaip19Id;
+}) {
   const {
     values: { amount },
   } = useFormikContext<TransferFormValues>();
-  useIsSenderNftOwner(caip19Id, amount);
+  useIsSenderNftOwner(tokenCaip19Id, amount);
 
   return (
     <div className="relative w-full">

--- a/src/features/tokens/SelectTokenIdField.tsx
+++ b/src/features/tokens/SelectTokenIdField.tsx
@@ -10,11 +10,11 @@ import { useOriginTokenIdBalance } from './balances';
 
 type Props = {
   name: string;
-  caip19Id: Caip19Id;
+  tokenCaip19Id: TokenCaip19Id;
   disabled?: boolean;
 };
 
-export function SelectTokenIdField({ name, caip19Id, disabled }: Props) {
+export function SelectTokenIdField({ name, tokenCaip19Id, disabled }: Props) {
   const [, , helpers] = useField<number>(name);
   const [tokenId, setTokenId] = useState<string | undefined>(undefined);
   const handleChange = (newTokenId: string) => {
@@ -22,7 +22,7 @@ export function SelectTokenIdField({ name, caip19Id, disabled }: Props) {
     setTokenId(newTokenId);
   };
 
-  const { isLoading, tokenIds } = useOriginTokenIdBalance(caip19Id);
+  const { isLoading, tokenIds } = useOriginTokenIdBalance(tokenCaip19Id);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
 

--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -25,8 +25,8 @@ export function TokenListModal({
   isOpen: boolean;
   close: () => void;
   onSelect: (token: TokenMetadata) => void;
-  originCaip2Id: Caip2Id;
-  destinationCaip2Id: Caip2Id;
+  originCaip2Id: ChainCaip2Id;
+  destinationCaip2Id: ChainCaip2Id;
   tokenRoutes: RoutesMap;
 }) {
   const [search, setSearch] = useState('');
@@ -74,8 +74,8 @@ export function TokenList({
   searchQuery,
   onSelect,
 }: {
-  originCaip2Id: Caip2Id;
-  destinationCaip2Id: Caip2Id;
+  originCaip2Id: ChainCaip2Id;
+  destinationCaip2Id: ChainCaip2Id;
   tokenRoutes: RoutesMap;
   searchQuery: string;
   onSelect: (token: TokenMetadata) => void;
@@ -84,7 +84,12 @@ export function TokenList({
     const q = searchQuery?.trim().toLowerCase();
     return getTokens()
       .map((t) => {
-        const hasRoute = hasTokenRoute(originCaip2Id, destinationCaip2Id, t.caip19Id, tokenRoutes);
+        const hasRoute = hasTokenRoute(
+          originCaip2Id,
+          destinationCaip2Id,
+          t.tokenCaip19Id,
+          tokenRoutes,
+        );
         return { ...t, disabled: !hasRoute };
       })
       .sort((a, b) => {
@@ -97,7 +102,7 @@ export function TokenList({
         return (
           t.name.toLowerCase().includes(q) ||
           t.symbol.toLowerCase().includes(q) ||
-          t.caip19Id.toLowerCase().includes(q)
+          t.tokenCaip19Id.toLowerCase().includes(q)
         );
       })
       .filter((t) => (config.showDisabledTokens ? true : !t.disabled));
@@ -111,7 +116,7 @@ export function TokenList({
             className={`-mx-2 py-2 px-2 rounded mb-2  ${
               t.disabled ? 'opacity-50' : 'hover:bg-gray-200'
             } transition-all duration-250`}
-            key={t.caip19Id}
+            key={t.tokenCaip19Id}
             type="button"
             disabled={t.disabled}
             onClick={() => onSelect(t)}
@@ -124,12 +129,14 @@ export function TokenList({
               </div>
               <div className="ml-3 text-left">
                 <div className="text-xs">
-                  {isNativeToken(t.caip19Id) ? 'Native chain token' : getTokenAddress(t.caip19Id)}
+                  {isNativeToken(t.tokenCaip19Id)
+                    ? 'Native chain token'
+                    : getTokenAddress(t.tokenCaip19Id)}
                 </div>
                 <div className=" mt-0.5 text-xs flex space-x-1">
                   <span>{`Decimals: ${t.decimals}`}</span>
                   <span>-</span>
-                  <span>{`Type: ${getAssetNamespace(t.caip19Id)}`}</span>
+                  <span>{`Type: ${getAssetNamespace(t.tokenCaip19Id)}`}</span>
                 </div>
               </div>
               {t.disabled && (

--- a/src/features/tokens/TokenSelectField.tsx
+++ b/src/features/tokens/TokenSelectField.tsx
@@ -13,8 +13,8 @@ import { TokenMetadata } from './types';
 
 type Props = {
   name: string;
-  originCaip2Id: Caip2Id;
-  destinationCaip2Id: Caip2Id;
+  originCaip2Id: ChainCaip2Id;
+  destinationCaip2Id: ChainCaip2Id;
   tokenRoutes: RoutesMap;
   disabled?: boolean;
   setIsNft: (value: boolean) => void;
@@ -37,7 +37,7 @@ export function TokenSelectField({
   // Keep local state in sync with formik state
   useEffect(() => {
     if (!field.value) setToken(undefined);
-    else if (field.value !== token?.caip19Id) {
+    else if (field.value !== token?.tokenCaip19Id) {
       setToken(undefined);
       helpers.setValue('');
     }
@@ -45,13 +45,13 @@ export function TokenSelectField({
 
   const handleChange = (newToken: TokenMetadata) => {
     // Set the token address value in formik state
-    helpers.setValue(newToken.caip19Id);
+    helpers.setValue(newToken.tokenCaip19Id);
     // reset amount after change token
     setFieldValue('amount', '');
     // Update local state
     setToken(newToken);
     // Update nft state in parent
-    setIsNft(!!isNonFungibleToken(newToken.caip19Id));
+    setIsNft(!!isNonFungibleToken(newToken.tokenCaip19Id));
   };
 
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/src/features/tokens/adapters/AdapterFactory.ts
+++ b/src/features/tokens/adapters/AdapterFactory.ts
@@ -5,7 +5,12 @@ import { ProtocolType } from '@hyperlane-xyz/sdk';
 
 import { convertToProtocolAddress } from '../../../utils/addresses';
 import { parseCaip2Id } from '../../caip/chains';
-import { AssetNamespace, getCaip2FromToken, isNativeToken, parseCaip19Id } from '../../caip/tokens';
+import {
+  AssetNamespace,
+  getChainIdFromToken,
+  isNativeToken,
+  parseCaip19Id,
+} from '../../caip/tokens';
 import { getMultiProvider, getProvider } from '../../multiProvider';
 import { Route, RouteType } from '../routes/types';
 
@@ -25,18 +30,18 @@ import {
 } from './SealevelTokenAdapter';
 
 export class AdapterFactory {
-  static TokenAdapterFromAddress(caip19Id: Caip19Id) {
-    const { address, caip2Id } = parseCaip19Id(caip19Id);
-    const { protocol, reference } = parseCaip2Id(caip2Id);
+  static TokenAdapterFromAddress(tokenCaip19Id: TokenCaip19Id) {
+    const { address, chainCaip2Id } = parseCaip19Id(tokenCaip19Id);
+    const { protocol, reference } = parseCaip2Id(chainCaip2Id);
     if (protocol == ProtocolType.Ethereum) {
-      const provider = getProvider(caip2Id);
-      return isNativeToken(caip19Id)
+      const provider = getProvider(chainCaip2Id);
+      return isNativeToken(tokenCaip19Id)
         ? new EvmNativeTokenAdapter(provider)
         : new EvmTokenAdapter(provider, address);
     } else if (protocol === ProtocolType.Sealevel) {
       const rpcUrl = getMultiProvider().getRpcUrl(reference);
       const connection = new Connection(rpcUrl, 'confirmed');
-      return isNativeToken(caip19Id)
+      return isNativeToken(tokenCaip19Id)
         ? new SealevelNativeTokenAdapter(connection)
         : new SealevelTokenAdapter(connection, address);
     } else {
@@ -44,45 +49,45 @@ export class AdapterFactory {
     }
   }
 
-  static HypCollateralAdapterFromAddress(baseCaip19Id: Caip19Id, routerAddress: Address) {
+  static HypCollateralAdapterFromAddress(baseTokenCaip19Id: TokenCaip19Id, routerAddress: Address) {
     return AdapterFactory.selectHypAdapter(
-      getCaip2FromToken(baseCaip19Id),
+      getChainIdFromToken(baseTokenCaip19Id),
       routerAddress,
-      baseCaip19Id,
+      baseTokenCaip19Id,
       EvmHypCollateralAdapter,
-      isNativeToken(baseCaip19Id) ? SealevelHypNativeAdapter : SealevelHypCollateralAdapter,
+      isNativeToken(baseTokenCaip19Id) ? SealevelHypNativeAdapter : SealevelHypCollateralAdapter,
     );
   }
 
   static HypSyntheticTokenAdapterFromAddress(
-    baseCaip19Id: Caip19Id,
-    caip2Id: Caip2Id,
+    baseTokenCaip19Id: TokenCaip19Id,
+    chainCaip2Id: ChainCaip2Id,
     routerAddress: Address,
   ) {
     return AdapterFactory.selectHypAdapter(
-      caip2Id,
+      chainCaip2Id,
       routerAddress,
-      baseCaip19Id,
+      baseTokenCaip19Id,
       EvmHypSyntheticAdapter,
       SealevelHypSyntheticAdapter,
     );
   }
 
   static HypTokenAdapterFromRouteOrigin(route: Route) {
-    const { type, originCaip2Id, originRouterAddress, baseCaip19Id } = route;
+    const { type, originCaip2Id, originRouterAddress, baseTokenCaip19Id } = route;
     if (type === RouteType.BaseToSynthetic) {
       return AdapterFactory.selectHypAdapter(
         originCaip2Id,
         originRouterAddress,
-        baseCaip19Id,
+        baseTokenCaip19Id,
         EvmHypCollateralAdapter,
-        isNativeToken(baseCaip19Id) ? SealevelHypNativeAdapter : SealevelHypCollateralAdapter,
+        isNativeToken(baseTokenCaip19Id) ? SealevelHypNativeAdapter : SealevelHypCollateralAdapter,
       );
     } else if (type === RouteType.SyntheticToBase || type === RouteType.SyntheticToSynthetic) {
       return AdapterFactory.selectHypAdapter(
         originCaip2Id,
         originRouterAddress,
-        baseCaip19Id,
+        baseTokenCaip19Id,
         EvmHypSyntheticAdapter,
         SealevelHypSyntheticAdapter,
       );
@@ -92,20 +97,20 @@ export class AdapterFactory {
   }
 
   static HypTokenAdapterFromRouteDest(route: Route) {
-    const { type, destCaip2Id, destRouterAddress, baseCaip19Id } = route;
+    const { type, destCaip2Id, destRouterAddress, baseTokenCaip19Id } = route;
     if (type === RouteType.SyntheticToBase) {
       return AdapterFactory.selectHypAdapter(
         destCaip2Id,
         destRouterAddress,
-        baseCaip19Id,
+        baseTokenCaip19Id,
         EvmHypCollateralAdapter,
-        isNativeToken(baseCaip19Id) ? SealevelHypNativeAdapter : SealevelHypCollateralAdapter,
+        isNativeToken(baseTokenCaip19Id) ? SealevelHypNativeAdapter : SealevelHypCollateralAdapter,
       );
     } else if (type === RouteType.BaseToSynthetic || type === RouteType.SyntheticToSynthetic) {
       return AdapterFactory.selectHypAdapter(
         destCaip2Id,
         destRouterAddress,
-        baseCaip19Id,
+        baseTokenCaip19Id,
         EvmHypSyntheticAdapter,
         SealevelHypSyntheticAdapter,
       );
@@ -115,9 +120,9 @@ export class AdapterFactory {
   }
 
   protected static selectHypAdapter(
-    caip2Id: Caip2Id,
+    chainCaip2Id: ChainCaip2Id,
     routerAddress: Address,
-    baseCaip19Id: Caip19Id,
+    baseTokenCaip19Id: TokenCaip19Id,
     EvmAdapter: new (provider: providers.Provider, routerAddress: Address) => IHypTokenAdapter,
     SealevelAdapter: new (
       connection: Connection,
@@ -126,10 +131,10 @@ export class AdapterFactory {
       isSpl2022?: boolean,
     ) => IHypTokenAdapter,
   ) {
-    const { protocol, reference } = parseCaip2Id(caip2Id);
-    const { address: baseTokenAddress, namespace } = parseCaip19Id(baseCaip19Id);
+    const { protocol, reference } = parseCaip2Id(chainCaip2Id);
+    const { address: baseTokenAddress, namespace } = parseCaip19Id(baseTokenCaip19Id);
     if (protocol == ProtocolType.Ethereum) {
-      const provider = getProvider(caip2Id);
+      const provider = getProvider(chainCaip2Id);
       return new EvmAdapter(provider, convertToProtocolAddress(routerAddress, protocol));
     } else if (protocol === ProtocolType.Sealevel) {
       const rpcUrl = getMultiProvider().getRpcUrl(reference);

--- a/src/features/tokens/balances.tsx
+++ b/src/features/tokens/balances.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { areAddressesEqual, isValidAddress } from '../../utils/addresses';
 import { logger } from '../../utils/logger';
 import { getProtocolType } from '../caip/chains';
-import { parseCaip19Id, tryGetCaip2FromToken } from '../caip/tokens';
+import { parseCaip19Id, tryGetChainIdFromToken } from '../caip/tokens';
 import { getProvider } from '../multiProvider';
 import { useStore } from '../store';
 import { TransferFormValues } from '../transfer/types';
@@ -85,9 +85,9 @@ export function useDestinationBalance(
 }
 
 // TODO solana support
-export function useOriginTokenIdBalance(caip19Id: Caip19Id) {
-  const caip2Id = tryGetCaip2FromToken(caip19Id);
-  const accountAddress = useAccountForChain(caip2Id)?.address;
+export function useOriginTokenIdBalance(tokenCaip19Id: TokenCaip19Id) {
+  const chainCaip2Id = tryGetChainIdFromToken(tokenCaip19Id);
+  const accountAddress = useAccountForChain(chainCaip2Id)?.address;
   const setSenderNftIds = useStore((state) => state.setSenderNftIds);
 
   const {
@@ -95,10 +95,10 @@ export function useOriginTokenIdBalance(caip19Id: Caip19Id) {
     isError: hasError,
     data: tokenIds,
   } = useQuery({
-    queryKey: ['useOriginTokenIdBalance', caip19Id, accountAddress],
+    queryKey: ['useOriginTokenIdBalance', tokenCaip19Id, accountAddress],
     queryFn: () => {
-      if (!caip19Id || !accountAddress) return null;
-      return fetchListOfERC721TokenId(caip19Id, accountAddress);
+      if (!tokenCaip19Id || !accountAddress) return null;
+      return fetchListOfERC721TokenId(tokenCaip19Id, accountAddress);
     },
     refetchInterval: 5000,
   });
@@ -112,13 +112,13 @@ export function useOriginTokenIdBalance(caip19Id: Caip19Id) {
 
 // TODO solana support
 export async function fetchListOfERC721TokenId(
-  caip19Id: Caip19Id,
+  tokenCaip19Id: TokenCaip19Id,
   accountAddress: Address,
 ): Promise<string[]> {
-  const { caip2Id, address: tokenAddress } = parseCaip19Id(caip19Id);
-  logger.debug(`Fetching list of tokenID for account ${accountAddress} on chain ${caip2Id}`);
+  const { chainCaip2Id, address: tokenAddress } = parseCaip19Id(tokenCaip19Id);
+  logger.debug(`Fetching list of tokenID for account ${accountAddress} on chain ${chainCaip2Id}`);
 
-  const hypERC721 = getHypErc721Contract(tokenAddress, getProvider(caip2Id));
+  const hypERC721 = getHypErc721Contract(tokenAddress, getProvider(chainCaip2Id));
 
   const balance = await hypERC721.balanceOf(accountAddress);
   const index = Array.from({ length: parseInt(balance.toString()) }, (_, index) => index);
@@ -128,21 +128,24 @@ export async function fetchListOfERC721TokenId(
     return response.toString();
   });
   const result = await Promise.all(promises);
-  logger.debug(`TokenIds that the ${accountAddress} owns on chain ${caip2Id}: ${result} `);
+  logger.debug(`TokenIds that the ${accountAddress} owns on chain ${chainCaip2Id}: ${result} `);
   return result;
 }
 
 // TODO solana support
-export function useContractSupportsTokenByOwner(caip19Id: Caip19Id, accountAddress?: Address) {
+export function useContractSupportsTokenByOwner(
+  tokenCaip19Id: TokenCaip19Id,
+  accountAddress?: Address,
+) {
   const {
     isLoading,
     isError: hasError,
     data: isContractAllowToGetTokenIds,
   } = useQuery({
-    queryKey: ['useContractSupportsTokenByOwner', caip19Id, accountAddress],
+    queryKey: ['useContractSupportsTokenByOwner', tokenCaip19Id, accountAddress],
     queryFn: () => {
-      if (!caip19Id || !accountAddress) return null;
-      return contractSupportsTokenByOwner(caip19Id, accountAddress);
+      if (!tokenCaip19Id || !accountAddress) return null;
+      return contractSupportsTokenByOwner(tokenCaip19Id, accountAddress);
     },
   });
 
@@ -151,11 +154,11 @@ export function useContractSupportsTokenByOwner(caip19Id: Caip19Id, accountAddre
 
 // TODO solana support
 async function contractSupportsTokenByOwner(
-  caip19Id: Caip19Id,
+  tokenCaip19Id: TokenCaip19Id,
   accountAddress: Address,
 ): Promise<boolean> {
-  const { caip2Id, address: tokenAddress } = parseCaip19Id(caip19Id);
-  const hypERC721 = getHypErc721Contract(tokenAddress, getProvider(caip2Id));
+  const { chainCaip2Id, address: tokenAddress } = parseCaip19Id(tokenCaip19Id);
+  const hypERC721 = getHypErc721Contract(tokenAddress, getProvider(chainCaip2Id));
   try {
     await hypERC721.tokenOfOwnerByIndex(accountAddress, '0');
     return true;
@@ -165,9 +168,9 @@ async function contractSupportsTokenByOwner(
 }
 
 // TODO solana support
-export function useIsSenderNftOwner(caip19Id: Caip19Id, tokenId: string) {
-  const caip2Id = tryGetCaip2FromToken(caip19Id);
-  const senderAddress = useAccountForChain(caip2Id)?.address;
+export function useIsSenderNftOwner(tokenCaip19Id: TokenCaip19Id, tokenId: string) {
+  const chainCaip2Id = tryGetChainIdFromToken(tokenCaip19Id);
+  const senderAddress = useAccountForChain(chainCaip2Id)?.address;
   const setIsSenderNftOwner = useStore((state) => state.setIsSenderNftOwner);
 
   const {
@@ -175,10 +178,10 @@ export function useIsSenderNftOwner(caip19Id: Caip19Id, tokenId: string) {
     isError: hasError,
     data: owner,
   } = useQuery({
-    queryKey: ['useOwnerOfErc721', caip19Id, tokenId],
+    queryKey: ['useOwnerOfErc721', tokenCaip19Id, tokenId],
     queryFn: () => {
-      if (!caip19Id || !tokenId) return null;
-      return fetchERC721Owner(caip19Id, tokenId);
+      if (!tokenCaip19Id || !tokenId) return null;
+      return fetchERC721Owner(tokenCaip19Id, tokenId);
     },
   });
 
@@ -191,9 +194,9 @@ export function useIsSenderNftOwner(caip19Id: Caip19Id, tokenId: string) {
 }
 
 // TODO solana support
-async function fetchERC721Owner(caip19Id: Caip19Id, tokenId: string): Promise<string> {
-  const { caip2Id, address: tokenAddress } = parseCaip19Id(caip19Id);
-  const hypERC721 = getHypErc721Contract(tokenAddress, getProvider(caip2Id));
+async function fetchERC721Owner(tokenCaip19Id: TokenCaip19Id, tokenId: string): Promise<string> {
+  const { chainCaip2Id, address: tokenAddress } = parseCaip19Id(tokenCaip19Id);
+  const hypERC721 = getHypErc721Contract(tokenAddress, getProvider(chainCaip2Id));
   try {
     const ownerAddress = await hypERC721.ownerOf(tokenId);
     return ownerAddress;

--- a/src/features/tokens/metadata.ts
+++ b/src/features/tokens/metadata.ts
@@ -23,8 +23,8 @@ export function getTokens() {
   return tokens || [];
 }
 
-export function getToken(caip19Id: Caip19Id) {
-  return getTokens().find((t) => t.caip19Id === caip19Id);
+export function getToken(tokenCaip19Id: TokenCaip19Id) {
+  return getTokens().find((t) => t.tokenCaip19Id === tokenCaip19Id);
 }
 
 export async function parseTokens() {
@@ -50,7 +50,7 @@ async function parseTokenConfigs(configList: WarpTokenConfig): Promise<TokenMeta
     const { type, chainId, logoURI } = config;
 
     const protocol = multiProvider.getChainMetadata(chainId).protocol || ProtocolType.Ethereum;
-    const caip2Id = getCaip2Id(protocol, chainId);
+    const chainCaip2Id = getCaip2Id(protocol, chainId);
     const isNative = type == TokenType.native;
     const isNft = type === TokenType.collateral && config.isNft;
     const isSpl2022 = type === TokenType.collateral && config.isSpl2022;
@@ -59,7 +59,7 @@ async function parseTokenConfigs(configList: WarpTokenConfig): Promise<TokenMeta
     const routerAddress =
       type === TokenType.collateral ? config.hypCollateralAddress : config.hypNativeAddress;
     const namespace = resolveAssetNamespace(protocol, isNative, isNft, isSpl2022);
-    const caip19Id = getCaip19Id(caip2Id, namespace, address);
+    const tokenCaip19Id = getCaip19Id(chainCaip2Id, namespace, address);
 
     const { name, symbol, decimals } = await fetchNameAndDecimals(
       config,
@@ -74,7 +74,7 @@ async function parseTokenConfigs(configList: WarpTokenConfig): Promise<TokenMeta
       decimals,
       logoURI,
       type,
-      caip19Id,
+      tokenCaip19Id,
       routerAddress,
     });
   }

--- a/src/features/tokens/routes/hooks.ts
+++ b/src/features/tokens/routes/hooks.ts
@@ -111,7 +111,7 @@ function computeTokenRoutes(tokens: TokenMetadataWithHypTokens[]) {
         routerAddress: baseRouterAddress,
         decimals: baseDecimals,
       } = token;
-      const baseCaip2Id = getChainIdFromToken(baseTokenCaip19Id);
+      const baseChainCaip2Id = getChainIdFromToken(baseTokenCaip19Id);
       const { chainCaip2Id: syntheticCaip2Id, address: syntheticRouterAddress } = parseCaip19Id(
         hypToken.tokenCaip19Id,
       );
@@ -121,23 +121,23 @@ function computeTokenRoutes(tokens: TokenMetadataWithHypTokens[]) {
         baseTokenCaip19Id,
         baseRouterAddress,
       };
-      tokenRoutes[baseCaip2Id][syntheticCaip2Id]?.push({
+      tokenRoutes[baseChainCaip2Id][syntheticCaip2Id]?.push({
         type: RouteType.BaseToSynthetic,
         ...commonRouteProps,
-        originCaip2Id: baseCaip2Id,
+        originCaip2Id: baseChainCaip2Id,
         originRouterAddress: baseRouterAddress,
         originDecimals: baseDecimals,
         destCaip2Id: syntheticCaip2Id,
         destRouterAddress: syntheticRouterAddress,
         destDecimals: syntheticDecimals,
       });
-      tokenRoutes[syntheticCaip2Id][baseCaip2Id]?.push({
+      tokenRoutes[syntheticCaip2Id][baseChainCaip2Id]?.push({
         type: RouteType.SyntheticToBase,
         ...commonRouteProps,
         originCaip2Id: syntheticCaip2Id,
         originRouterAddress: syntheticRouterAddress,
         originDecimals: syntheticDecimals,
-        destCaip2Id: baseCaip2Id,
+        destCaip2Id: baseChainCaip2Id,
         destRouterAddress: baseRouterAddress,
         destDecimals: baseDecimals,
       });

--- a/src/features/tokens/routes/types.ts
+++ b/src/features/tokens/routes/types.ts
@@ -6,14 +6,14 @@ export enum RouteType {
 
 export interface Route {
   type: RouteType;
-  baseCaip19Id: Caip19Id; // i.e. the underlying 'collateralized' token
+  baseTokenCaip19Id: TokenCaip19Id; // i.e. the underlying 'collateralized' token
   baseRouterAddress: Address;
-  originCaip2Id: Caip2Id;
+  originCaip2Id: ChainCaip2Id;
   originRouterAddress: Address;
   originDecimals: number;
-  destCaip2Id: Caip2Id;
+  destCaip2Id: ChainCaip2Id;
   destRouterAddress: Address;
   destDecimals: number;
 }
 
-export type RoutesMap = Record<Caip2Id, Record<Caip2Id, Route[]>>;
+export type RoutesMap = Record<ChainCaip2Id, Record<ChainCaip2Id, Route[]>>;

--- a/src/features/tokens/routes/utils.ts
+++ b/src/features/tokens/routes/utils.ts
@@ -1,30 +1,30 @@
 import { Route, RoutesMap } from './types';
 
 export function getTokenRoutes(
-  originCaip2Id: Caip2Id,
-  destinationCaip2Id: Caip2Id,
+  originCaip2Id: ChainCaip2Id,
+  destinationCaip2Id: ChainCaip2Id,
   tokenRoutes: RoutesMap,
 ): Route[] {
   return tokenRoutes[originCaip2Id]?.[destinationCaip2Id] || [];
 }
 
 export function getTokenRoute(
-  originCaip2Id: Caip2Id,
-  destinationCaip2Id: Caip2Id,
-  caip19Id: Caip19Id,
+  originCaip2Id: ChainCaip2Id,
+  destinationCaip2Id: ChainCaip2Id,
+  tokenCaip19Id: TokenCaip19Id,
   tokenRoutes: RoutesMap,
 ): Route | undefined {
-  if (!caip19Id) return undefined;
+  if (!tokenCaip19Id) return undefined;
   return getTokenRoutes(originCaip2Id, destinationCaip2Id, tokenRoutes).find(
-    (r) => r.baseCaip19Id === caip19Id,
+    (r) => r.baseTokenCaip19Id === tokenCaip19Id,
   );
 }
 
 export function hasTokenRoute(
-  originCaip2Id: Caip2Id,
-  destinationCaip2Id: Caip2Id,
-  caip19Id: Caip19Id,
+  originCaip2Id: ChainCaip2Id,
+  destinationCaip2Id: ChainCaip2Id,
+  tokenCaip19Id: TokenCaip19Id,
   tokenRoutes: RoutesMap,
 ): boolean {
-  return !!getTokenRoute(originCaip2Id, destinationCaip2Id, caip19Id, tokenRoutes);
+  return !!getTokenRoute(originCaip2Id, destinationCaip2Id, tokenCaip19Id, tokenRoutes);
 }

--- a/src/features/tokens/types.ts
+++ b/src/features/tokens/types.ts
@@ -69,7 +69,7 @@ export type WarpTokenConfig = Array<CollateralTokenConfig | NativeTokenConfig>;
  */
 interface BaseTokenMetadata extends MinimalTokenMetadata {
   type: TokenType;
-  caip19Id: Caip19Id;
+  tokenCaip19Id: TokenCaip19Id;
   routerAddress: Address; // Shared name for hypCollateralAddr or hypNativeAddr
   logoURI?: string;
 }
@@ -88,7 +88,7 @@ export type TokenMetadata = CollateralTokenMetadata | NativeTokenMetadata;
  * Extended types including synthetic hyp token addresses
  */
 interface HypTokens {
-  hypTokens: Array<{ caip19Id: Caip19Id; decimals: number }>;
+  hypTokens: Array<{ tokenCaip19Id: TokenCaip19Id; decimals: number }>;
 }
 
 type NativeTokenMetadataWithHypTokens = NativeTokenMetadata & HypTokens;

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -34,8 +34,8 @@ import { TransferFormValues } from './types';
 import { isTransferApproveRequired, useTokenTransfer } from './useTokenTransfer';
 
 export function TransferTokenForm({ tokenRoutes }: { tokenRoutes: RoutesMap }) {
-  const caip2Ids = useRouteChains(tokenRoutes);
-  const initialValues = useFormInitialValues(caip2Ids, tokenRoutes);
+  const chainCaip2Ids = useRouteChains(tokenRoutes);
+  const initialValues = useFormInitialValues(chainCaip2Ids, tokenRoutes);
 
   // Flag for if form is in input vs review mode
   const [isReview, setIsReview] = useState(false);
@@ -61,7 +61,7 @@ export function TransferTokenForm({ tokenRoutes }: { tokenRoutes: RoutesMap }) {
       validateOnBlur={false}
     >
       <Form className="flex flex-col items-stretch w-full mt-2">
-        <ChainSelectSection caip2Ids={caip2Ids} isReview={isReview} />
+        <ChainSelectSection chainCaip2Ids={chainCaip2Ids} isReview={isReview} />
         <div className="mt-3 flex justify-between space-x-4">
           <TokenSection tokenRoutes={tokenRoutes} setIsNft={setIsNft} isReview={isReview} />
           <AmountSection tokenRoutes={tokenRoutes} isNft={isNft} isReview={isReview} />
@@ -101,7 +101,13 @@ function SwapChainsButton({ disabled }: { disabled?: boolean }) {
   );
 }
 
-function ChainSelectSection({ caip2Ids, isReview }: { caip2Ids: Caip2Id[]; isReview: boolean }) {
+function ChainSelectSection({
+  chainCaip2Ids,
+  isReview,
+}: {
+  chainCaip2Ids: ChainCaip2Id[];
+  isReview: boolean;
+}) {
   const ChevronIcon = ({ classes }: { classes?: string }) => (
     <WideChevron
       width="17"
@@ -115,7 +121,12 @@ function ChainSelectSection({ caip2Ids, isReview }: { caip2Ids: Caip2Id[]; isRev
 
   return (
     <div className="flex items-center justify-center space-x-7 sm:space-x-10">
-      <ChainSelectField name="originCaip2Id" label="From" caip2Ids={caip2Ids} disabled={isReview} />
+      <ChainSelectField
+        name="originCaip2Id"
+        label="From"
+        chainCaip2Ids={chainCaip2Ids}
+        disabled={isReview}
+      />
       <div className="flex flex-col items-center">
         <div className="flex mb-6 sm:space-x-1.5">
           <ChevronIcon classes="hidden sm:block" />
@@ -127,7 +138,7 @@ function ChainSelectSection({ caip2Ids, isReview }: { caip2Ids: Caip2Id[]; isRev
       <ChainSelectField
         name="destinationCaip2Id"
         label="To"
-        caip2Ids={caip2Ids}
+        chainCaip2Ids={chainCaip2Ids}
         disabled={isReview}
       />
     </div>
@@ -297,7 +308,7 @@ function ButtonSection({
   if (!isReview) {
     return (
       <ConnectAwareSubmitButton
-        caip2Id={values.originCaip2Id}
+        chainCaip2Id={values.originCaip2Id}
         text="Continue"
         classes="mt-4 px-3 py-1.5"
       />
@@ -468,17 +479,20 @@ function validateFormValues(
   return {};
 }
 
-function useFormInitialValues(caip2Ids: Caip2Id[], tokenRoutes: RoutesMap): TransferFormValues {
+function useFormInitialValues(
+  chainCaip2Ids: ChainCaip2Id[],
+  tokenRoutes: RoutesMap,
+): TransferFormValues {
   return useMemo(() => {
-    const firstRoute = Object.values(tokenRoutes[caip2Ids[0]]).filter(
+    const firstRoute = Object.values(tokenRoutes[chainCaip2Ids[0]]).filter(
       (routes) => routes.length,
     )[0][0];
     return {
       originCaip2Id: firstRoute.originCaip2Id,
       destinationCaip2Id: firstRoute.destCaip2Id,
       amount: '',
-      tokenCaip19Id: '' as Caip19Id,
+      tokenCaip19Id: '' as TokenCaip19Id,
       recipientAddress: '',
     };
-  }, [caip2Ids, tokenRoutes]);
+  }, [chainCaip2Ids, tokenRoutes]);
 }

--- a/src/features/transfer/TransfersDetailsModal.tsx
+++ b/src/features/transfer/TransfersDetailsModal.tsx
@@ -108,7 +108,7 @@ export function TransfersDetailsModal({
     >
       <div className="flex flex-row items-center justify-between">
         <div className="flex">
-          <ChainLogo caip2Id={originCaip2Id} size={22} />
+          <ChainLogo chainCaip2Id={originCaip2Id} size={22} />
           <div className="flex items items-baseline">
             <span className="text-black text-base font-normal ml-1">{amount}</span>
             <span className="text-black text-base font-normal ml-1">{token?.symbol || ''}</span>
@@ -119,14 +119,14 @@ export function TransfersDetailsModal({
         </div>
         <div className="flex items-center">
           <div className="flex">
-            <ChainLogo caip2Id={originCaip2Id} size={22} />
+            <ChainLogo chainCaip2Id={originCaip2Id} size={22} />
             <span className="text-gray-900 text-base font-normal tracking-wider ml-2">
               {getChainDisplayName(originCaip2Id, true)}
             </span>
           </div>
           <Image className="mx-2.5" src={ArrowRightIcon} width={13} height={13} alt="" />
           <div className="flex">
-            <ChainLogo caip2Id={destinationCaip2Id} size={22} />
+            <ChainLogo chainCaip2Id={destinationCaip2Id} size={22} />
             <span className="text-gray-900 text-base font-normal tracking-wider ml-2">
               {getChainDisplayName(destinationCaip2Id, true)}
             </span>

--- a/src/features/transfer/types.ts
+++ b/src/features/transfer/types.ts
@@ -1,9 +1,9 @@
 import type { Route } from '../tokens/routes/types';
 
 export interface TransferFormValues {
-  originCaip2Id: Caip2Id;
-  destinationCaip2Id: Caip2Id;
-  tokenCaip19Id: Caip19Id;
+  originCaip2Id: ChainCaip2Id;
+  destinationCaip2Id: ChainCaip2Id;
+  tokenCaip19Id: TokenCaip19Id;
   amount: string;
   recipientAddress: Address;
 }

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -158,7 +158,7 @@ export function SideBarMenu({
                   >
                     <div className="flex">
                       <div className="mr-2.5 flex flex-col items-center justify-center rounded-full bg-gray-100 h-[2.25rem] w-[2.25rem] p-1.5">
-                        <ChainLogo caip2Id={t.params.originCaip2Id} size={20} />
+                        <ChainLogo chainCaip2Id={t.params.originCaip2Id} size={20} />
                       </div>
                       <div className="flex flex-col">
                         <div className="flex flex-col">

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,4 @@
 declare type Address = string;
 declare type DomainId = number;
-declare type Caip2Id = `${string}:${string}`; // e.g. ethereum:1 or solana:mainnet-beta
-declare type Caip19Id = `${string}:${string}/${string}:${string}`; // e.g. ethereum:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f
+declare type ChainCaip2Id = `${string}:${string}`; // e.g. ethereum:1 or solana:mainnet-beta
+declare type TokenCaip19Id = `${string}:${string}/${string}:${string}`; // e.g. ethereum:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -6,7 +6,7 @@ import { getMultiProvider } from '../features/multiProvider';
 import { toBase64 } from './base64';
 
 // TODO test with solana chain config, or disallow it
-export function getHypExplorerLink(originCaip2Id: Caip2Id, msgId?: string) {
+export function getHypExplorerLink(originCaip2Id: ChainCaip2Id, msgId?: string) {
   if (!originCaip2Id || !msgId) return null;
   const baseLink = `${links.explorer}/message/${msgId}`;
   if (isPermissionlessChain(originCaip2Id)) {


### PR DESCRIPTION
The Caip2 and Caip19 types were confusing for newcomers to the codebase.
This should clarify that caip2 IDs are for chains and Caip19 ids are for tokens