### PR TITLE
fix balance display when recipient is the same on the remote chain

### DIFF
--- a/src/features/tokens/balances.ts
+++ b/src/features/tokens/balances.ts
@@ -41,5 +41,5 @@ export function useDestinationBalance({
 }: TransferFormValues) {
   const originToken = getTokenByIndex(tokenIndex);
   const connection = originToken?.getConnectionForChain(destination);
-  return useBalance(origin, connection?.token, recipient);
+  return useBalance(destination, connection?.token, recipient);
 }


### PR DESCRIPTION
I was encountering the displayed balance to be the same with the remote balance when I set the recipient to the account to be the same as the sender. This will only happen when the sender and recipient are the same address, in other cases the webui displays correctly, e.g. the recipient is different from the sender. 

Changing `origin` at `src/features/tokens/balances.ts#44` to `destination` fixed. 
 
![image](https://github.com/user-attachments/assets/682834b1-7116-4e3a-962c-e29b83bc0a2e)


Configs:
```yaml
tokens:
- addressOrDenom: '0x4A679253410272dd5232B3Ff7cF5dbB88f295319'
  chainName: geth45206
  connections:
  - token: ethereum|geth45207|0x4A679253410272dd5232B3Ff7cF5dbB88f295319
  decimals: 18
  logoURI: /logos/weth.png
  name: Ether6
  standard: EvmHypNative
  symbol: ETH6
- addressOrDenom: '0x4A679253410272dd5232B3Ff7cF5dbB88f295319'
  chainName: geth45207
  connections:
  - token: ethereum|geth45206|0x4A679253410272dd5232B3Ff7cF5dbB88f295319
  decimals: 18
  logoURI: /logos/weth.png
  name: Ether7
  standard: EvmHypSynthetic
  symbol: ETH7
```
```yaml
geth45206:
  chainId: 45206
  domainId: 45206
  name: geth45206
  nativeToken:
    decimals: 18
    name: Eth6
    symbol: ETH
  protocol: ethereum
  rpcUrls:
  - http: http://localhost:9096
geth45207:
  chainId: 45207
  domainId: 45207
  name: geth45207
  nativeToken:
    decimals: 18
    name: Eth7
    symbol: ETH
  protocol: ethereum
  rpcUrls:
  - http: http://localhost:9097
```
