### PR TITLE
fix: Re-add pzEth

### DIFF
--- a/src/consts/warpRoutes.yaml
+++ b/src/consts/warpRoutes.yaml
@@ -1,5 +1,27 @@
 # yaml-language-server: $schema=../schema.json
 tokens:
+  # ======== PZEth ========
+  - chainName: ethereum
+    addressOrDenom: '0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd'
+    collateralAddressOrDenom: '0xbC5511354C4A9a50DE928F56DB01DD327c4e56d5'
+    connections:
+      - token: ethereum|zircuit|0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764
+    decimals: 18
+    logoURI: /deployments/warp_routes/PZETH/logo.svg
+    name: 'Renzo Restaked LST '
+    standard: EvmHypXERC20Lockbox
+    symbol: pzETH
+  - chainName: zircuit
+    addressOrDenom: '0x8303Ce0E207BB44a3D3B2313AC219d0fC73b3764'
+    collateralAddressOrDenom: '0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7'
+    connections:
+      - token: ethereum|ethereum|0x0220b1EA1b56ECE8e2b62c8965659f0A621e9ebd
+    decimals: 18
+    logoURI: /deployments/warp_routes/PZETH/logo.svg
+    name: 'Renzo Restaked LST '
+    standard: EvmHypXERC20
+    symbol: pzETH
+  # ======== EZEth ========
   - addressOrDenom: '0xB26bBfC6d1F469C821Ea25099017862e7368F4E8'
     chainName: arbitrum
     collateralAddressOrDenom: '0x2416092f143378750bb29b79eD961ab195CcEea5'


### PR DESCRIPTION
## Summary
## Rebase + beta refresh
- rebased onto latest `main` (`7c1f829`)
- bumped to `@hyperlane-xyz/core@11.3.1-beta.96f6fcc6c1bcec20d4ec51c8032281f26468ee7e` and `@hyperlane-xyz/sdk|utils|widgets@30.2.0-beta.96f6fcc6c1bcec20d4ec51c8032281f26468ee7e`
- validated on refreshed head `bb5b948` with `pnpm typecheck` and `pnpm build`
- perf numbers below are refreshed on this exact rebased head

Applies the useful Warp UI perf learnings to Explorer on top of current `main`.

Main moves:
- restack on current `main`
- bump to `@hyperlane-xyz/sdk|utils|widgets@30.2.0-beta.96f6fcc6c1bcec20d4ec51c8032281f26468ee7e`
- keep runtime/provider creation EVM-only
- use the kept monorepo narrow surfaces: `MultiProviderAdapter`, `providers/runtime/evm`, `token/adapters/evmHyp`
- cut local mini-resolver/read helpers over to SDK directly
- keep chain search metadata-only with a local modal instead of widget `ChainSearchMenu` / `ChainAddMenu`
- no registry beta here

## Why
Goal was to preserve the shipped-JS result that landed via `#295` on `main` while still improving clean build time further.

The winning pattern is:
- metadata-first for cross-VM decode/view paths
- explicit protocol-bound runtime surfaces where provider-backed paths are EVM-only in practice

The later SDK helper cutover matters because it removes Explorer-local copies of the lightweight metadata/read helpers that apps clearly ended up needing.

## Measured impact

### Clean build time

| State | Build time | Compile time |
| --- | ---: | ---: |
| current `main` (`7c1f829`) | `51.26s` | `48s` |
| current branch (`bb5b948`) | `12.72s` | `10.2s` |

### Coarse emitted-output size

These are Turbopack emitted-artifact sizes from `.next`, not the old webpack page-size table.

| State | `.next` total | `.next/static/chunks` | static chunk JS bytes | `.next/server` |
| --- | ---: | ---: | ---: | ---: |
| current `main` (`7c1f829`) | `1,167,312 KB` | `101,588 KB` | `103,770,385` | `313,596 KB` |
| current branch (`bb5b948`) | `531,556 KB` | `40,780 KB` | `41,497,203` | `115,536 KB` |

Interpretation:
- clean build is still materially better than current `main`
- total emitted output is smaller
- the coarse client-chunk proxy is somewhat larger, so this is a build-time-first win more than a clear client-payload win under Turbopack

## What changed
- EVM-only runtime setup in `src/features/hyperlane/sdkRuntime.ts`
- provider store restacked over that narrow runtime surface
- local metadata-only chain search modal instead of widget runtime-heavy menus
- direct SDK metadata/read helper imports:
  - `@hyperlane-xyz/sdk/metadata/ChainMetadataResolver`
  - `@hyperlane-xyz/sdk/warp/read`
- deleted Explorer-local duplicates of those helpers
- local EVM hyp-adapter helper usage in collateral / warp-balance paths
- package bump to the latest kept monorepo beta line
- follow-up chain-search fixes:
  - case-insensitive `name` search
  - guarded `domainId` uniqueness
  - duplicate `chainId` rejection
  - surfaced async save failures in the modal
  - memoized merged metadata map passed into the add form
  - effective `domainId` collision checks
  - case-normalized `chainId`/`domainId` search
  - reactive `showAddChainMenu` behavior
  - allow updating an existing override without forcing local-storage reset

## Takeaways
- Turbopack no longer prints the old page-size table in the build output, so current comparison is build-time first
- clean build is materially better than current `main`
- the SDK helper cutover is mainly code-shape cleanup, which is the right outcome once Explorer is already protocol-bound

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm clean && NEXT_TELEMETRY_DISABLED=1 /usr/bin/time -p pnpm build`

Notes:
- `pnpm lint` / `next lint` still does not produce a clean completion signal in this repo, so I am not counting lint as passed
- latest validated head is `bb5b948`


### Deployed preview interaction pass

Measured with Playwright against the deployed previews, not just homepage HTML.

After initial page load:
- clicking the first message row on the branch triggered `0` new `/_next/` JS/CSS requests
- clicking the first message row on current `main` also triggered `0` new `/_next/` JS/CSS requests

Interpretation:
- Explorer branch should be described primarily as a build-time / emitted-output win
- unlike Warp UI, this is not a meaningful deployed client-payload win on interaction


## 2026-04-10 benchmark refresh

Fresh local clean-build refresh on exact rebased heads and latest published betas (`@hyperlane-xyz/core@11.3.1-beta.96f6...`, `@hyperlane-xyz/sdk|utils|widgets@30.2.0-beta.96f6...`). This supersedes the older local benchmark table above.

### Local clean build

| State | Build time | Compile time |
| --- | ---: | ---: |
| current `main` (`7c1f829`) | `56.08s` | `52s` |
| current branch (`bb5b948`) | `11.26s` | `8.8s` |

### Local emitted output proxy

| State | `.next` total | `.next/static/chunks` | static chunk JS bytes | `.next/server` |
| --- | ---: | ---: | ---: | ---: |
| current `main` (`7c1f829`) | `1,167,360 KB` | `101,588 KB` | `103,770,385` | `313,596 KB` |
| current branch (`bb5b948`) | `425,132 KB` | `15,164 KB` | `15,261,407` | `87,364 KB` |

Interpretation:
- `#301` remains a very large build-time / emitted-output win on the refreshed heads
- no fresh preview-fetch rerun in this pass; prior preview notes remain historical context only
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades core Hyperlane dependencies and changes how runtime providers are constructed (now async, EVM-only), which can affect message fetching/debug flows despite limited surface-area changes in app code.
> 
> **Overview**
> **Build/perf-oriented Hyperlane refresh.** Updates `@hyperlane-xyz/*` packages to newer beta versions and wires Next.js route typing into `next-env.d.ts`.
> 
> **Runtime/provider setup is narrowed and centralized.** Replaces direct `MultiProtocolProvider` usage with an async, EVM-only `MultiProviderAdapter` constructed by `createRuntimeMultiProvider` (used in API utilities and PI message search), and updates imports to the SDK’s narrower metadata/type entrypoints.
> 
> **Chain search UI is rebuilt to stay metadata-first.** `ChainSearchModal` is rewritten to a local searchable list plus an “Add chain metadata” form that parses JSON/YAML, validates via `ChainMetadataSchema`, and rejects name/`chainId`/effective `domainId` collisions before persisting overrides; an outdated `metadataManager.test.ts` is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb5b9487ffe6c2405debed592441718cd1cc8bed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



