### PR TITLE
feat: support native IBC transfers to/from Celestia for Stride/Eclipse warp routes

### DIFF
--- a/src/consts/warpRoutes.ts
+++ b/src/consts/warpRoutes.ts
@@ -5,7 +5,7 @@ import { TokenConnectionType, TokenStandard, WarpCoreConfig } from '@hyperlane-x
 // The input here is typically the output of the Hyperlane CLI warp deploy command
 export const warpRouteConfigs: WarpCoreConfig = {
   tokens: [
-    // TIA Celestia to Neutron
+    // TIA Celestia to Neutron and Stride
     {
       chainName: 'celestia',
       standard: TokenStandard.CosmosIbc,
@@ -15,6 +15,7 @@ export const warpRouteConfigs: WarpCoreConfig = {
       addressOrDenom: 'utia',
       logoURI: '/deployments/warp_routes/TIA/logo.svg',
       connections: [
+        // To Neutron
         {
           token:
             'cosmos|neutron|ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7',
@@ -22,6 +23,7 @@ export const warpRouteConfigs: WarpCoreConfig = {
           sourcePort: 'transfer',
           sourceChannel: 'channel-8',
         },
+        // To Aribtrum via Neutron
         {
           token: 'ethereum|arbitrum|0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C',
           type: TokenConnectionType.IbcHyperlane,
@@ -33,6 +35,7 @@ export const warpRouteConfigs: WarpCoreConfig = {
           intermediateIbcDenom:
             'ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7',
         },
+        // To Manta Pacific via Neutron
         {
           token: 'ethereum|mantapacific|0x6Fae4D9935E2fcb11fC79a64e917fb2BF14DaFaa',
           type: TokenConnectionType.IbcHyperlane,
@@ -43,6 +46,26 @@ export const warpRouteConfigs: WarpCoreConfig = {
             'neutron1ch7x3xgpnj62weyes8vfada35zff6z59kt2psqhnx9gjnt2ttqdqtva3pa',
           intermediateIbcDenom:
             'ibc/773B4D0A3CD667B2275D5A4A7A2F0909C0BA0F4059C0B9181E680DDF4965DCC7',
+        },
+        // To Stride
+        {
+          token:
+            'cosmos|stride|ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801',
+          type: TokenConnectionType.Ibc,
+          sourcePort: 'transfer',
+          sourceChannel: 'channel-4',
+        },
+        // To Eclipse via Stride
+        {
+          token: 'sealevel|eclipsemainnet|BpXHAiktwjx7fN6M9ST9wr6qKAsH27wZFhdHEhReJsR6',
+          type: TokenConnectionType.IbcHyperlane,
+          sourcePort: 'transfer',
+          sourceChannel: 'channel-4',
+          intermediateChainName: 'stride',
+          intermediateRouterAddress:
+            'stride1pvtesu3ve7qn7ctll2x495mrqf2ysp6fws68grvcu6f7n2ajghgsh2jdj6',
+          intermediateIbcDenom:
+            'ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801',
         },
       ],
     },
@@ -65,6 +88,25 @@ export const warpRouteConfigs: WarpCoreConfig = {
         },
       ],
     },
+
+    // TIA on Stride from Celestia
+    {
+      chainName: 'stride',
+      standard: TokenStandard.CosmosIbc,
+      name: 'Celestia',
+      symbol: 'TIA',
+      decimals: 6,
+      addressOrDenom: 'ibc/BF3B4F53F3694B66E13C23107C84B6485BD2B96296BB7EC680EA77BBA75B4801',
+      logoURI: '/deployments/warp_routes/TIA/logo.svg',
+      connections: [
+        {
+          token: 'cosmos|celestia|utia',
+          type: TokenConnectionType.Ibc,
+          sourcePort: 'transfer',
+          sourceChannel: 'channel-162',
+        },
+      ],
+    },
   ],
   options: {
     interchainFeeConstants: [
@@ -78,6 +120,12 @@ export const warpRouteConfigs: WarpCoreConfig = {
         origin: 'celestia',
         destination: 'mantapacific',
         amount: 270000,
+        addressOrDenom: 'utia',
+      },
+      {
+        origin: 'celestia',
+        destination: 'eclipsemainnet',
+        amount: 120000,
         addressOrDenom: 'utia',
       },
     ],

--- a/src/features/wallet/hooks/cosmos.ts
+++ b/src/features/wallet/hooks/cosmos.ts
@@ -108,8 +108,8 @@ export function useCosmosTransactionFns(): ChainTransactionFns {
         // The fee param of 'auto' here stopped working for Neutron-based IBC transfers
         // It seems the signAndBroadcast method uses a default fee multiplier of 1.4
         // https://github.com/cosmos/cosmjs/blob/e819a1fc0e99a3e5320d8d6667a08d3b92e5e836/packages/stargate/src/signingstargateclient.ts#L115
-        // Bumping to 1.6 fixes the insufficient gas issue
-        result = await client.signAndBroadcast(chainContext.address, [tx.transaction], 1.6);
+        // A multiplier of 1.6 was insufficient for Celestia -> Neutron|Cosmos -> XXX transfers, but 2 worked.
+        result = await client.signAndBroadcast(chainContext.address, [tx.transaction], 2);
         txDetails = await client.getTx(result.transactionHash);
       } else {
         throw new Error(`Invalid cosmos provider type ${tx.type}`);


### PR DESCRIPTION
- Followed the example for Neutron. Tested all routes (stride -> celestia, celestia -> stride, celestia -> eclipse)
- Ran into some issues with gas for the Celestia -> Eclipse transfers. I was able to repro the issue with Celestia -> Manta Pacific, which is interesting. The fix turned out to be to spend a bit more on fees -- I bumped our multiplier from 1.6 to 2, and both Celestia -> Mantapacific and Celestia -> Eclipse work now. This is the error I was getting prior to the fix:
![Screen Shot 2024-11-05 at 12 09 59 PM](https://github.com/user-attachments/assets/9772e692-622f-494d-9541-af0fa85e8c62)
- Found the channels to use by looking at the existing Forma/Stride config https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/deployments/warp_routes/TIA/forma-stride-config.yaml#L29 and looking at the channel used by Keplr