### PR TITLE
chore: increase the Cosmos gas estimate multiplier

### DIFF
--- a/src/features/wallet/hooks/cosmos.ts
+++ b/src/features/wallet/hooks/cosmos.ts
@@ -69,7 +69,7 @@ export function useCosmosDisconnectFn(): () => Promise<void> {
 }
 
 export function useCosmosActiveChain(): ActiveChainInfo {
-  return useMemo(() => ({} as ActiveChainInfo), []);
+  return useMemo(() => ({}) as ActiveChainInfo, []);
 }
 
 export function useCosmosTransactionFns(): ChainTransactionFns {

--- a/src/features/wallet/hooks/cosmos.ts
+++ b/src/features/wallet/hooks/cosmos.ts
@@ -69,7 +69,7 @@ export function useCosmosDisconnectFn(): () => Promise<void> {
 }
 
 export function useCosmosActiveChain(): ActiveChainInfo {
-  return useMemo(() => ({}) as ActiveChainInfo, []);
+  return useMemo(() => ({} as ActiveChainInfo), []);
 }
 
 export function useCosmosTransactionFns(): ChainTransactionFns {
@@ -108,8 +108,8 @@ export function useCosmosTransactionFns(): ChainTransactionFns {
         // The fee param of 'auto' here stopped working for Neutron-based IBC transfers
         // It seems the signAndBroadcast method uses a default fee multiplier of 1.4
         // https://github.com/cosmos/cosmjs/blob/e819a1fc0e99a3e5320d8d6667a08d3b92e5e836/packages/stargate/src/signingstargateclient.ts#L115
-        // Bumping to 1.6 fixes the insufficient gas issue
-        result = await client.signAndBroadcast(chainContext.address, [tx.transaction], 1.6);
+        // A multiplier of 1.6 was insufficient for Celestia -> Neutron|Cosmos -> XXX transfers, but 2 worked.
+        result = await client.signAndBroadcast(chainContext.address, [tx.transaction], 2);
         txDetails = await client.getTx(result.transactionHash);
       } else {
         throw new Error(`Invalid cosmos provider type ${tx.type}`);


### PR DESCRIPTION
From #309:
- Ran into some issues with gas for the Celestia -> Eclipse transfers. I was able to repro the issue with Celestia -> Manta Pacific, which is interesting. The fix turned out to be to spend a bit more on fees -- I bumped our multiplier from 1.6 to 2, and both Celestia -> Mantapacific and Celestia -> Eclipse work now. This is the error I was getting prior to the fix:
![Screen Shot 2024-11-05 at 12 09 59 PM](https://github.com/user-attachments/assets/9772e692-622f-494d-9541-af0fa85e8c62)

The drive-by is a change that exists in the `nexus` branch -- I just checked out the whole file here