### PR TITLE
chore: Format imports for auto-ordering

### DIFF
--- a/src/components/banner/FormWarningBanner.tsx
+++ b/src/components/banner/FormWarningBanner.tsx
@@ -1,5 +1,4 @@
 import { ComponentProps } from 'react';
-
 import { WarningBanner } from '../../components/banner/WarningBanner';
 import { cardStyles } from '../layout/Card';
 

--- a/src/components/banner/WarningBanner.tsx
+++ b/src/components/banner/WarningBanner.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import { PropsWithChildren, ReactNode } from 'react';
-
 import WarningIcon from '../../images/icons/warning.svg';
 
 export function WarningBanner({

--- a/src/components/buttons/ConnectAwareSubmitButton.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.tsx
@@ -1,12 +1,9 @@
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import { useFormikContext } from 'formik';
 import { useCallback } from 'react';
-
-import { ProtocolType } from '@hyperlane-xyz/utils';
-
 import { tryGetChainProtocol } from '../../features/chains/utils';
 import { useAccountForChain, useConnectFns } from '../../features/wallet/hooks/multiProtocol';
 import { useTimeout } from '../../utils/timeout';
-
 import { SolidButton } from './SolidButton';
 
 interface Props {

--- a/src/components/buttons/CopyButton.tsx
+++ b/src/components/buttons/CopyButton.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import { useState } from 'react';
-
 import CheckmarkIcon from '../../images/icons/checkmark.svg';
 import CopyIcon from '../../images/icons/copy-stack.svg';
 import { tryClipboardSet } from '../../utils/clipboard';

--- a/src/components/errors/ErrorBoundary.tsx
+++ b/src/components/errors/ErrorBoundary.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import { Component } from 'react';
-
 import { links } from '../../consts/links';
 import ErrorIcon from '../../images/icons/error-circle.svg';
 import { logger } from '../../utils/logger';

--- a/src/components/icons/ChainLogo.tsx
+++ b/src/components/icons/ChainLogo.tsx
@@ -1,8 +1,6 @@
+import { ChainLogo as ChainLogoInner } from '@hyperlane-xyz/widgets';
 import Image from 'next/image';
 import { useMemo } from 'react';
-
-import { ChainLogo as ChainLogoInner } from '@hyperlane-xyz/widgets';
-
 import { getRegistry } from '../../context/context';
 import { tryGetChainMetadata } from '../../features/chains/utils';
 

--- a/src/components/icons/Chevron.tsx
+++ b/src/components/icons/Chevron.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-
 import { Color } from '../../styles/Color';
 
 interface Props {

--- a/src/components/icons/Docs.tsx
+++ b/src/components/icons/Docs.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-
 import { Color } from '../../styles/Color';
 import { IconProps } from './types';
 

--- a/src/components/icons/HelpIcon.tsx
+++ b/src/components/icons/HelpIcon.tsx
@@ -1,6 +1,5 @@
 import { memo } from 'react';
 import { toast } from 'react-toastify';
-
 import Question from '../../images/icons/question-circle.svg';
 import { IconButton } from '../buttons/IconButton';
 

--- a/src/components/icons/History.tsx
+++ b/src/components/icons/History.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-
 import { Color } from '../../styles/Color';
 import { IconProps } from './types';
 

--- a/src/components/icons/Identicon.tsx
+++ b/src/components/icons/Identicon.tsx
@@ -1,8 +1,7 @@
-import jazzicon from '@metamask/jazzicon';
-import { memo } from 'react';
-
 import { isValidAddressEvm, normalizeAddressEvm } from '@hyperlane-xyz/utils';
 import { Circle } from '@hyperlane-xyz/widgets';
+import jazzicon from '@metamask/jazzicon';
+import { memo } from 'react';
 
 type Props = {
   address?: string;

--- a/src/components/icons/TokenIcon.tsx
+++ b/src/components/icons/TokenIcon.tsx
@@ -1,8 +1,6 @@
-import { memo } from 'react';
-
 import { IToken } from '@hyperlane-xyz/sdk';
 import { Circle } from '@hyperlane-xyz/widgets';
-
+import { memo } from 'react';
 import { getRegistry } from '../../context/context';
 import { isValidHttpsUrl, isValidRelativeUrl } from '../../utils/url';
 import { ErrorBoundary } from '../errors/ErrorBoundary';

--- a/src/components/icons/Wallet.tsx
+++ b/src/components/icons/Wallet.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react';
-
 import { Color } from '../../styles/Color';
 import { IconProps } from './types';
 

--- a/src/components/icons/WalletLogo.tsx
+++ b/src/components/icons/WalletLogo.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-
 import { WalletDetails } from '../../features/wallet/hooks/types';
 import Wallet from '../../images/icons/wallet.svg';
 import WalletConnect from '../../images/logos/wallet-connect.svg';

--- a/src/components/icons/WideChevron.tsx
+++ b/src/components/icons/WideChevron.tsx
@@ -1,5 +1,4 @@
 import { WideChevronIcon } from '@hyperlane-xyz/widgets';
-
 import { Color } from '../../styles/Color';
 
 export function WideChevron({ className }: { className?: string }) {

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import { PropsWithChildren } from 'react';
-
 import { APP_NAME, BACKGROUND_COLOR, BACKGROUND_IMAGE } from '../../consts/app';
 import { useStore } from '../../features/store';
 import { SideBarMenu } from '../../features/wallet/SideBarMenu';

--- a/src/components/layout/Modal.tsx
+++ b/src/components/layout/Modal.tsx
@@ -1,6 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react';
 import { Fragment, PropsWithChildren } from 'react';
-
 import XCircle from '../../images/icons/x-circle.svg';
 import { IconButton } from '../buttons/IconButton';
 

--- a/src/components/nav/Footer.tsx
+++ b/src/components/nav/Footer.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import { ReactNode } from 'react';
-
 import { links } from '../../consts/links';
 import { Color } from '../../styles/Color';
 import { Discord } from '../icons/Discord';

--- a/src/components/nav/Header.tsx
+++ b/src/components/nav/Header.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import Link from 'next/link';
-
 import { WalletControlBar } from '../../features/wallet/WalletControlBar';
 import Logo from '../../images/logos/app-logo.svg';
 import Name from '../../images/logos/app-name.svg';

--- a/src/components/tip/TipCard.tsx
+++ b/src/components/tip/TipCard.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import { useState } from 'react';
-
 import { IconButton } from '../../components/buttons/IconButton';
 import { config } from '../../consts/config';
 import { links } from '../../consts/links';

--- a/src/components/toast/IgpDetailsToast.tsx
+++ b/src/components/toast/IgpDetailsToast.tsx
@@ -1,5 +1,4 @@
 import { toast } from 'react-toastify';
-
 import { links } from '../../consts/links';
 
 export function toastIgpDetails(igpFee: string, tokenName = 'native token') {

--- a/src/components/toast/TxSuccessToast.tsx
+++ b/src/components/toast/TxSuccessToast.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react';
 import { toast } from 'react-toastify';
-
 import { getMultiProvider } from '../../context/context';
 
 export function toastTxSuccess(msg: string, txHash: string, chain: ChainName) {

--- a/src/components/toast/useToastError.tsx
+++ b/src/components/toast/useToastError.tsx
@@ -1,8 +1,6 @@
+import { errorToString } from '@hyperlane-xyz/utils';
 import { useEffect } from 'react';
 import { toast } from 'react-toastify';
-
-import { errorToString } from '@hyperlane-xyz/utils';
-
 import { logger } from '../../utils/logger';
 
 export function useToastError(error: any, errorMsg?: string) {

--- a/src/consts/app.ts
+++ b/src/consts/app.ts
@@ -1,5 +1,4 @@
 import { Space_Grotesk } from 'next/font/google';
-
 import { Color } from '../styles/Color';
 
 export const MAIN_FONT = Space_Grotesk({

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -1,5 +1,4 @@
 import { ChainMap } from '@hyperlane-xyz/sdk';
-
 import { ADDRESS_BLACKLIST } from './blacklist';
 
 const isDevMode = process?.env?.NODE_ENV === 'development';

--- a/src/context/WarpContext.tsx
+++ b/src/context/WarpContext.tsx
@@ -1,8 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
-
 import { Spinner } from '../components/animation/Spinner';
-
 import { initWarpContext } from './context';
 
 export function WarpContext({ children }: PropsWithChildren<unknown>) {

--- a/src/context/chains.ts
+++ b/src/context/chains.ts
@@ -1,8 +1,6 @@
-import { z } from 'zod';
-
 import { GithubRegistry, chainMetadata } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainMetadataSchema } from '@hyperlane-xyz/sdk';
-
+import { z } from 'zod';
 import { PROXY_DEPLOYED_URL } from '../consts/app.ts';
 import { chains as ChainsTS } from '../consts/chains.ts';
 import ChainsYaml from '../consts/chains.yaml';

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -8,7 +8,6 @@ import {
   WarpCore,
 } from '@hyperlane-xyz/sdk';
 import { isNullish } from '@hyperlane-xyz/utils';
-
 import { assembleChainMetadata } from './chains';
 import { assembleWarpCoreConfig } from './warpCoreConfig';
 

--- a/src/context/warpCoreConfig.ts
+++ b/src/context/warpCoreConfig.ts
@@ -1,7 +1,6 @@
 import { warpRouteConfigs } from '@hyperlane-xyz/registry';
 import { WarpCoreConfig, WarpCoreConfigSchema } from '@hyperlane-xyz/sdk';
 import { objFilter, objMerge } from '@hyperlane-xyz/utils';
-
 import { warpRouteWhitelist } from '../consts/warpRouteWhitelist.ts';
 import { warpRouteConfigs as WarpRoutesTs } from '../consts/warpRoutes.ts';
 import WarpRoutesYaml from '../consts/warpRoutes.yaml';

--- a/src/features/chains/ChainSelectField.tsx
+++ b/src/features/chains/ChainSelectField.tsx
@@ -1,11 +1,9 @@
 import { useField, useFormikContext } from 'formik';
 import Image from 'next/image';
 import { useState } from 'react';
-
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import ChevronIcon from '../../images/icons/chevron-down.svg';
 import { TransferFormValues } from '../transfer/types';
-
 import { ChainSelectListModal } from './ChainSelectModal';
 import { getChainDisplayName } from './utils';
 

--- a/src/features/chains/ChainSelectModal.tsx
+++ b/src/features/chains/ChainSelectModal.tsx
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
-
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import { Modal } from '../../components/layout/Modal';
-
 import { getChainDisplayName } from './utils';
 
 export function ChainSelectListModal({

--- a/src/features/chains/ChainWalletWarning.tsx
+++ b/src/features/chains/ChainWalletWarning.tsx
@@ -1,12 +1,9 @@
-import { useMemo } from 'react';
-
 import { toTitleCase } from '@hyperlane-xyz/utils';
-
+import { useMemo } from 'react';
 import { FormWarningBanner } from '../../components/banner/FormWarningBanner';
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
 import { useConnectFns, useDisconnectFns, useWalletDetails } from '../wallet/hooks/multiProtocol';
-
 import { getChainDisplayName, tryGetChainProtocol } from './utils';
 
 export function ChainWalletWarning({ originChain }: { originChain: ChainName }) {

--- a/src/features/chains/utils.ts
+++ b/src/features/chains/utils.ts
@@ -1,6 +1,5 @@
 import { ChainNameOrId } from '@hyperlane-xyz/sdk';
 import { ProtocolType, toTitleCase } from '@hyperlane-xyz/utils';
-
 import { getMultiProvider } from '../../context/context';
 
 const ABACUS_WORKS_DEPLOYER_NAME = 'abacus works';

--- a/src/features/sanctions/hooks/useIsAccountChainalysisSanctioned.ts
+++ b/src/features/sanctions/hooks/useIsAccountChainalysisSanctioned.ts
@@ -1,6 +1,5 @@
 import { isAddress } from 'viem';
 import { useReadContract } from 'wagmi';
-
 import { useEvmAccount } from '../../wallet/hooks/evm';
 
 // https://go.chainalysis.com/chainalysis-oracle-docs.html

--- a/src/features/sanctions/hooks/useIsAccountOfacSanctioned.ts
+++ b/src/features/sanctions/hooks/useIsAccountOfacSanctioned.ts
@@ -1,7 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { eqAddress } from '@hyperlane-xyz/utils';
-
+import { useQuery } from '@tanstack/react-query';
 import { useEvmAccount } from '../../wallet/hooks/evm';
 
 const OFAC_SANCTIONED_ADDRESSES_ENDPOINT =

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-
 import { FinalTransferStatuses, TransferContext, TransferStatus } from './transfer/types';
 
 // Increment this when persist state has breaking changes

--- a/src/features/tokens/SelectOrInputTokenIds.tsx
+++ b/src/features/tokens/SelectOrInputTokenIds.tsx
@@ -1,8 +1,6 @@
 import { useFormikContext } from 'formik';
-
 import { TextField } from '../../components/input/TextField';
 import { TransferFormValues } from '../transfer/types';
-
 import { SelectTokenIdField } from './SelectTokenIdField';
 
 // import { useContractSupportsTokenByOwner, useIsSenderNftOwner } from './balances';

--- a/src/features/tokens/SelectTokenIdField.tsx
+++ b/src/features/tokens/SelectTokenIdField.tsx
@@ -1,7 +1,6 @@
 import { useField } from 'formik';
 import Image from 'next/image';
 import { useState } from 'react';
-
 import { Spinner } from '../../components/animation/Spinner';
 import { Modal } from '../../components/layout/Modal';
 import ChevronIcon from '../../images/icons/chevron-down.svg';

--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -1,8 +1,6 @@
+import { IToken } from '@hyperlane-xyz/sdk';
 import Image from 'next/image';
 import { useMemo, useState } from 'react';
-
-import { IToken } from '@hyperlane-xyz/sdk';
-
 import { TokenIcon } from '../../components/icons/TokenIcon';
 import { TextInput } from '../../components/input/TextField';
 import { Modal } from '../../components/layout/Modal';

--- a/src/features/tokens/TokenSelectField.tsx
+++ b/src/features/tokens/TokenSelectField.tsx
@@ -1,14 +1,11 @@
+import { IToken } from '@hyperlane-xyz/sdk';
 import { useField, useFormikContext } from 'formik';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-
-import { IToken } from '@hyperlane-xyz/sdk';
-
 import { TokenIcon } from '../../components/icons/TokenIcon';
 import { getIndexForToken, getTokenByIndex, getWarpCore } from '../../context/context';
 import ChevronIcon from '../../images/icons/chevron-down.svg';
 import { TransferFormValues } from '../transfer/types';
-
 import { TokenListModal } from './TokenListModal';
 
 type Props = {

--- a/src/features/tokens/approval.ts
+++ b/src/features/tokens/approval.ts
@@ -1,7 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { IToken } from '@hyperlane-xyz/sdk';
-
+import { useQuery } from '@tanstack/react-query';
 import { useToastError } from '../../components/toast/useToastError';
 import { getWarpCore } from '../../context/context';
 import { useAccountAddressForChain } from '../wallet/hooks/multiProtocol';

--- a/src/features/tokens/balances.ts
+++ b/src/features/tokens/balances.ts
@@ -1,8 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { IToken } from '@hyperlane-xyz/sdk';
 import { isValidAddress } from '@hyperlane-xyz/utils';
-
+import { useQuery } from '@tanstack/react-query';
 import { useToastError } from '../../components/toast/useToastError';
 import { getMultiProvider, getTokenByIndex } from '../../context/context';
 import { TransferFormValues } from '../transfer/types';

--- a/src/features/transfer/TransferTokenCard.tsx
+++ b/src/features/transfer/TransferTokenCard.tsx
@@ -1,5 +1,4 @@
 import { Card } from '../../components/layout/Card';
-
 import { TransferTokenForm } from './TransferTokenForm';
 
 export function TransferTokenCard() {

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -1,11 +1,9 @@
+import { TokenAmount } from '@hyperlane-xyz/sdk';
+import { ProtocolType, errorToString, isNullish, toWei } from '@hyperlane-xyz/utils';
 import BigNumber from 'bignumber.js';
 import { Form, Formik, useFormikContext } from 'formik';
 import { useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
-
-import { TokenAmount } from '@hyperlane-xyz/sdk';
-import { ProtocolType, errorToString, isNullish, toWei } from '@hyperlane-xyz/utils';
-
 import { SmallSpinner } from '../../components/animation/SmallSpinner';
 import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareSubmitButton';
 import { IconButton } from '../../components/buttons/IconButton';
@@ -31,7 +29,6 @@ import {
   useAccounts,
 } from '../wallet/hooks/multiProtocol';
 import { AccountInfo } from '../wallet/hooks/types';
-
 import { useFetchMaxAmount } from './maxAmount';
 import { TransferFormValues } from './types';
 import { useRecipientBalanceWatcher } from './useBalanceWatcher';

--- a/src/features/transfer/TransfersDetailsModal.tsx
+++ b/src/features/transfer/TransfersDetailsModal.tsx
@@ -1,9 +1,7 @@
-import Image from 'next/image';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { MessageStatus, MessageTimeline, useMessageTimeline } from '@hyperlane-xyz/widgets';
-
+import Image from 'next/image';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Spinner } from '../../components/animation/Spinner';
 import { CopyButton } from '../../components/buttons/CopyButton';
 import { ChainLogo } from '../../components/icons/ChainLogo';
@@ -24,7 +22,6 @@ import {
 } from '../../utils/transfer';
 import { getChainDisplayName, hasPermissionlessChain } from '../chains/utils';
 import { useAccountForChain, useWalletDetails } from '../wallet/hooks/multiProtocol';
-
 import { TransferContext, TransferStatus } from './types';
 
 export function TransfersDetailsModal({

--- a/src/features/transfer/maxAmount.ts
+++ b/src/features/transfer/maxAmount.ts
@@ -1,9 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
-import { toast } from 'react-toastify';
-
 import { TokenAmount } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
-
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
 import { getWarpCore } from '../../context/context';
 import { logger } from '../../utils/logger';
 import { getChainMetadata } from '../chains/utils';

--- a/src/features/transfer/useBalanceWatcher.ts
+++ b/src/features/transfer/useBalanceWatcher.ts
@@ -1,7 +1,6 @@
+import { TokenAmount } from '@hyperlane-xyz/sdk';
 import { useEffect, useRef } from 'react';
 import { toast } from 'react-toastify';
-
-import { TokenAmount } from '@hyperlane-xyz/sdk';
 
 export function useRecipientBalanceWatcher(recipient?: Address, balance?: TokenAmount) {
   // A crude way to detect transfer completions by triggering

--- a/src/features/transfer/useFeeQuotes.ts
+++ b/src/features/transfer/useFeeQuotes.ts
@@ -1,12 +1,9 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { TokenAmount } from '@hyperlane-xyz/sdk';
 import { HexString } from '@hyperlane-xyz/utils';
-
+import { useQuery } from '@tanstack/react-query';
 import { getTokenByIndex, getWarpCore } from '../../context/context';
 import { logger } from '../../utils/logger';
 import { getAccountAddressAndPubKey, useAccounts } from '../wallet/hooks/multiProtocol';
-
 import { TransferFormValues } from './types';
 
 const FEE_QUOTE_REFRESH_INTERVAL = 15_000; // 10s

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -1,9 +1,7 @@
-import { useCallback, useState } from 'react';
-import { toast } from 'react-toastify';
-
 import { TypedTransactionReceipt, WarpTxCategory } from '@hyperlane-xyz/sdk';
 import { toTitleCase, toWei } from '@hyperlane-xyz/utils';
-
+import { useCallback, useState } from 'react';
+import { toast } from 'react-toastify';
 import { toastTxSuccess } from '../../components/toast/TxSuccessToast';
 import { getTokenByIndex, getWarpCore } from '../../context/context';
 import { logger } from '../../utils/logger';
@@ -15,7 +13,6 @@ import {
   useActiveChains,
   useTransactionFns,
 } from '../wallet/hooks/multiProtocol';
-
 import { TransferContext, TransferFormValues, TransferStatus } from './types';
 import { tryGetMsgIdFromTransferReceipt } from './utils';
 

--- a/src/features/transfer/utils.ts
+++ b/src/features/transfer/utils.ts
@@ -5,7 +5,6 @@ import {
   ProviderType,
   TypedTransactionReceipt,
 } from '@hyperlane-xyz/sdk';
-
 import { getMultiProvider } from '../../context/context';
 import { logger } from '../../utils/logger';
 

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
-
 import { SmallSpinner } from '../../components/animation/SmallSpinner';
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import { WalletLogo } from '../../components/icons/WalletLogo';
@@ -17,7 +16,6 @@ import { getChainDisplayName } from '../chains/utils';
 import { useStore } from '../store';
 import { TransfersDetailsModal } from '../transfer/TransfersDetailsModal';
 import { TransferContext } from '../transfer/types';
-
 import { useAccounts, useDisconnectFns, useWalletDetails } from './hooks/multiProtocol';
 import { AccountInfo } from './hooks/types';
 

--- a/src/features/wallet/WalletControlBar.tsx
+++ b/src/features/wallet/WalletControlBar.tsx
@@ -1,14 +1,11 @@
-import Image from 'next/image';
-
 import { ProtocolType, shortenAddress } from '@hyperlane-xyz/utils';
 import { ChevronIcon } from '@hyperlane-xyz/widgets';
-
+import Image from 'next/image';
 import { SolidButton } from '../../components/buttons/SolidButton';
 import { WalletLogo } from '../../components/icons/WalletLogo';
 import Wallet from '../../images/icons/wallet.svg';
 import { useIsSsr } from '../../utils/ssr';
 import { useStore } from '../store';
-
 import { useAccounts, useWalletDetails } from './hooks/multiProtocol';
 
 export function WalletControlBar() {

--- a/src/features/wallet/WalletEnvSelectionModal.tsx
+++ b/src/features/wallet/WalletEnvSelectionModal.tsx
@@ -1,12 +1,9 @@
-import Image from 'next/image';
-import { PropsWithChildren } from 'react';
-
 import { ethereum, solanamainnet } from '@hyperlane-xyz/registry';
 import { ProtocolType } from '@hyperlane-xyz/utils';
-
+import Image from 'next/image';
+import { PropsWithChildren } from 'react';
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import { Modal } from '../../components/layout/Modal';
-
 import { useConnectFns } from './hooks/multiProtocol';
 
 export function WalletEnvSelectionModal({ isOpen, close }: { isOpen: boolean; close: () => void }) {

--- a/src/features/wallet/WalletFloatingButtons.tsx
+++ b/src/features/wallet/WalletFloatingButtons.tsx
@@ -1,13 +1,11 @@
 import Link from 'next/link';
-
 import { IconButton } from '../../components/buttons/IconButton';
 import { DocsIcon } from '../../components/icons/Docs';
+import { HistoryIcon } from '../../components/icons/History';
 import { WalletIcon } from '../../components/icons/Wallet';
 import { links } from '../../consts/links';
 import { Color } from '../../styles/Color';
 import { useStore } from '../store';
-
-import { HistoryIcon } from '../../components/icons/History';
 import { useAccounts } from './hooks/multiProtocol';
 
 export function WalletFloatingButtons() {

--- a/src/features/wallet/context/CosmosWalletContext.tsx
+++ b/src/features/wallet/context/CosmosWalletContext.tsx
@@ -6,7 +6,6 @@ import { wallets as leapWallets } from '@cosmos-kit/leap';
 import { ChainProvider } from '@cosmos-kit/react';
 import '@interchain-ui/react/styles';
 import { PropsWithChildren } from 'react';
-
 import { APP_DESCRIPTION, APP_NAME, APP_URL } from '../../../consts/app';
 import { config } from '../../../consts/config';
 import { getCosmosKitConfig } from '../../chains/metadata';

--- a/src/features/wallet/context/SolanaWalletContext.tsx
+++ b/src/features/wallet/context/SolanaWalletContext.tsx
@@ -14,7 +14,6 @@ import {
 import { clusterApiUrl } from '@solana/web3.js';
 import { PropsWithChildren, useCallback, useMemo } from 'react';
 import { toast } from 'react-toastify';
-
 import { logger } from '../../../utils/logger';
 
 export function SolanaWalletContext({ children }: PropsWithChildren<unknown>) {

--- a/src/features/wallet/hooks/cosmos.ts
+++ b/src/features/wallet/hooks/cosmos.ts
@@ -1,11 +1,9 @@
 import { DeliverTxResponse, ExecuteResult, IndexedTx } from '@cosmjs/cosmwasm-stargate';
 import { useChain, useChains } from '@cosmos-kit/react';
-import { useCallback, useMemo } from 'react';
-import { toast } from 'react-toastify';
-
 import { ProviderType, TypedTransactionReceipt, WarpTypedTransaction } from '@hyperlane-xyz/sdk';
 import { HexString, ProtocolType, assert } from '@hyperlane-xyz/utils';
-
+import { useCallback, useMemo } from 'react';
+import { toast } from 'react-toastify';
 import { PLACEHOLDER_COSMOS_CHAIN } from '../../../consts/values';
 import { logger } from '../../../utils/logger';
 import { getCosmosChainNames } from '../../chains/metadata';

--- a/src/features/wallet/hooks/evm.ts
+++ b/src/features/wallet/hooks/evm.ts
@@ -1,15 +1,12 @@
+import { ProviderType, TypedTransactionReceipt, WarpTypedTransaction } from '@hyperlane-xyz/sdk';
+import { ProtocolType, assert, sleep } from '@hyperlane-xyz/utils';
 import { useConnectModal } from '@rainbow-me/rainbowkit';
 import { getAccount, sendTransaction, switchChain, waitForTransactionReceipt } from '@wagmi/core';
 import { useCallback, useMemo } from 'react';
 import { useAccount, useConfig, useDisconnect } from 'wagmi';
-
-import { ProviderType, TypedTransactionReceipt, WarpTypedTransaction } from '@hyperlane-xyz/sdk';
-import { ProtocolType, assert, sleep } from '@hyperlane-xyz/utils';
-
 import { logger } from '../../../utils/logger';
 import { getChainMetadata, tryGetChainMetadata } from '../../chains/utils';
 import { ethers5TxToWagmiTx } from '../utils';
-
 import { AccountInfo, ActiveChainInfo, ChainTransactionFns, WalletDetails } from './types';
 
 export function useEvmAccount(): AccountInfo {

--- a/src/features/wallet/hooks/multiProtocol.tsx
+++ b/src/features/wallet/hooks/multiProtocol.tsx
@@ -1,12 +1,9 @@
+import { HexString, ProtocolType } from '@hyperlane-xyz/utils';
 import { useMemo } from 'react';
 import { toast } from 'react-toastify';
-
-import { HexString, ProtocolType } from '@hyperlane-xyz/utils';
-
 import { config } from '../../../consts/config';
 import { logger } from '../../../utils/logger';
 import { getChainProtocol, tryGetChainProtocol } from '../../chains/utils';
-
 import {
   useCosmosAccount,
   useCosmosActiveChain,

--- a/src/features/wallet/hooks/solana.ts
+++ b/src/features/wallet/hooks/solana.ts
@@ -1,15 +1,12 @@
+import { ProviderType, TypedTransactionReceipt, WarpTypedTransaction } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import { useConnection, useWallet } from '@solana/wallet-adapter-react';
 import { useWalletModal } from '@solana/wallet-adapter-react-ui';
 import { Connection } from '@solana/web3.js';
 import { useCallback, useMemo } from 'react';
-
-import { ProviderType, TypedTransactionReceipt, WarpTypedTransaction } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
-
 import { getMultiProvider } from '../../../context/context';
 import { logger } from '../../../utils/logger';
 import { getChainByRpcUrl } from '../../chains/utils';
-
 import { AccountInfo, ActiveChainInfo, ChainTransactionFns, WalletDetails } from './types';
 
 export function useSolAccount(): AccountInfo {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,9 @@
+import '@hyperlane-xyz/widgets/styles.css';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Analytics } from '@vercel/analytics/react';
 import type { AppProps } from 'next/app';
 import { ToastContainer, Zoom } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import '../vendor/inpage-metamask';
-import '../vendor/polyfill';
-
-import '@hyperlane-xyz/widgets/styles.css';
-
 import { ErrorBoundary } from '../components/errors/ErrorBoundary';
 import { AppLayout } from '../components/layout/AppLayout';
 import { MAIN_FONT } from '../consts/app';
@@ -17,6 +13,8 @@ import { EvmWalletContext } from '../features/wallet/context/EvmWalletContext';
 import { SolanaWalletContext } from '../features/wallet/context/SolanaWalletContext';
 import '../styles/globals.css';
 import { useIsSsr } from '../utils/ssr';
+import '../vendor/inpage-metamask';
+import '../vendor/polyfill';
 
 const reactQueryClient = new QueryClient({
   defaultOptions: {

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,4 @@
 import { Head, Html, Main, NextScript } from 'next/document';
-
 import { APP_DESCRIPTION, APP_NAME, APP_URL, BRAND_COLOR, MAIN_FONT } from '../consts/app';
 
 export default function Document() {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import type { NextPage } from 'next';
-
 import { TipCard } from '../components/tip/TipCard';
 import { TransferTokenCard } from '../features/transfer/TransferTokenCard';
 import { WalletFloatingButtons } from '../features/wallet/WalletFloatingButtons';

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,5 +1,4 @@
 import { toBase64 } from '@hyperlane-xyz/utils';
-
 import { config } from '../consts/config';
 import { links } from '../consts/links';
 import { getChainMetadata, isPermissionlessChain } from '../features/chains/utils';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 import { captureException } from '@sentry/nextjs';
-
 import { config } from '../consts/config';
 
 export const logger = {

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -1,5 +1,4 @@
 import { SafeParseReturnType } from 'zod';
-
 import { logger } from './logger';
 
 export function validateZodResult<T>(


### PR DESCRIPTION
Remove spaces left from the former prettier import order plugin (trivago) that were confusing the new plugin