### PR TITLE
feat: Chain Search Menu

### DIFF
--- a/src/features/chains/ChainSelectField.tsx
+++ b/src/features/chains/ChainSelectField.tsx
@@ -1,3 +1,4 @@
+import { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 import { useField, useFormikContext } from 'formik';
 import Image from 'next/image';
 import { useState } from 'react';
@@ -10,12 +11,23 @@ import { useChainDisplayName } from './hooks';
 type Props = {
   name: string;
   label: string;
-  chains: ChainName[];
   onChange?: (id: ChainName) => void;
   disabled?: boolean;
+  chains: ChainMap<ChainMetadata>;
+  customListItemField: ChainMap<{
+    display: string;
+    sortValue: number;
+  }>;
 };
 
-export function ChainSelectField({ name, label, chains, onChange, disabled }: Props) {
+export function ChainSelectField({
+  name,
+  label,
+  chains,
+  onChange,
+  disabled,
+  customListItemField,
+}: Props) {
   const [field, , helpers] = useField<ChainName>(name);
   const { setFieldValue } = useFormikContext<TransferFormValues>();
 
@@ -62,6 +74,7 @@ export function ChainSelectField({ name, label, chains, onChange, disabled }: Pr
         close={() => setIsModalOpen(false)}
         chains={chains}
         onSelect={handleChange}
+        customListItemField={customListItemField}
       />
     </div>
   );

--- a/src/features/chains/ChainSelectModal.tsx
+++ b/src/features/chains/ChainSelectModal.tsx
@@ -1,45 +1,46 @@
-import { useMemo } from 'react';
-import { ChainLogo } from '../../components/icons/ChainLogo';
-import { Modal } from '../../components/layout/Modal';
-import { useMultiProvider } from './hooks';
-import { getChainDisplayName } from './utils';
+import { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import { ChainSearchMenu, Modal } from '@hyperlane-xyz/widgets';
+import { useStore } from '../store';
 
 export function ChainSelectListModal({
   isOpen,
   close,
   chains,
   onSelect,
+  customListItemField,
 }: {
   isOpen: boolean;
   close: () => void;
-  chains: ChainName[];
+  chains: ChainMap<ChainMetadata>;
   onSelect: (chain: ChainName) => void;
+  customListItemField: ChainMap<{
+    display: string;
+    sortValue: number;
+  }>;
 }) {
-  const multiProvider = useMultiProvider();
+  const { chainMetadataOverrides, setChainMetadataOverrides } = useStore((s) => ({
+    chainMetadataOverrides: s.chainMetadataOverrides,
+    setChainMetadataOverrides: s.setChainMetadataOverrides,
+  }));
 
-  const sortedChains = useMemo(() => chains.sort(), [chains]);
-
-  const onSelectChain = (chain: ChainName) => {
-    return () => {
-      onSelect(chain);
-      close();
-    };
+  const onSelectChain = (chain: ChainMetadata) => {
+    onSelect(chain.name);
+    close();
   };
 
   return (
-    <Modal isOpen={isOpen} title="Select Chain" close={close}>
-      <div className="mt-2 flex flex-col space-y-1">
-        {sortedChains.map((c) => (
-          <button
-            key={c}
-            className="flex items-center rounded px-2 py-1.5 text-sm transition-all duration-200 hover:bg-gray-100 active:bg-gray-200"
-            onClick={onSelectChain(c)}
-          >
-            <ChainLogo chainName={c} size={16} background={false} />
-            <span className="ml-2">{getChainDisplayName(multiProvider, c, true)}</span>
-          </button>
-        ))}
-      </div>
+    <Modal isOpen={isOpen} close={close} panelClassname="p-4 sm:p-5 max-w-lg min-h-[40vh]">
+      <ChainSearchMenu
+        chainMetadata={chains}
+        onClickChain={onSelectChain}
+        overrideChainMetadata={chainMetadataOverrides}
+        onChangeOverrideMetadata={setChainMetadataOverrides}
+        customListItemField={{
+          header: 'Warp Routes',
+          data: customListItemField,
+        }}
+        defaultSortField="custom"
+      />
     </Modal>
   );
 }

--- a/src/features/chains/hooks.ts
+++ b/src/features/chains/hooks.ts
@@ -1,6 +1,7 @@
 import { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 import { useMemo } from 'react';
 import { useStore } from '../store';
+import { useWarpCore } from '../tokens/hooks';
 import { getChainDisplayName } from './utils';
 
 export function useMultiProvider() {
@@ -32,10 +33,12 @@ export function useChainDisplayName(chainName: ChainName, shortName = false) {
 }
 
 /**
- * Return a chainMetadata object with given chains
+ * Returns chainMetadata object with warp core token chains
  */
-export function useChainMetadataMap(chains: string[]) {
+export function useTokenChainsMetadata() {
   const multiProvider = useMultiProvider();
+  const warpCore = useWarpCore();
+  const chains = useMemo(() => warpCore.getTokenChains(), [warpCore]);
 
   const chainMetadata = useMemo(() => {
     return chains.reduce<ChainMap<ChainMetadata>>((obj, chain) => {

--- a/src/features/chains/hooks.ts
+++ b/src/features/chains/hooks.ts
@@ -31,6 +31,9 @@ export function useChainDisplayName(chainName: ChainName, shortName = false) {
   return getChainDisplayName(multiProvider, chainName, shortName);
 }
 
+/**
+ * Return a chainMetadata object with given chains
+ */
 export function useChainMetadataMap(chains: string[]) {
   const multiProvider = useMultiProvider();
 

--- a/src/features/chains/hooks.ts
+++ b/src/features/chains/hooks.ts
@@ -1,3 +1,5 @@
+import { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import { useMemo } from 'react';
 import { useStore } from '../store';
 import { getChainDisplayName } from './utils';
 
@@ -27,4 +29,18 @@ export function useChainProtocol(chainName?: ChainName) {
 export function useChainDisplayName(chainName: ChainName, shortName = false) {
   const multiProvider = useMultiProvider();
   return getChainDisplayName(multiProvider, chainName, shortName);
+}
+
+export function useChainMetadataMap(chains: string[]) {
+  const multiProvider = useMultiProvider();
+
+  const chainMetadata = useMemo(() => {
+    return chains.reduce<ChainMap<ChainMetadata>>((obj, chain) => {
+      const metadata = multiProvider.tryGetChainMetadata(chain);
+      if (metadata) obj[chain] = metadata;
+      return obj;
+    }, {});
+  }, [chains, multiProvider]);
+
+  return chainMetadata;
 }

--- a/src/features/chains/utils.ts
+++ b/src/features/chains/utils.ts
@@ -1,5 +1,5 @@
 import { isAbacusWorksChain } from '@hyperlane-xyz/registry';
-import { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { ChainMap, ChainMetadata, MultiProtocolProvider, WarpCore } from '@hyperlane-xyz/sdk';
 import { ProtocolType, toTitleCase } from '@hyperlane-xyz/utils';
 
 export function getChainDisplayName(
@@ -29,5 +29,28 @@ export function getChainByRpcUrl(multiProvider: MultiProtocolProvider, url?: str
   const allMetadata = Object.values(multiProvider.metadata);
   return allMetadata.find(
     (m) => !!m.rpcUrls.find((rpc) => rpc.http.toLowerCase().includes(url.toLowerCase())),
+  );
+}
+
+/**
+ * Return a customListItemField object that contains the route
+ * from all the chains to a single origin chain
+ */
+export function getCustomListItemField(
+  warpCore: WarpCore,
+  origin: ChainName,
+  chains: ChainMap<ChainMetadata>,
+): ChainMap<{ display: string; sortValue: number }> {
+  return Object.keys(chains).reduce<ChainMap<{ display: string; sortValue: number }>>(
+    (obj, chainName) => {
+      const tokens = warpCore.getTokensForRoute(origin, chainName);
+      obj[chainName] = {
+        display: `${tokens.length} routes`,
+        sortValue: tokens.length,
+      };
+
+      return obj;
+    },
+    {},
   );
 }

--- a/src/features/chains/utils.ts
+++ b/src/features/chains/utils.ts
@@ -33,8 +33,8 @@ export function getChainByRpcUrl(multiProvider: MultiProtocolProvider, url?: str
 }
 
 /**
- * Return a customListItemField object that contains the route
- * from all the chains to a single origin chain
+ * Return a customListItemField object that contains the amount of
+ * routes from a single chain to every other chain
  */
 export function getCustomListItemField(
   warpCore: WarpCore,

--- a/src/features/chains/utils.ts
+++ b/src/features/chains/utils.ts
@@ -33,18 +33,18 @@ export function getChainByRpcUrl(multiProvider: MultiProtocolProvider, url?: str
 }
 
 /**
- * Return a customListItemField object that contains the amount of
+ * Returns an object that contains the amount of
  * routes from a single chain to every other chain
  */
-export function getCustomListItemField(
+export function getAllTokenRoutesFromChain(
   warpCore: WarpCore,
   origin: ChainName,
   chains: ChainMap<ChainMetadata>,
 ): ChainMap<{ display: string; sortValue: number }> {
   return Object.keys(chains).reduce<ChainMap<{ display: string; sortValue: number }>>(
-    (obj, chainName) => {
-      const tokens = warpCore.getTokensForRoute(origin, chainName);
-      obj[chainName] = {
+    (obj, destination) => {
+      const tokens = warpCore.getTokensForRoute(origin, destination);
+      obj[destination] = {
         display: `${tokens.length} routes`,
         sortValue: tokens.length,
       };

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -15,8 +15,8 @@ import { Color } from '../../styles/Color';
 import { logger } from '../../utils/logger';
 import { ChainSelectField } from '../chains/ChainSelectField';
 import { ChainWalletWarning } from '../chains/ChainWalletWarning';
-import { useChainDisplayName, useChainMetadataMap } from '../chains/hooks';
-import { getCustomListItemField } from '../chains/utils';
+import { useChainDisplayName, useTokenChainsMetadata } from '../chains/hooks';
+import { getAllTokenRoutesFromChain } from '../chains/utils';
 import { useIsAccountSanctioned } from '../sanctions/hooks/useIsAccountSanctioned';
 import { useStore } from '../store';
 import { SelectOrInputTokenIds } from '../tokens/SelectOrInputTokenIds';
@@ -111,17 +111,16 @@ function SwapChainsButton({ disabled }: { disabled?: boolean }) {
 
 function ChainSelectSection({ isReview }: { isReview: boolean }) {
   const warpCore = useWarpCore();
-  const chains = useMemo(() => warpCore.getTokenChains(), [warpCore]);
-  const chainMetadata = useChainMetadataMap(chains);
+  const chainMetadata = useTokenChainsMetadata();
 
   const { values } = useFormikContext<TransferFormValues>();
 
   const originRoutes = useMemo(() => {
-    return getCustomListItemField(warpCore, values.origin, chainMetadata);
+    return getAllTokenRoutesFromChain(warpCore, values.origin, chainMetadata);
   }, [values.origin, warpCore, chainMetadata]);
 
   const destinationRoutes = useMemo(() => {
-    return getCustomListItemField(warpCore, values.destination, chainMetadata);
+    return getAllTokenRoutesFromChain(warpCore, values.destination, chainMetadata);
   }, [values.destination, warpCore, chainMetadata]);
 
   return (

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -15,7 +15,8 @@ import { Color } from '../../styles/Color';
 import { logger } from '../../utils/logger';
 import { ChainSelectField } from '../chains/ChainSelectField';
 import { ChainWalletWarning } from '../chains/ChainWalletWarning';
-import { useChainDisplayName } from '../chains/hooks';
+import { useChainDisplayName, useChainMetadataMap } from '../chains/hooks';
+import { getCustomListItemField } from '../chains/utils';
 import { useIsAccountSanctioned } from '../sanctions/hooks/useIsAccountSanctioned';
 import { useStore } from '../store';
 import { SelectOrInputTokenIds } from '../tokens/SelectOrInputTokenIds';
@@ -111,14 +112,37 @@ function SwapChainsButton({ disabled }: { disabled?: boolean }) {
 function ChainSelectSection({ isReview }: { isReview: boolean }) {
   const warpCore = useWarpCore();
   const chains = useMemo(() => warpCore.getTokenChains(), [warpCore]);
+  const chainMetadata = useChainMetadataMap(chains);
+
+  const { values } = useFormikContext<TransferFormValues>();
+
+  const originRoutes = useMemo(() => {
+    return getCustomListItemField(warpCore, values.origin, chainMetadata);
+  }, [values.origin, warpCore, chainMetadata]);
+
+  const destinationRoutes = useMemo(() => {
+    return getCustomListItemField(warpCore, values.destination, chainMetadata);
+  }, [values.destination, warpCore, chainMetadata]);
 
   return (
     <div className="mt-4 flex items-center justify-between gap-4">
-      <ChainSelectField name="origin" label="From" chains={chains} disabled={isReview} />
+      <ChainSelectField
+        name="origin"
+        label="From"
+        chains={chainMetadata}
+        disabled={isReview}
+        customListItemField={destinationRoutes}
+      />
       <div className="flex flex-1 flex-col items-center">
         <SwapChainsButton disabled={isReview} />
       </div>
-      <ChainSelectField name="destination" label="To" chains={chains} disabled={isReview} />
+      <ChainSelectField
+        name="destination"
+        label="To"
+        chains={chainMetadata}
+        disabled={isReview}
+        customListItemField={originRoutes}
+      />
     </div>
   );
 }


### PR DESCRIPTION
- Replace current chain menu with `ChainSearchMenu` from widgets
- Create a `chainMetadata` (not taken from the registry) with the tokens that come from the warpCore
- Create a `customListItemField` object that contains all the routes from a single chain to any other warp core token chain
- Chain Search Menu will show the routes from the opposing field. EX: If you open `"To"` chain, it will show all the routes from the `"From"` field chain to all the chains

![image](https://github.com/user-attachments/assets/bfaf9876-6d91-4f77-9543-6cfe1dc4f6fc)
