### PR TITLE
[draft] feat: add ezSOL and apxETH

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "6.1.0",
+    "@hyperlane-xyz/registry": "6.2.0",
     "@hyperlane-xyz/sdk": "7.1.0",
     "@hyperlane-xyz/utils": "7.1.0",
     "@hyperlane-xyz/widgets": "7.1.0",

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -17,6 +17,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // tETH routes
   'tETH/eclipsemainnet-ethereum',
 
+  // apxETH routes
+  'apxETH/eclipsemainnet-ethereum',
+
   // ECLIP routes
   'ECLIP/arbitrum-neutron',
 
@@ -39,6 +42,9 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // SOL routes
   'SOL/eclipsemainnet-solanamainnet',
+
+  // ezSOL routes
+  'ezSOL/eclipsemainnet-solanamainnet',
 
   // WIF routes
   'WIF/eclipsemainnet-solanamainnet',

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -222,7 +222,7 @@ function RecipientSection({ isReview }: { isReview: boolean }) {
 }
 
 function TokenBalance({ label, balance }: { label: string; balance?: TokenAmount | null }) {
-  const value = balance?.getDecimalFormattedAmount().toFixed(4) || '0';
+  const value = balance?.getDecimalFormattedAmount().toFixed(5) || '0';
   return <div className="text-right text-xs text-gray-600">{`${label}: ${value}`}</div>;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,13 +3899,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:6.1.0":
-  version: 6.1.0
-  resolution: "@hyperlane-xyz/registry@npm:6.1.0"
+"@hyperlane-xyz/registry@npm:6.2.0":
+  version: 6.2.0
+  resolution: "@hyperlane-xyz/registry@npm:6.2.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/a0e1ecc02d83604793ddda0a3e00a9ffcaa38b1cddf9883b47cf8f1919b4474abd6cc2ee84846e6a35e1bc7539299b9bec92bfdf06be72beecff6aa44b73d382
+  checksum: 10/4fb270af56e75589e01dead30de2a42a7f3bc15ba15436300b9b58e7e5fe059a4ec3b4e95b2fe1dd105d4512ba007c6bd61908487a27740956d747d3fd5f4e59
   languageName: node
   linkType: hard
 
@@ -3971,7 +3971,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:6.1.0"
+    "@hyperlane-xyz/registry": "npm:6.2.0"
     "@hyperlane-xyz/sdk": "npm:7.1.0"
     "@hyperlane-xyz/utils": "npm:7.1.0"
     "@hyperlane-xyz/widgets": "npm:7.1.0"


### PR DESCRIPTION
draft for now until there's an ownership transfer - opening to get a link

- Upgrades registry and adds ezSOL and apxETH
- Drive-by to display 5 decimals for balances, found this useful for test amounts of ETH (high decimal count, high value token)