### PR TITLE
feat: add ezSOL to Nexus

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -46,6 +46,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // SOL routes
   'SOL/eclipsemainnet-solanamainnet',
 
+  // ezSOL routes
+  'ezSOL/eclipsemainnet-solanamainnet',
+
   // WIF routes
   'WIF/eclipsemainnet-solanamainnet',
 


### PR DESCRIPTION
- Similar to #343, but on Nexus
- They indicated they wanted this route on Nexus because it's a common path for Eclipse users