### PR TITLE
feat: add appchain base usdc route to nexus

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "6.4.0",
+    "@hyperlane-xyz/registry": "6.8.0",
     "@hyperlane-xyz/sdk": "7.1.0",
     "@hyperlane-xyz/utils": "7.1.0",
     "@hyperlane-xyz/widgets": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "6.8.0",
+    "@hyperlane-xyz/registry": "6.9.1",
     "@hyperlane-xyz/sdk": "7.1.0",
     "@hyperlane-xyz/utils": "7.1.0",
     "@hyperlane-xyz/widgets": "7.1.0",

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -34,6 +34,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/ancient8-ethereum',
   'USDC/ethereum-viction',
   'USDC/eclipsemainnet-ethereum-solanamainnet',
+  'USDC/appchain-base',
 
   // USDT routes
   'USDT/ethereum-inevm',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,13 +3899,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:6.4.0":
-  version: 6.4.0
-  resolution: "@hyperlane-xyz/registry@npm:6.4.0"
+"@hyperlane-xyz/registry@npm:6.8.0":
+  version: 6.8.0
+  resolution: "@hyperlane-xyz/registry@npm:6.8.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/ac5dbd8cf82c4488cf4093c8a86e845b98573842b28095722a2d778128e4e4342ecda7f7865a9b1b153e8b7c2c299ba67660bbe500f8e626b71b6c561de8f695
+  checksum: 10/d03e9b3cfcef629f24bb25667d26708a42c8506cfae4d2d4b9d51d9154e709cf6c518ed9695a173f17d02cd835652f5f28c3d3a4d378fde046646eaede8e1eb2
   languageName: node
   linkType: hard
 
@@ -3971,7 +3971,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:6.4.0"
+    "@hyperlane-xyz/registry": "npm:6.8.0"
     "@hyperlane-xyz/sdk": "npm:7.1.0"
     "@hyperlane-xyz/utils": "npm:7.1.0"
     "@hyperlane-xyz/widgets": "npm:7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3899,13 +3899,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:6.8.0":
-  version: 6.8.0
-  resolution: "@hyperlane-xyz/registry@npm:6.8.0"
+"@hyperlane-xyz/registry@npm:6.9.1":
+  version: 6.9.1
+  resolution: "@hyperlane-xyz/registry@npm:6.9.1"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/d03e9b3cfcef629f24bb25667d26708a42c8506cfae4d2d4b9d51d9154e709cf6c518ed9695a173f17d02cd835652f5f28c3d3a4d378fde046646eaede8e1eb2
+  checksum: 10/b8c2037b667131e75f2c94efd48d992ebc990433fddfe32a7714652b3cbddf37e51918a401f57f95bb48085da5b82bff05825b75e2529b5c8c9a367e3e484eef
   languageName: node
   linkType: hard
 
@@ -3971,7 +3971,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:6.8.0"
+    "@hyperlane-xyz/registry": "npm:6.9.1"
     "@hyperlane-xyz/sdk": "npm:7.1.0"
     "@hyperlane-xyz/utils": "npm:7.1.0"
     "@hyperlane-xyz/widgets": "npm:7.1.0"


### PR DESCRIPTION
Adds USDC warp route that links appchain to base to nexus whitelist and bumps registry version