### PR TITLE
feat: support intents

### DIFF
--- a/src/consts/warpRoutes.ts
+++ b/src/consts/warpRoutes.ts
@@ -1,9 +1,182 @@
-import { WarpCoreConfig } from '@hyperlane-xyz/sdk';
+import { TokenStandard, WarpCoreConfig } from '@hyperlane-xyz/sdk';
+import { zeroAddress } from 'viem';
+
+const ROUTER = '0xe0c8f83bA0686FDF1a76AF0cC202181AEaA25a03';
+const ITT = '0x5f94BC7Fb4A2779fef010F96b496cD36A909E818';
 
 // A list of Warp Route token configs
 // These configs will be merged with the warp routes in the configured registry
 // The input here is typically the output of the Hyperlane CLI warp deploy command
 export const warpRouteConfigs: WarpCoreConfig = {
-  tokens: [],
+  tokens: [
+    {
+      addressOrDenom: ITT,
+      chainName: 'optimismsepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|basesepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|arbitrumsepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|sepolia|' + ITT,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ITT',
+      standard: TokenStandard.EvmIntent,
+      symbol: 'ITT',
+    },
+    {
+      addressOrDenom: ITT,
+      chainName: 'basesepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|optimismsepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|arbitrumsepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|sepolia|' + ITT,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ITT',
+      standard: TokenStandard.EvmIntent,
+      symbol: 'ITT',
+    },
+    {
+      addressOrDenom: ITT,
+      chainName: 'arbitrumsepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|optimismsepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|basesepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|sepolia|' + ITT,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ITT',
+      standard: TokenStandard.EvmIntent,
+      symbol: 'ITT',
+    },
+    {
+      addressOrDenom: ITT,
+      chainName: 'sepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|optimismsepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|arbitrumsepolia|' + ITT,
+        },
+        {
+          token: 'ethereum|basesepolia|' + ITT,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ITT',
+      standard: TokenStandard.EvmIntent,
+      symbol: 'ITT',
+    },
+    {
+      addressOrDenom: zeroAddress,
+      chainName: 'optimismsepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|basesepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|arbitrumsepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|sepolia|' + zeroAddress,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ETH',
+      standard: TokenStandard.EvmIntentNative,
+      symbol: 'ETH',
+    },
+    {
+      addressOrDenom: zeroAddress,
+      chainName: 'basesepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|optimismsepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|arbitrumsepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|sepolia|' + zeroAddress,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ETH',
+      standard: TokenStandard.EvmIntentNative,
+      symbol: 'ETH',
+    },
+    {
+      addressOrDenom: zeroAddress,
+      chainName: 'arbitrumsepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|optimismsepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|basesepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|sepolia|' + zeroAddress,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ETH',
+      standard: TokenStandard.EvmIntentNative,
+      symbol: 'ETH',
+    },
+    {
+      addressOrDenom: zeroAddress,
+      chainName: 'sepolia',
+      intentRouterAddressOrDenom: ROUTER,
+      connections: [
+        {
+          token: 'ethereum|optimismsepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|arbitrumsepolia|' + zeroAddress,
+        },
+        {
+          token: 'ethereum|basesepolia|' + zeroAddress,
+        },
+      ],
+      decimals: 18,
+      logoURI: '/deployments/warp_routes/ETH/logo.svg',
+      name: 'ETH',
+      standard: TokenStandard.EvmIntentNative,
+      symbol: 'ETH',
+    },
+  ],
   options: {},
 };

--- a/src/features/CoreProxy.ts
+++ b/src/features/CoreProxy.ts
@@ -1,0 +1,352 @@
+import {
+  ChainNameOrId,
+  IntentCore,
+  IntentCoreFeeEstimate,
+  IToken,
+  MultiProtocolProvider,
+  parseTokenConnectionId,
+  Token,
+  TokenAmount,
+  WarpCore,
+  WarpCoreConfigSchema,
+  WarpCoreOptions,
+} from '@hyperlane-xyz/sdk';
+import { TransactionFeeEstimate } from '@hyperlane-xyz/sdk/dist/providers/transactionFeeEstimators';
+import { WarpCoreFeeEstimate } from '@hyperlane-xyz/sdk/dist/warp/types';
+import { assert, HexString } from '@hyperlane-xyz/utils';
+import { isIntentStandard } from '../utils/intents';
+
+export class CoreProxy {
+  private readonly warpCore: WarpCore;
+  private readonly intentCore: IntentCore;
+
+  constructor(
+    multiProvider: MultiProtocolProvider<{ mailbox?: Address }>,
+    tokens: Token[],
+    options?: WarpCoreOptions,
+  ) {
+    this.warpCore = new WarpCore(
+      multiProvider,
+      tokens.filter(({ standard }) => !isIntentStandard(standard)),
+      options,
+    );
+    this.intentCore = new IntentCore(
+      multiProvider,
+      tokens.filter(({ standard }) => isIntentStandard(standard)),
+      options,
+    );
+  }
+
+  /**
+   * Takes the serialized representation of an intent config and returns a CoreProxy instance
+   * @param multiProvider the MultiProtocolProvider containing chain metadata
+   * @param config the config object of type IntentCoreConfig
+   */
+  static FromConfig(
+    multiProvider: MultiProtocolProvider<{ mailbox?: Address }>,
+    config: unknown,
+  ): CoreProxy {
+    // Validate and parse config data
+    const parsedConfig = WarpCoreConfigSchema.parse(config);
+    // Instantiate all tokens
+    const tokens = parsedConfig.tokens.map(
+      (t) =>
+        new Token({
+          ...t,
+          addressOrDenom: t.addressOrDenom || '',
+          intentRouterAddressOrDenom: isIntentStandard(t.standard)
+            ? t.intentRouterAddressOrDenom
+            : undefined,
+          connections: undefined,
+        }),
+    );
+    // Connect tokens together
+    parsedConfig.tokens.forEach((config, i) => {
+      for (const connection of config.connections || []) {
+        const token1 = tokens[i];
+        const { chainName, addressOrDenom } = parseTokenConnectionId(connection.token);
+        const token2 = tokens.find(
+          (t) => t.chainName === chainName && t.addressOrDenom === addressOrDenom,
+        );
+        assert(token2, `Connected token not found: ${chainName} ${addressOrDenom}`);
+        token1.addConnection({
+          ...connection,
+          token: token2,
+        });
+      }
+    });
+    // Create new Intent
+    return new CoreProxy(multiProvider, tokens, parsedConfig.options);
+  }
+
+  async getInterchainTransferFee({
+    originToken,
+    destination,
+    sender,
+  }: {
+    originToken: IToken;
+    destination: ChainNameOrId;
+    sender?: Address;
+  }): Promise<TokenAmount> {
+    if (isIntentStandard(originToken.standard)) {
+      return this.intentCore.getInterchainTransferFee({ originToken, destination, sender });
+    } else {
+      return this.warpCore.getInterchainTransferFee({ originToken, destination, sender });
+    }
+  }
+
+  async getLocalTransferFee({
+    originToken,
+    destination,
+    sender,
+    senderPubKey,
+    interchainFee,
+  }: {
+    originToken: IToken;
+    destination: ChainNameOrId;
+    sender: Address;
+    senderPubKey?: HexString;
+    interchainFee?: TokenAmount;
+  }): Promise<TransactionFeeEstimate> {
+    if (isIntentStandard(originToken.standard)) {
+      return this.intentCore.getLocalTransferFee({
+        originToken,
+        destination,
+        sender,
+        senderPubKey,
+        interchainFee,
+      });
+    } else {
+      return this.warpCore.getLocalTransferFee({
+        originToken,
+        destination,
+        sender,
+        senderPubKey,
+        interchainFee,
+      });
+    }
+  }
+
+  async getLocalTransferFeeAmount({
+    originToken,
+    destination,
+    sender,
+    senderPubKey,
+    interchainFee,
+  }: {
+    originToken: IToken;
+    destination: ChainNameOrId;
+    sender: Address;
+    senderPubKey?: HexString;
+    interchainFee?: TokenAmount;
+  }): Promise<TokenAmount> {
+    if (isIntentStandard(originToken.standard)) {
+      return this.intentCore.getLocalTransferFeeAmount({
+        originToken,
+        destination,
+        sender,
+        senderPubKey,
+        interchainFee,
+      });
+    } else {
+      return this.warpCore.getLocalTransferFeeAmount({
+        originToken,
+        destination,
+        sender,
+        senderPubKey,
+        interchainFee,
+      });
+    }
+  }
+
+  async getTransferRemoteTxs({
+    originTokenAmount,
+    destination,
+    sender,
+    recipient,
+    interchainFee,
+  }: {
+    originTokenAmount: TokenAmount;
+    destination: ChainNameOrId;
+    sender: Address;
+    recipient: Address;
+    interchainFee?: TokenAmount;
+  }): Promise<Array<WarpTypedTransaction>> {
+    if (isIntentStandard(originTokenAmount.token.standard)) {
+      return this.intentCore.getTransferRemoteTxs({
+        originTokenAmount,
+        destination,
+        sender,
+        recipient,
+        interchainFee,
+      });
+    } else {
+      return this.warpCore.getTransferRemoteTxs({
+        originTokenAmount,
+        destination,
+        sender,
+        recipient,
+        interchainFee,
+      });
+    }
+  }
+
+  async estimateTransferRemoteFees({
+    originToken,
+    destination,
+    sender,
+    senderPubKey,
+  }: {
+    originToken: IToken;
+    destination: ChainNameOrId;
+    sender: Address;
+    senderPubKey?: HexString;
+  }): Promise<WarpCoreFeeEstimate> {
+    if (isIntentStandard(originToken.standard)) {
+      return this.intentCore.estimateTransferRemoteFees({
+        originToken,
+        destination,
+        sender,
+        senderPubKey,
+      });
+    } else {
+      return this.warpCore.estimateTransferRemoteFees({
+        originToken,
+        destination,
+        sender,
+        senderPubKey,
+      });
+    }
+  }
+
+  async getMaxTransferAmount({
+    balance,
+    destination,
+    sender,
+    senderPubKey,
+    feeEstimate,
+  }: {
+    balance: TokenAmount;
+    destination: ChainNameOrId;
+    sender: Address;
+    senderPubKey?: HexString;
+    feeEstimate?: IntentCoreFeeEstimate;
+  }): Promise<TokenAmount> {
+    if (isIntentStandard(balance.token.standard)) {
+      return this.intentCore.getMaxTransferAmount({
+        balance,
+        destination,
+        sender,
+        senderPubKey,
+        feeEstimate,
+      });
+    } else {
+      return this.warpCore.getMaxTransferAmount({
+        balance,
+        destination,
+        sender,
+        senderPubKey,
+        feeEstimate,
+      });
+    }
+  }
+
+  async isDestinationCollateralSufficient({
+    originTokenAmount,
+    destination,
+  }: {
+    originTokenAmount: TokenAmount;
+    destination: ChainNameOrId;
+  }): Promise<boolean> {
+    if (isIntentStandard(originTokenAmount.token.standard)) {
+      return this.intentCore.isDestinationCollateralSufficient({
+        originTokenAmount,
+        destination,
+      });
+    } else {
+      return this.warpCore.isDestinationCollateralSufficient({
+        originTokenAmount,
+        destination,
+      });
+    }
+  }
+
+  async isApproveRequired({
+    originTokenAmount,
+    owner,
+  }: {
+    originTokenAmount: TokenAmount;
+    owner: Address;
+  }): Promise<boolean> {
+    if (isIntentStandard(originTokenAmount.token.standard)) {
+      return this.intentCore.isApproveRequired({ originTokenAmount, owner });
+    } else {
+      return this.warpCore.isApproveRequired({ originTokenAmount, owner });
+    }
+  }
+
+  async validateTransfer({
+    originTokenAmount,
+    destination,
+    recipient,
+    sender,
+    senderPubKey,
+  }: {
+    originTokenAmount: TokenAmount;
+    destination: ChainNameOrId;
+    recipient: Address;
+    sender: Address;
+    senderPubKey?: HexString;
+  }): Promise<Record<string, string> | null> {
+    if (isIntentStandard(originTokenAmount.token.standard)) {
+      return this.intentCore.validateTransfer({
+        originTokenAmount,
+        destination,
+        recipient,
+        sender,
+        senderPubKey,
+      });
+    } else {
+      return this.warpCore.validateTransfer({
+        originTokenAmount,
+        destination,
+        recipient,
+        sender,
+        senderPubKey,
+      });
+    }
+  }
+
+  findToken(chainName: ChainName, addressOrDenom?: Address | string): Token | null {
+    return (
+      this.warpCore.findToken(chainName, addressOrDenom) ??
+      this.intentCore.findToken(chainName, addressOrDenom)
+    );
+  }
+
+  getTokenChains(): ChainName[] {
+    return [...new Set(...this.warpCore.getTokenChains(), ...this.intentCore.getTokenChains())];
+  }
+
+  getTokensForChain(chainName: ChainName): Token[] {
+    return [
+      ...this.warpCore.getTokensForChain(chainName),
+      ...this.intentCore.getTokensForChain(chainName),
+    ];
+  }
+
+  getTokensForRoute(origin: ChainName, destination: ChainName): Token[] {
+    return [
+      ...this.warpCore.getTokensForRoute(origin, destination),
+      ...this.intentCore.getTokensForRoute(origin, destination),
+    ];
+  }
+
+  get tokens(): Token[] {
+    return [...this.warpCore.tokens, ...this.intentCore.tokens];
+  }
+
+  get multiProvider(): MultiProtocolProvider {
+    return this.warpCore.multiProvider;
+  }
+}

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -1,5 +1,5 @@
 import { GithubRegistry, IRegistry } from '@hyperlane-xyz/registry';
-import { ChainMap, ChainMetadata, MultiProtocolProvider, WarpCore } from '@hyperlane-xyz/sdk';
+import { ChainMap, ChainMetadata, MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { objFilter } from '@hyperlane-xyz/utils';
 import { toast } from 'react-toastify';
 import { create } from 'zustand';
@@ -22,12 +22,12 @@ export interface AppState {
   setChainMetadataOverrides: (overrides?: ChainMap<Partial<ChainMetadata> | undefined>) => void;
   multiProvider: MultiProtocolProvider;
   registry: IRegistry;
-  warpCore: WarpCore;
+  warpCore: CoreProxy;
   setWarpContext: (context: {
     registry: IRegistry;
     chainMetadata: ChainMap<ChainMetadata>;
     multiProvider: MultiProtocolProvider;
-    warpCore: WarpCore;
+    warpCore: CoreProxy;
   }) => void;
 
   // User history
@@ -71,7 +71,7 @@ export const useStore = create<AppState>()(
         branch: config.registryBranch,
         proxyUrl: config.registryProxyUrl,
       }),
-      warpCore: new WarpCore(new MultiProtocolProvider({}), []),
+      warpCore: new CoreProxy(new MultiProtocolProvider({}), []),
       setWarpContext: ({ registry, chainMetadata, multiProvider, warpCore }) => {
         logger.debug('Setting warp context in store');
         set({ registry, chainMetadata, multiProvider, warpCore });
@@ -164,7 +164,7 @@ async function initWarpContext(
       storeMetadataOverrides,
     );
     const multiProvider = new MultiProtocolProvider(chainMetadataWithOverrides);
-    const warpCore = WarpCore.FromConfig(multiProvider, coreConfig);
+    const warpCore = CoreProxy.FromConfig(multiProvider, coreConfig);
     return { registry, chainMetadata, multiProvider, warpCore };
   } catch (error) {
     toast.error('Error initializing warp context. Please check connection status and configs.');
@@ -173,7 +173,7 @@ async function initWarpContext(
       registry,
       chainMetadata: {},
       multiProvider: new MultiProtocolProvider({}),
-      warpCore: new WarpCore(new MultiProtocolProvider({}), []),
+      warpCore: new CoreProxy(new MultiProtocolProvider({}), []),
     };
   }
 }

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -19,6 +19,7 @@ import { SolidButton } from '../../components/buttons/SolidButton';
 import { TextField } from '../../components/input/TextField';
 import { config } from '../../consts/config';
 import { Color } from '../../styles/Color';
+import { isIntentStandard } from '../../utils/intents';
 import { logger } from '../../utils/logger';
 import { ChainConnectionWarning } from '../chains/ChainConnectionWarning';
 import { ChainSelectField } from '../chains/ChainSelectField';
@@ -391,15 +392,26 @@ function ReviewDetails({ visible }: { visible: boolean }) {
               <div>
                 <h4>Transaction 1: Approve Transfer</h4>
                 <div className="ml-1.5 mt-1.5 space-y-1.5 border-l border-gray-300 pl-2 text-xs">
-                  <p>{`Router Address: ${originToken?.addressOrDenom}`}</p>
-                  {originToken?.collateralAddressOrDenom && (
-                    <p>{`Collateral Address: ${originToken.collateralAddressOrDenom}`}</p>
+                  {originToken && isIntentStandard(originToken.standard) ? (
+                    <>
+                      <p>{`Router Address: ${originToken?.intentRouterAddressOrDenom}`}</p>
+                      {originToken?.addressOrDenom && (
+                        <p>{`Token Address: ${originToken.addressOrDenom}`}</p>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <p>{`Router Address: ${originToken?.addressOrDenom}`}</p>
+                      {originToken?.collateralAddressOrDenom && (
+                        <p>{`Collateral Address: ${originToken.collateralAddressOrDenom}`}</p>
+                      )}
+                    </>
                   )}
                 </div>
               </div>
             )}
             <div>
-              <h4>{`Transaction${isApproveRequired ? ' 2' : ''}: Transfer Remote`}</h4>
+              <h4>{`Transaction${isApproveRequired ? ' 2' : ''}: Open Order`}</h4>
               <div className="ml-1.5 mt-1.5 space-y-1.5 border-l border-gray-300 pl-2 text-xs">
                 {destinationToken?.addressOrDenom && (
                   <p className="flex">
@@ -414,7 +426,7 @@ function ReviewDetails({ visible }: { visible: boolean }) {
                 {fees?.localQuote && fees.localQuote.amount > 0n && (
                   <p className="flex">
                     <span className="min-w-[6.5rem]">Local Gas (est.)</span>
-                    <span>{`${fees.localQuote.getDecimalFormattedAmount().toFixed(4) || '0'} ${
+                    <span>{`${fees.localQuote.getDecimalFormattedAmount().toFixed(18) || '0'} ${
                       fees.localQuote.token.symbol || ''
                     }`}</span>
                   </p>

--- a/src/utils/intents.ts
+++ b/src/utils/intents.ts
@@ -1,0 +1,3 @@
+export function isIntentStandard(standard: TokenStandard): boolean {
+  return standard === TokenStandard.EvmIntent || standard === TokenStandard.EvmIntentNative;
+}


### PR DESCRIPTION
A draft to showcase the intent support in the UI using `CoreProxy` to allow interfacing with `IntentCore` or `WarpCore` based on the token standard.

This is a WIP, a lot of types are not properly set and still requires fine tunings


/cc @nambrot 