### PR TITLE
chore: add rstETH/ethereum-zircuit route to nexus

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -80,4 +80,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // TRUMP routes
   'TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain',
+
+  // rstETH routes
+  'rstETH/ethereum-zircuit',
 ];


### PR DESCRIPTION
Add rstETH/ethereum-zircuit to `warpRouteWhiteList.ts`

Tested from ethereum <> zircuit