### PR TITLE
feat: update LUMIA route for migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "8.0.0",
+    "@hyperlane-xyz/registry": "9.0.0",
     "@hyperlane-xyz/sdk": "8.5.0",
     "@hyperlane-xyz/utils": "8.5.0",
     "@hyperlane-xyz/widgets": "8.5.0",

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -27,7 +27,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'ECLIP/arbitrum-neutron',
 
   // LUMIA routes
-  'LUMIA/bsc-ethereum-lumia',
+  'LUMIA/bsc-ethereum-lumiaprism',
 
   // USDC routes
   'USDC/ethereum-inevm',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,13 +4073,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:8.0.0":
-  version: 8.0.0
-  resolution: "@hyperlane-xyz/registry@npm:8.0.0"
+"@hyperlane-xyz/registry@npm:9.0.0":
+  version: 9.0.0
+  resolution: "@hyperlane-xyz/registry@npm:9.0.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/96843c41aa5129bb5473f61a82f994454dd1edcb4658c453018ab9b44f950abc1831a4aeef680101c310423d19970a0edc4b16e7c2946bb91bcfe2893ca06884
+  checksum: 10/b58eddfcb8ff7b165f902811831a49137a778c262822437523bb95d1ce8d318ad3918b7c647fe89e7d9270c8533c6c8ad42866cbf0971b18950abf55367edcd9
   languageName: node
   linkType: hard
 
@@ -4145,7 +4145,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:8.0.0"
+    "@hyperlane-xyz/registry": "npm:9.0.0"
     "@hyperlane-xyz/sdk": "npm:8.5.0"
     "@hyperlane-xyz/utils": "npm:8.5.0"
     "@hyperlane-xyz/widgets": "npm:8.5.0"


### PR DESCRIPTION
- Post-migration LUMIA route. Uses a different lumiaprism router instead of the old lumia router
- fully tested manually locally