### PR TITLE
fix: url params persistence when one chain is not defined

### DIFF
--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -549,10 +549,11 @@ function useFormInitialValues(): TransferFormValues {
   return useMemo(() => {
     const firstToken = warpCore.tokens[0];
     const connectedToken = firstToken.connections?.[0];
+    const chainsValid = originQuery && destinationQuery;
 
     return {
-      origin: originQuery ? originQuery : firstToken.chainName,
-      destination: destinationQuery ? destinationQuery : connectedToken?.token?.chainName || '',
+      origin: chainsValid ? originQuery : firstToken.chainName,
+      destination: chainsValid ? destinationQuery : connectedToken?.token?.chainName || '',
       tokenIndex: tokenIndex,
       amount: '',
       recipient: '',


### PR DESCRIPTION
Fixed a bug where if only one of the chain is defined and there is only one connection, when page is first loaded, it will show as "No Tokens Route Available"

Now only adds persistence when params are defined