### PR TITLE
chore: add all warp routes ids to nexus

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "9.0.0",
+    "@hyperlane-xyz/registry": "9.4.0",
     "@hyperlane-xyz/sdk": "8.5.0",
     "@hyperlane-xyz/utils": "8.5.0",
     "@hyperlane-xyz/widgets": "8.5.0",

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -105,14 +105,14 @@ export const warpRouteWhitelist: Array<string> | null = [
   // WETH routes
   'WETH.a/artela-base',
 
-  // FASTUSD routes
+  // fastUSD routes
   'fastUSD/ethereum-sei',
 
-  // CBBTC routes
+  // cbBTC routes
   'cbBTC/ethereum-superseed',
   'cbBTC/ethereum-flowmainnet',
 
-  // EZETH routes
+  // ezETH routes
   'ezETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-zircuit',
 
   // GAME routes
@@ -121,10 +121,10 @@ export const warpRouteWhitelist: Array<string> | null = [
   // AIXBT routes
   'AIXBT/base-form',
 
-  // // WSTETH routes
+  // // wstETH routes
   'wstETH/ethereum-form',
 
-  // // PZETH routes
+  // // pzETH routes
   'pzETH/ethereum-swell-zircuit',
 
   // ART routes

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -13,7 +13,6 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // ETH routes
   'ETH/ethereum-viction',
-  'ETH/ethereum-vana',
 
   // tETH routes
   'tETH/eclipsemainnet-ethereum',
@@ -88,7 +87,6 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // TRUMP routes
   'TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain',
-  'TRUMP/solanamainnet-trumpchain',
 
   // jitoSOL
   'JitoSOL/eclipsemainnet-solanamainnet',
@@ -113,7 +111,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'cbBTC/ethereum-flowmainnet',
 
   // ezETH routes
-  'ezETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-zircuit',
+  'ezETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-zircuit',
 
   // GAME routes
   'GAME/base-form',

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -121,10 +121,10 @@ export const warpRouteWhitelist: Array<string> | null = [
   // AIXBT routes
   'AIXBT/base-form',
 
-  // // wstETH routes
+  // wstETH routes
   'wstETH/ethereum-form',
 
-  // // pzETH routes
+  // pzETH routes
   'pzETH/ethereum-swell-zircuit',
 
   // ART routes

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -13,6 +13,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // ETH routes
   'ETH/ethereum-viction',
+  'ETH/ethereum-vana',
 
   // tETH routes
   'tETH/eclipsemainnet-ethereum',
@@ -35,11 +36,17 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/ethereum-viction',
   'USDC/eclipsemainnet-ethereum-solanamainnet',
   'USDC/appchain-base',
+  'USDC/arbitrum-base-endurance',
+  'USDC/ethereum-form',
+  'USDC.a/artela-base',
+  'USDC/ethereum-superseed',
 
   // USDT routes
   'USDT/ethereum-inevm',
   'USDT/ethereum-viction',
   'USDT/eclipsemainnet-ethereum-solanamainnet',
+  'USDT/ethereum-form',
+  'USDT/ethereum-superseed',
 
   // INJ routes
   'INJ/inevm-injective',
@@ -56,6 +63,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // WBTC routes
   'WBTC/eclipsemainnet-ethereum',
+  'WBTC/ethereum-form',
 
   // ORCA routes
   'ORCA/eclipsemainnet-solanamainnet',
@@ -80,6 +88,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // TRUMP routes
   'TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain',
+  'TRUMP/solanamainnet-trumpchain',
 
   // jitoSOL
   'JitoSOL/eclipsemainnet-solanamainnet',
@@ -89,4 +98,35 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // SMOL routes
   'SMOL/arbitrum-ethereum-solanamainnet-treasure',
+
+  // MAGIC routes
+  'MAGIC/arbitrum-treasure',
+
+  // WETH routes
+  'WETH.a/artela-base',
+
+  // FASTUSD routes
+  'fastUSD/ethereum-sei',
+
+  // CBBTC routes
+  'cbBTC/ethereum-superseed',
+  'cbBTC/ethereum-flowmainnet',
+
+  // EZETH routes
+  'ezETH/arbitrum-base-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-zircuit',
+
+  // GAME routes
+  'GAME/base-form',
+
+  // AIXBT routes
+  'AIXBT/base-form',
+
+  // // WSTETH routes
+  'wstETH/ethereum-form',
+
+  // // PZETH routes
+  'pzETH/ethereum-swell-zircuit',
+
+  // ART routes
+  'ART/artela-base-solanamainnet',
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,13 +4073,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:9.0.0":
-  version: 9.0.0
-  resolution: "@hyperlane-xyz/registry@npm:9.0.0"
+"@hyperlane-xyz/registry@npm:9.4.0":
+  version: 9.4.0
+  resolution: "@hyperlane-xyz/registry@npm:9.4.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/b58eddfcb8ff7b165f902811831a49137a778c262822437523bb95d1ce8d318ad3918b7c647fe89e7d9270c8533c6c8ad42866cbf0971b18950abf55367edcd9
+  checksum: 10/13eb3ed671d70cc4b66a3546eb54b82e5606aed6c97cea82df54208415941026aab809ac434208a15b698d1b9fe88a828ce2e2b2d64239a6ca60d0dc2666c2fb
   languageName: node
   linkType: hard
 
@@ -4145,7 +4145,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:9.0.0"
+    "@hyperlane-xyz/registry": "npm:9.4.0"
     "@hyperlane-xyz/sdk": "npm:8.5.0"
     "@hyperlane-xyz/utils": "npm:8.5.0"
     "@hyperlane-xyz/widgets": "npm:8.5.0"


### PR DESCRIPTION
- Add all remaining WarpRouteIds to nexus. 
- Upgraded registry to 9.4.0

Routes added:

- USDC/arbitrum-base-endurance
- USDC/ethereum-form
- USDC.a/artela-base
- USDC/ethereum-superseed
- USDT/ethereum-form
-  USDT/ethereum-superseed
- WBTC/ethereum-form
- MAGIC/arbitrum-treasure
- WETH.a/artela-base
- fastUSD/ethereum-sei
- cbBTC/ethereum-superseed
- cbBTC/ethereum-flowmainnet
- ezETH/arbitrum-base-berachain-blast-bsc-ethereum-fraxtal-linea-mode-optimism-sei-swell-taiko-unichain-zircuit
- GAME/base-form
- AIXBT/base-form
- wstETH/ethereum-form
- pzETH/ethereum-swell-zircuit
- ART/artela-base-solanamainnet