### PR TITLE
fix: show collateral address for relevant tokens

### DIFF
--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -143,7 +143,7 @@ export function TokenList({
             </div>
             <div className="ml-2 min-w-0 shrink text-left">
               <div className="w-full truncate text-xs">
-                {t.token.addressOrDenom || 'Native chain token'}
+                {t.token.collateralAddressOrDenom || t.token.addressOrDenom || 'Native chain token'}
               </div>
               <div className="mt-0.5 flex space-x-1 text-xs">
                 <span>{`Decimals: ${t.token.decimals}`}</span>


### PR DESCRIPTION
fix: show collateral address for relevant tokens

- fixes cases where we display the `HypERC20Collateral` address instead of the actual token address when we expect that