### PR TITLE
feat: add MINT/mint-solanamainnet to nexus

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "10.1.0",
+    "@hyperlane-xyz/registry": "10.4.0",
     "@hyperlane-xyz/sdk": "8.5.0",
     "@hyperlane-xyz/utils": "8.5.0",
     "@hyperlane-xyz/widgets": "8.5.0",

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -137,4 +137,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // CDX routes
   'CDX/base-solanamainnet',
+
+  // Mint routes
+  'MINT/mint-solanamainnet',
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,13 +4073,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:10.1.0":
-  version: 10.1.0
-  resolution: "@hyperlane-xyz/registry@npm:10.1.0"
+"@hyperlane-xyz/registry@npm:10.4.0":
+  version: 10.4.0
+  resolution: "@hyperlane-xyz/registry@npm:10.4.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/2b7b3bcecc25f744a2ee7ee38899706441165092e39e174b83e1e73c4b7530f989da5d3215b0760408e0b990b8d0f1ecd205b06719243cb18f8dea64fb007b4a
+  checksum: 10/de83ff193fcaa27f597c7658bc8a6751c6bb97489949c48cc44bf38d8f83c38fb25f5f41adab03deba2b0b63746a6051b84137d59f097bbaac2a66e2c44d96a8
   languageName: node
   linkType: hard
 
@@ -4145,7 +4145,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:10.1.0"
+    "@hyperlane-xyz/registry": "npm:10.4.0"
     "@hyperlane-xyz/sdk": "npm:8.5.0"
     "@hyperlane-xyz/utils": "npm:8.5.0"
     "@hyperlane-xyz/widgets": "npm:8.5.0"


### PR DESCRIPTION
Adds the `MINT/mint-solanamainnet to nexus` warp route and updates the `@hyperlane-xyz/registry` package