### PR TITLE
feat: add Sonic SVM routes to Nexus

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "10.4.0",
+    "@hyperlane-xyz/registry": "10.5.0",
     "@hyperlane-xyz/sdk": "8.5.0",
     "@hyperlane-xyz/utils": "8.5.0",
     "@hyperlane-xyz/widgets": "8.5.0",

--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -4,6 +4,8 @@ import {
   injective,
   solanamainnet,
   solanamainnetAddresses,
+  sonicsvm,
+  sonicsvmAddresses,
   soon,
   soonAddresses,
 } from '@hyperlane-xyz/registry';
@@ -31,6 +33,10 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
   soon: {
     ...soon,
     mailbox: soonAddresses.mailbox,
+  },
+  sonicsvm: {
+    ...sonicsvm,
+    mailbox: sonicsvmAddresses.mailbox,
   },
   injective: {
     ...injective,

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -40,6 +40,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/ethereum-form',
   'USDC.a/artela-base',
   'USDC/ethereum-superseed',
+  'USDC/solanamainnet-sonicsvm',
 
   // USDT routes
   'USDT/ethereum-inevm',
@@ -48,6 +49,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDT/ethereum-form',
   'USDT/ethereum-hyperevm',
   'USDT/ethereum-superseed',
+  'USDT/solanamainnet-sonicsvm',
 
   // INJ routes
   'INJ/inevm-injective',
@@ -56,6 +58,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'SOL/eclipsemainnet-solanamainnet',
   'SOL/solanamainnet-soon',
   'SOL/hyperevm-solanamainnet',
+  'SOL/solanamainnet-sonicsvm',
 
   // ezSOL routes
   'ezSOL/eclipsemainnet-solanamainnet',
@@ -143,4 +146,16 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // Mint routes
   'MINT/mint-solanamainnet',
+
+  // lrtsSOL routes
+  'lrtsSOL/solanamainnet-sonicsvm',
+
+  // sSOL routes
+  'sSOL/solanamainnet-sonicsvm',
+
+  // sonicSOL routes
+  'sonicSOL/solanamainnet-sonicsvm',
+
+  // SONIC routes
+  'SONIC/solanamainnet-sonicsvm',
 ];

--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -138,8 +138,8 @@ export function TokenList({
               <TokenIcon token={t.token} size={30} />
             </div>
             <div className="ml-2 shrink-0 text-left">
-              <div className="w-14 truncate text-sm">{t.token.symbol || 'Unknown'}</div>
-              <div className="w-14 truncate text-xs text-gray-500">{t.token.name || 'Unknown'}</div>
+              <div className="w-16 truncate text-sm">{t.token.symbol || 'Unknown'}</div>
+              <div className="w-16 truncate text-xs text-gray-500">{t.token.name || 'Unknown'}</div>
             </div>
             <div className="ml-2 min-w-0 shrink text-left">
               <div className="w-full truncate text-xs">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,13 +4073,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:10.4.0":
-  version: 10.4.0
-  resolution: "@hyperlane-xyz/registry@npm:10.4.0"
+"@hyperlane-xyz/registry@npm:10.5.0":
+  version: 10.5.0
+  resolution: "@hyperlane-xyz/registry@npm:10.5.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/de83ff193fcaa27f597c7658bc8a6751c6bb97489949c48cc44bf38d8f83c38fb25f5f41adab03deba2b0b63746a6051b84137d59f097bbaac2a66e2c44d96a8
+  checksum: 10/89af70f1a36d51a1cb4f0776534eba47326824c8c80b611972368ac085670689aef43f130d1aef6260199ff765cb5d209dcfaf12eb1ec02ca76650cb846681d5
   languageName: node
   linkType: hard
 
@@ -4145,7 +4145,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:10.4.0"
+    "@hyperlane-xyz/registry": "npm:10.5.0"
     "@hyperlane-xyz/sdk": "npm:8.5.0"
     "@hyperlane-xyz/utils": "npm:8.5.0"
     "@hyperlane-xyz/widgets": "npm:8.5.0"


### PR DESCRIPTION
- Adds the Sonic SVM routes to Nexus
- Tested locally
- Drive-by to make the width for the symbol wider, added to accommodate "sonicSOL". Screenshots attached:

Before:
<img width="512" alt="Screen Shot 2025-02-27 at 1 32 35 PM" src="https://github.com/user-attachments/assets/bb65b66b-56d7-45cc-8401-a1337b3b71de" />

After:

<img width="521" alt="Screen Shot 2025-02-27 at 1 32 27 PM" src="https://github.com/user-attachments/assets/7a188103-f55f-4308-8117-b04dc927ed6d" />
