### PR TITLE
feat: showAddChainButton for chain search menu

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -21,6 +21,7 @@ interface Config {
   registryBranch?: string | undefined; // Optional customization of the registry branch instead of main
   registryProxyUrl?: string; // Optional URL to use a custom proxy for the GithubRegistry
   showAddRouteButton: boolean; // Show/Hide the add route config icon in the button strip
+  showAddChainButton: boolean; // Show/Hide add custom chain in the chain search menu
   showDisabledTokens: boolean; // Show/Hide invalid token options in the selection modal
   showTipBox: boolean; // Show/Hide the blue tip box above the transfer form
   shouldDisableChains: boolean; // Enable chain disabling for ChainSearchMenu. When true it will deactivate chains that have disabled status
@@ -40,6 +41,7 @@ export const config: Config = Object.freeze({
   registryBranch,
   registryProxyUrl,
   showAddRouteButton: true,
+  showAddChainButton: true,
   showDisabledTokens: false,
   showTipBox: true,
   version,

--- a/src/features/chains/ChainSelectModal.tsx
+++ b/src/features/chains/ChainSelectModal.tsx
@@ -38,6 +38,7 @@ export function ChainSelectListModal({
         defaultSortField="custom"
         showChainDetails={showChainDetails}
         shouldDisableChains={config.shouldDisableChains}
+        showAddChainButton={config.showAddChainButton}
       />
     </Modal>
   );


### PR DESCRIPTION
Include `showAddChainButton` in the configs to allow overrides of chain metadata to add custom chain s