### PR TITLE
chore: add rpc url for sonicsvm to env variable

### DIFF
--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -37,6 +37,10 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
   sonicsvm: {
     ...sonicsvm,
     mailbox: sonicsvmAddresses.mailbox,
+    // Including rpc override because the main Sonic public RPC is down
+    rpcUrls: process.env.NEXT_PUBLIC_SONIC_RPC_URL
+      ? [{ http: process.env.NEXT_PUBLIC_SONIC_RPC_URL }, ...sonicsvm.rpcUrls]
+      : sonicsvm.rpcUrls,
   },
   injective: {
     ...injective,

--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -38,8 +38,8 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
     ...sonicsvm,
     mailbox: sonicsvmAddresses.mailbox,
     // Including rpc override because the main Sonic public RPC is down
-    rpcUrls: process.env.NEXT_PUBLIC_SONIC_RPC_URL
-      ? [{ http: process.env.NEXT_PUBLIC_SONIC_RPC_URL }, ...sonicsvm.rpcUrls]
+    rpcUrls: process.env.NEXT_PUBLIC_SONICSVM_RPC_URL
+      ? [{ http: process.env.NEXT_PUBLIC_SONICSVM_RPC_URL }, ...sonicsvm.rpcUrls]
       : sonicsvm.rpcUrls,
   },
   injective: {


### PR DESCRIPTION
Add new environment variable for NEXT_PUBLIC_SONICSVM_RPC_URL override because main RPC is down