### PR TITLE
chore: remove ethereum superseed route

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -49,7 +49,6 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDT/eclipsemainnet-ethereum-solanamainnet',
   'USDT/ethereum-form',
   'USDT/ethereum-hyperevm',
-  'USDT/ethereum-superseed',
   'USDT/solanamainnet-sonicsvm',
 
   // INJ routes


### PR DESCRIPTION
Remove USDT/ethereum-superseed warp route from nexus