### PR TITLE
chore: remove ETH/base-ethereum-lumiaprism

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -14,7 +14,6 @@ export const warpRouteWhitelist: Array<string> | null = [
   // ETH routes
   'ETH/ethereum-hyperevm',
   'ETH/ethereum-viction',
-  'ETH/base-ethereum-lumiaprism',
 
   // tETH routes
   'tETH/eclipsemainnet-ethereum',


### PR DESCRIPTION
Temporary remove `ETH/base-ethereum-lumiaprism` route