### PR TITLE
feat: add default destination chain to config

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -15,6 +15,7 @@ interface Config {
   addressBlacklist: string[]; // A list of addresses that are blacklisted and cannot be used in the app
   chainWalletWhitelists: ChainMap<string[]>; // A map of chain names to a list of wallet names that work for it
   defaultOriginChain: string | undefined; // The initial origin chain to show when app first loads
+  defaultDestinationChain: string | undefined; // The initial destination chain to show when app first loads
   enableExplorerLink: boolean; // Include a link to the hyperlane explorer in the transfer modal
   isDevMode: boolean; // Enables some debug features in the app
   registryUrl: string | undefined; // Optional URL to use a custom registry instead of the published canonical version
@@ -36,6 +37,7 @@ export const config: Config = Object.freeze({
   chainWalletWhitelists,
   enableExplorerLink: false,
   defaultOriginChain: undefined,
+  defaultDestinationChain: undefined,
   isDevMode,
   registryUrl,
   registryBranch,

--- a/src/features/tokens/hooks.ts
+++ b/src/features/tokens/hooks.ts
@@ -79,12 +79,12 @@ export function getInitialTokenIndex(
     return getTokenIndexFromChains(warpCore, addressOrDenom, originQuery, destinationQuery);
 
   // if none of those are defined, use default values and pass token query
-  if (connectedToken) {
+  if (defaultDestinationChain || connectedToken) {
     return getTokenIndexFromChains(
       warpCore,
       addressOrDenom,
       firstToken.chainName,
-      defaultDestinationChain || connectedToken.chainName,
+      defaultDestinationChain || connectedToken?.chainName || '',
     );
   }
 

--- a/src/features/tokens/hooks.ts
+++ b/src/features/tokens/hooks.ts
@@ -69,22 +69,24 @@ export function getInitialTokenIndex(
   originQuery?: string,
   destinationQuery?: string,
   defaultOriginToken?: Token,
+  defaultDestinationChain?: string,
 ): number | undefined {
   const firstToken = defaultOriginToken || warpCore.tokens[0];
-  const connectedToken = firstToken.connections?.[0];
+  const connectedToken = firstToken.connections?.[0].token;
 
   // origin query and destination query is defined
   if (originQuery && destinationQuery)
     return getTokenIndexFromChains(warpCore, addressOrDenom, originQuery, destinationQuery);
 
   // if none of those are defined, use default values and pass token query
-  if (connectedToken)
+  if (connectedToken) {
     return getTokenIndexFromChains(
       warpCore,
       addressOrDenom,
       firstToken.chainName,
-      connectedToken.token.chainName,
+      defaultDestinationChain || connectedToken.chainName,
     );
+  }
 
   return undefined;
 }

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -539,6 +539,7 @@ function useFormInitialValues(): TransferFormValues {
     originQuery,
     destinationQuery,
     defaultOriginToken,
+    config.defaultDestinationChain,
   );
 
   return useMemo(() => {
@@ -548,7 +549,9 @@ function useFormInitialValues(): TransferFormValues {
 
     return {
       origin: chainsValid ? originQuery : firstToken.chainName,
-      destination: chainsValid ? destinationQuery : connectedToken?.token?.chainName || '',
+      destination: chainsValid
+        ? destinationQuery
+        : config.defaultDestinationChain || connectedToken?.token?.chainName || '',
       tokenIndex: tokenIndex,
       amount: '',
       recipient: '',


### PR DESCRIPTION
Include `defaultDestinationChain` to config allowing the UI to have both default origin and destination chain

fixes #475 