### PR TITLE
chore: add `TURTLE/ethereum-linea`

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -94,6 +94,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // TRUMP routes
   'TRUMP/arbitrum-avalanche-base-flowmainnet-form-optimism-solanamainnet-worldchain',
 
+  // TURTLE routes
+  'TURTLE/ethereum-linea',
+
   // jitoSOL
   'JitoSOL/eclipsemainnet-solanamainnet',
 


### PR DESCRIPTION
This PR adds `TURTLE/ethereum-linea` to Nexus.

This warp route was already included in the registry [v10.15.0](https://github.com/hyperlane-xyz/hyperlane-registry/releases/tag/v10.15.0), which is why it can be directly merged into `nexus` as it already includes the required registry version.