### PR TITLE
chore: add ethereum env variable for rpc and fix repeated RPC urls

### DIFF
--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -17,9 +17,9 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
     // SVM chains require mailbox addresses for the token adapters
     mailbox: solanamainnetAddresses.mailbox,
     // Including a convenient rpc override because the Solana public RPC does not allow browser requests from localhost
-    ...(process.env.NEXT_PUBLIC_SOLANA_RPC_URL && {
-      rpcUrls: [{ http: process.env.NEXT_PUBLIC_SOLANA_RPC_URL }],
-    }),
+    rpcUrls: process.env.NEXT_PUBLIC_SOLANA_RPC_URL
+      ? [{ http: process.env.NEXT_PUBLIC_SOLANA_RPC_URL }]
+      : solanamainnet.rpcUrls,
   },
   eclipsemainnet: {
     ...eclipsemainnet,
@@ -50,8 +50,8 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
   // },
   ethereum: {
     ...ethereum,
-    ...(process.env.NEXT_PUBLIC_ETHEREUM_RPC_URL && {
-      rpcUrls: [{ http: process.env.NEXT_PUBLIC_ETHEREUM_RPC_URL }],
-    }),
+    rpcUrls: process.env.NEXT_PUBLIC_ETHEREUM_RPC_URL
+      ? [{ http: process.env.NEXT_PUBLIC_ETHEREUM_RPC_URL }]
+      : ethereum.rpcUrls,
   },
 };

--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -1,6 +1,7 @@
 import {
   eclipsemainnet,
   eclipsemainnetAddresses,
+  ethereum,
   solanamainnet,
   solanamainnetAddresses,
 } from '@hyperlane-xyz/registry';
@@ -16,9 +17,9 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
     // SVM chains require mailbox addresses for the token adapters
     mailbox: solanamainnetAddresses.mailbox,
     // Including a convenient rpc override because the Solana public RPC does not allow browser requests from localhost
-    rpcUrls: process.env.NEXT_PUBLIC_SOLANA_RPC_URL
-      ? [{ http: process.env.NEXT_PUBLIC_SOLANA_RPC_URL }, ...solanamainnet.rpcUrls]
-      : solanamainnet.rpcUrls,
+    ...(process.env.NEXT_PUBLIC_SOLANA_RPC_URL && {
+      rpcUrls: [{ http: process.env.NEXT_PUBLIC_SOLANA_RPC_URL }],
+    }),
   },
   eclipsemainnet: {
     ...eclipsemainnet,
@@ -47,4 +48,10 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
   //   },
   //   logoURI: '/logo.svg',
   // },
+  ethereum: {
+    ...ethereum,
+    ...(process.env.NEXT_PUBLIC_ETHEREUM_RPC_URL && {
+      rpcUrls: [{ http: process.env.NEXT_PUBLIC_ETHEREUM_RPC_URL }],
+    }),
+  },
 };


### PR DESCRIPTION
- Add environment variable for `ethereum` public RPC url
- Fixed an issue where RPC urls would be repeated because the [metadata merge](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/blob/55399638a3b5e893ba95c5716a93e86554c95f86/src/features/chains/metadata.ts#L56) would take both arrays

caveat: if the environment variable does not exist, array will be repeated twice (same as now) and empty arrays are not allowed because of the `safeParse` in the `chainMetadata`, ideally we would want the `mergeChainMetadataMap` to remove any duplicates

Before: 
![image](https://github.com/user-attachments/assets/1fde8d72-a7ec-45ae-9be0-ae5ff347aeb1)

After:
![image](https://github.com/user-attachments/assets/e608322e-1905-4be3-98d5-c88948923764)
