### PR TITLE
feat: include transport fallback for wagmiConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hyperlane-xyz/warp-ui-template",
   "description": "A web app template for building Hyperlane Warp Route UIs",
-  "version": "11.0.0",
+  "version": "12.1.0",
   "author": "J M Rossy",
   "dependencies": {
     "@chakra-ui/next-js": "^2.4.2",
@@ -18,9 +18,9 @@
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
     "@hyperlane-xyz/registry": "13.5.0",
-    "@hyperlane-xyz/sdk": "11.0.0",
-    "@hyperlane-xyz/utils": "11.0.0",
-    "@hyperlane-xyz/widgets": "11.0.0",
+    "@hyperlane-xyz/sdk": "12.1.0",
+    "@hyperlane-xyz/utils": "12.1.0",
+    "@hyperlane-xyz/widgets": "12.1.0",
     "@interchain-ui/react": "^1.23.28",
     "@metamask/post-message-stream": "6.1.2",
     "@metamask/providers": "10.2.1",

--- a/src/features/wallet/context/EvmWalletContext.tsx
+++ b/src/features/wallet/context/EvmWalletContext.tsx
@@ -14,7 +14,7 @@ import {
   walletConnectWallet,
 } from '@rainbow-me/rainbowkit/wallets';
 import { PropsWithChildren, useMemo } from 'react';
-import { createClient, http } from 'viem';
+import { createClient, fallback, http } from 'viem';
 import { WagmiProvider, createConfig } from 'wagmi';
 import { APP_NAME } from '../../../consts/app';
 import { config } from '../../../consts/config';
@@ -44,7 +44,7 @@ function initWagmi(multiProvider: MultiProtocolProvider) {
     chains: [chains[0], ...chains.splice(1)],
     connectors,
     client({ chain }) {
-      const transport = http(chain.rpcUrls.default.http[0]);
+      const transport = fallback(chain.rpcUrls.default.http.map((chainHttp) => http(chainHttp)));
       return createClient({ chain, transport });
     },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,14 +4548,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/core@npm:6.1.0":
-  version: 6.1.0
-  resolution: "@hyperlane-xyz/core@npm:6.1.0"
+"@hyperlane-xyz/core@npm:7.1.0":
+  version: 7.1.0
+  resolution: "@hyperlane-xyz/core@npm:7.1.0"
   dependencies:
     "@arbitrum/nitro-contracts": "npm:^1.2.1"
     "@chainlink/contracts-ccip": "npm:^1.5.0"
     "@eth-optimism/contracts": "npm:^0.6.0"
-    "@hyperlane-xyz/utils": "npm:11.0.0"
+    "@hyperlane-xyz/utils": "npm:12.1.0"
     "@layerzerolabs/lz-evm-oapp-v2": "npm:2.0.2"
     "@matterlabs/hardhat-zksync-solc": "npm:1.2.5"
     "@matterlabs/hardhat-zksync-verify": "npm:1.7.1"
@@ -4566,7 +4566,7 @@ __metadata:
     "@ethersproject/abi": "*"
     "@ethersproject/providers": "*"
     "@types/sinon-chai": "*"
-  checksum: 10/a45eb1ae30b240f345b8873d6d8f2ee98cca6701fcbe1ef2bcd62f9d47ce7399137b2d4c5ab6abee41ffde6ae5892af54158b9e39394509781a9a9e6acd8ece1
+  checksum: 10/fe76fa68ccecdb1832b58e8d91fd89c3f66ff7f99b37302a5a57e5efd1d160e73fb2a34f2b36050cc40384cedfb933ffa94c8c4a0698ee8bdf0d2b79ea849980
   languageName: node
   linkType: hard
 
@@ -4580,17 +4580,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/sdk@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@hyperlane-xyz/sdk@npm:11.0.0"
+"@hyperlane-xyz/sdk@npm:12.1.0":
+  version: 12.1.0
+  resolution: "@hyperlane-xyz/sdk@npm:12.1.0"
   dependencies:
     "@arbitrum/sdk": "npm:^4.0.0"
     "@aws-sdk/client-s3": "npm:^3.577.0"
     "@chain-registry/types": "npm:^0.50.14"
     "@cosmjs/cosmwasm-stargate": "npm:^0.32.4"
     "@cosmjs/stargate": "npm:^0.32.4"
-    "@hyperlane-xyz/core": "npm:6.1.0"
-    "@hyperlane-xyz/utils": "npm:11.0.0"
+    "@hyperlane-xyz/core": "npm:7.1.0"
+    "@hyperlane-xyz/utils": "npm:12.1.0"
     "@safe-global/api-kit": "npm:1.3.0"
     "@safe-global/protocol-kit": "npm:1.3.0"
     "@safe-global/safe-deployments": "npm:1.37.23"
@@ -4603,17 +4603,18 @@ __metadata:
     pino: "npm:^8.19.0"
     starknet: "npm:^6.23.1"
     viem: "npm:^2.21.45"
+    zksync-ethers: "npm:^5.10.0"
     zod: "npm:^3.21.2"
   peerDependencies:
     "@ethersproject/abi": "*"
     "@ethersproject/providers": "*"
-  checksum: 10/35c26c37be707af86a847b335399d8dbeb15b18c486ddf9e79a5f7b96b38a4282e89e551ef5018d0a05a11c7d120989e2e918d08b16dd7d54e46c7c9b6df2267
+  checksum: 10/9416031867a5b4eb2bced1903c0b6c3e6c6d79e7c16bfd6e719505970b0a3f42d45dd3cf273f0f99fc40fc5da87220f77ae1dac9c7aab3d46f70a46c21337872
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/utils@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@hyperlane-xyz/utils@npm:11.0.0"
+"@hyperlane-xyz/utils@npm:12.1.0":
+  version: 12.1.0
+  resolution: "@hyperlane-xyz/utils@npm:12.1.0"
   dependencies:
     "@cosmjs/encoding": "npm:^0.32.4"
     "@solana/web3.js": "npm:^1.95.4"
@@ -4622,7 +4623,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     pino: "npm:^8.19.0"
     yaml: "npm:2.4.5"
-  checksum: 10/1f605c1280b23877ff696a31d325c0869af4671f7b3658ae0a31c2359b971c970e180cb91257732cf23f239fc5e70f6b1bc9dd05d959b698a2599e466c04fca0
+  checksum: 10/628225400fad5fe43db506939f8ecfc0dabfffc0c29f64a7ed2a47c45898abce7134e2d8787a971939c0416b660f06b9d2fbf30454dc32dce315a8dcb83174ed
   languageName: node
   linkType: hard
 
@@ -4644,9 +4645,9 @@ __metadata:
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
     "@hyperlane-xyz/registry": "npm:13.5.0"
-    "@hyperlane-xyz/sdk": "npm:11.0.0"
-    "@hyperlane-xyz/utils": "npm:11.0.0"
-    "@hyperlane-xyz/widgets": "npm:11.0.0"
+    "@hyperlane-xyz/sdk": "npm:12.1.0"
+    "@hyperlane-xyz/utils": "npm:12.1.0"
+    "@hyperlane-xyz/widgets": "npm:12.1.0"
     "@interchain-ui/react": "npm:^1.23.28"
     "@metamask/post-message-stream": "npm:6.1.2"
     "@metamask/providers": "npm:10.2.1"
@@ -4703,14 +4704,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/widgets@npm:11.0.0":
-  version: 11.0.0
-  resolution: "@hyperlane-xyz/widgets@npm:11.0.0"
+"@hyperlane-xyz/widgets@npm:12.1.0":
+  version: 12.1.0
+  resolution: "@hyperlane-xyz/widgets@npm:12.1.0"
   dependencies:
     "@cosmos-kit/react": "npm:^2.18.0"
     "@headlessui/react": "npm:^2.1.8"
-    "@hyperlane-xyz/sdk": "npm:11.0.0"
-    "@hyperlane-xyz/utils": "npm:11.0.0"
+    "@hyperlane-xyz/sdk": "npm:12.1.0"
+    "@hyperlane-xyz/utils": "npm:12.1.0"
     "@interchain-ui/react": "npm:^1.23.28"
     "@rainbow-me/rainbowkit": "npm:^2.2.0"
     "@solana/wallet-adapter-react": "npm:^0.15.32"
@@ -4725,7 +4726,7 @@ __metadata:
   peerDependencies:
     react: ^18
     react-dom: ^18
-  checksum: 10/eeda498803a5c17826e6422df6a389767e5ad19b471d9a081201382b0d994718f905d7f2e823e5c82a6bb8791ee69adaa7703507dace0be88aba08f6d633e92b
+  checksum: 10/3d970537177d29bd77a4fbd0c75d247c115134795f4d9038dfcb602bad81c667646d4b70d0e8f68b7f6714042da4f1e5340371bb333670b86e3278e3960610b0
   languageName: node
   linkType: hard
 
@@ -27135,6 +27136,17 @@ __metadata:
   version: 0.1.0
   resolution: "yocto-queue@npm:0.1.0"
   checksum: 10/f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
+  languageName: node
+  linkType: hard
+
+"zksync-ethers@npm:^5.10.0":
+  version: 5.10.0
+  resolution: "zksync-ethers@npm:5.10.0"
+  dependencies:
+    ethers: "npm:~5.7.0"
+  peerDependencies:
+    ethers: ~5.7.0
+  checksum: 10/826719e2e40731e1104cf8a0c16c758526de6ca9e907d0483eb5bd80b635f02e3cce012115b75d68976a8dd746d63d4f83d576cc3bddc18a02a49d2bc023347f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now the transactions signing will use a fallback RPC whenever one of the RPC fails instead of only having one point of failure. Also upgrade hyperlane packages that contains the needed changes for the RPC update

Reference: https://viem.sh/docs/clients/transports/fallback.html

How to test:
1 - With the current `main` branch, locally try doing a transaction with Ethereum or Arbitrum, they will more likely fail because of flakky RPC
2 - Do the same with this branch and the transactions will go through without issue, you can also check the network tab and see the requests going through