### PR TITLE
feat: check for all RPC healths in ChainConnectionWarning for EVM chains

### DIFF
--- a/src/features/chains/ChainConnectionWarning.tsx
+++ b/src/features/chains/ChainConnectionWarning.tsx
@@ -1,4 +1,5 @@
 import { ChainMetadata, isRpcHealthy } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { FormWarningBanner } from '../../components/banner/FormWarningBanner';
@@ -64,12 +65,19 @@ export function ChainConnectionWarning({
 
 async function checkRpcHealth(chainMetadata: ChainMetadata) {
   try {
-    // Note: this currently checks the health of only the first RPC,
-    // which is what wallets and wallet libs (e.g. wagmi) will use
-    const isHealthy = await isRpcHealthy(chainMetadata, 0);
-    return isHealthy;
+    // Note: this currently checks the health of only the first RPC for non EVM chains,
+    // which is what wallets and wallet libs will use
+    // for EVM chains it will use a fallback RPC, that is why we need to check if any RPC are healthy instead
+    if (chainMetadata.protocol === ProtocolType.Ethereum) {
+      const healthChecks = chainMetadata.rpcUrls.map((_, i) =>
+        isRpcHealthy(chainMetadata, i).then((result) => (result ? true : Promise.reject())),
+      );
+      return await Promise.any(healthChecks);
+    } else return await isRpcHealthy(chainMetadata, 0);
   } catch (error) {
-    logger.warn('Error checking RPC health', error);
+    if (error instanceof AggregateError)
+      logger.warn(`No healthy RPCs found for ${chainMetadata.name}`);
+    else logger.warn('Error checking RPC health', error);
     return false;
   }
 }


### PR DESCRIPTION
Now will only display the `ChainConnectionWarning` banner when all of the chains are unhealthy for EVM chains. This is because now we have fallback transports for EVM chains. Other VMs behavior remain unchanged and only use the first RPC

