### PR TITLE
chore: cosmos addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "13.9.0",
-    "@hyperlane-xyz/sdk": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk",
-    "@hyperlane-xyz/utils": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils",
-    "@hyperlane-xyz/widgets": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets",
+    "@hyperlane-xyz/registry": "13.10.0",
+    "@hyperlane-xyz/sdk": "12.3.0",
+    "@hyperlane-xyz/utils": "12.3.0",
+    "@hyperlane-xyz/widgets": "12.3.0",
     "@interchain-ui/react": "^1.23.28",
     "@metamask/post-message-stream": "6.1.2",
     "@metamask/providers": "10.2.1",
@@ -108,7 +108,6 @@
     "lit-html": "2.8.0",
     "react-fast-compare": "^3.2",
     "viem": "^2.21.41",
-    "zustand": "^4.4",
-    "@hyperlane-xyz/sdk": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk"
+    "zustand": "^4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
     "@hyperlane-xyz/registry": "13.9.0",
-    "@hyperlane-xyz/sdk": "12.1.0",
-    "@hyperlane-xyz/utils": "12.1.0",
-    "@hyperlane-xyz/widgets": "12.1.0",
+    "@hyperlane-xyz/sdk": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk",
+    "@hyperlane-xyz/utils": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils",
+    "@hyperlane-xyz/widgets": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets",
     "@interchain-ui/react": "^1.23.28",
     "@metamask/post-message-stream": "6.1.2",
     "@metamask/providers": "10.2.1",
@@ -108,6 +108,7 @@
     "lit-html": "2.8.0",
     "react-fast-compare": "^3.2",
     "viem": "^2.21.41",
-    "zustand": "^4.4"
+    "zustand": "^4.4",
+    "@hyperlane-xyz/sdk": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk"
   }
 }

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -2,6 +2,7 @@ import { chainAddresses, chainMetadata, IRegistry, PartialRegistry } from '@hype
 import {
   ChainMap,
   ChainMetadata,
+  ChainName,
   MultiProtocolProvider,
   WarpCore,
   WarpCoreConfig,
@@ -57,6 +58,9 @@ export interface AppState {
   setIsSideBarOpen: (isOpen: boolean) => void;
   showEnvSelectModal: boolean;
   setShowEnvSelectModal: (show: boolean) => void;
+
+  originChainName: ChainName;
+  setOriginChainName: (originChainName: ChainName) => void;
 }
 
 export const useStore = create<AppState>()(
@@ -137,6 +141,10 @@ export const useStore = create<AppState>()(
       showEnvSelectModal: false,
       setShowEnvSelectModal: (showEnvSelectModal) => {
         set(() => ({ showEnvSelectModal }));
+      },
+      originChainName: '',
+      setOriginChainName: (originChainName: ChainName) => {
+        set(() => ({ originChainName }));
       },
     }),
 

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -198,6 +198,7 @@ function ChainSelectSection({ isReview }: { isReview: boolean }) {
     updateQueryParam(WARP_QUERY_PARAMS.ORIGIN, origin);
     updateQueryParam(WARP_QUERY_PARAMS.DESTINATION, destination);
     setTokenOnChainChange(origin, destination);
+    setOriginChainName(origin);
   };
 
   return (

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -55,8 +55,17 @@ export function TransferTokenForm() {
   const multiProvider = useMultiProvider();
   const warpCore = useWarpCore();
 
+  const { originChainName, setOriginChainName } = useStore((s) => ({
+    originChainName: s.originChainName,
+    setOriginChainName: s.setOriginChainName,
+  }));
+
   const initialValues = useFormInitialValues();
   const { accounts } = useAccounts(multiProvider, config.addressBlacklist);
+
+  if (!originChainName) {
+    setOriginChainName(initialValues.origin);
+  }
 
   // Flag for if form is in input vs review mode
   const [isReview, setIsReview] = useState(false);
@@ -173,14 +182,15 @@ function ChainSelectSection({ isReview }: { isReview: boolean }) {
     const token = getTokenByIndex(warpCore, tokenIndex);
     updateQueryParam(WARP_QUERY_PARAMS.TOKEN, token?.addressOrDenom);
     setFieldValue('tokenIndex', tokenIndex);
-    setOriginChainName(origin);
   };
 
   const handleChange = (chainName: string, fieldName: string) => {
-    if (fieldName === WARP_QUERY_PARAMS.ORIGIN)
+    if (fieldName === WARP_QUERY_PARAMS.ORIGIN) {
       setTokenOnChainChange(chainName, values.destination);
-    else if (fieldName === WARP_QUERY_PARAMS.DESTINATION)
+      setOriginChainName(chainName);
+    } else if (fieldName === WARP_QUERY_PARAMS.DESTINATION) {
       setTokenOnChainChange(values.origin, chainName);
+    }
     updateQueryParam(fieldName, chainName);
   };
 

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -154,6 +154,10 @@ function SwapChainsButton({
 function ChainSelectSection({ isReview }: { isReview: boolean }) {
   const warpCore = useWarpCore();
 
+  const { setOriginChainName } = useStore((s) => ({
+    setOriginChainName: s.setOriginChainName,
+  }));
+
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
 
   const originRouteCounts = useMemo(() => {
@@ -169,6 +173,7 @@ function ChainSelectSection({ isReview }: { isReview: boolean }) {
     const token = getTokenByIndex(warpCore, tokenIndex);
     updateQueryParam(WARP_QUERY_PARAMS.TOKEN, token?.addressOrDenom);
     setFieldValue('tokenIndex', tokenIndex);
+    setOriginChainName(origin);
   };
 
   const handleChange = (chainName: string, fieldName: string) => {

--- a/src/features/wallet/ConnectWalletButton.tsx
+++ b/src/features/wallet/ConnectWalletButton.tsx
@@ -4,6 +4,9 @@ import { useStore } from '../store';
 
 export function ConnectWalletButton() {
   const multiProvider = useMultiProvider();
+  const { originChainName } = useStore((s) => ({
+    originChainName: s.originChainName,
+  }));
 
   const { setShowEnvSelectModal, setIsSideBarOpen } = useStore((s) => ({
     setShowEnvSelectModal: s.setShowEnvSelectModal,
@@ -17,6 +20,7 @@ export function ConnectWalletButton() {
       onClickWhenConnected={() => setIsSideBarOpen(true)}
       className="rounded-lg bg-white"
       countClassName="bg-accent-500"
+      chainName={originChainName}
     />
   );
 }

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -30,10 +30,11 @@ export function SideBarMenu({
 
   const multiProvider = useMultiProvider();
 
-  const { transfers, resetTransfers, transferLoading } = useStore((s) => ({
+  const { transfers, resetTransfers, transferLoading, originChainName } = useStore((s) => ({
     transfers: s.transfers,
     resetTransfers: s.resetTransfers,
     transferLoading: s.transferLoading,
+    originChainName: s.originChainName,
   }));
 
   useEffect(() => {
@@ -82,6 +83,7 @@ export function SideBarMenu({
             onClickConnectWallet={onClickConnectWallet}
             onCopySuccess={onCopySuccess}
             className="px-3 py-3"
+            chainName={originChainName}
           />
           <div className="mb-4 w-full bg-primary-500 px-3.5 py-2 text-base font-normal tracking-wider text-white">
             Transfer History

--- a/yarn.lock
+++ b/yarn.lock
@@ -4721,7 +4721,7 @@ __metadata:
 
 "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
   version: 12.1.0
-  resolution: "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::hash=276d3d&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
+  resolution: "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::hash=30b5e6&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
   dependencies:
     "@cosmos-kit/react": "npm:^2.18.0"
     "@headlessui/react": "npm:^2.1.8"
@@ -4741,7 +4741,7 @@ __metadata:
   peerDependencies:
     react: ^18
     react-dom: ^18
-  checksum: 10/177e0daeb7b0de1df64ea7ffbb68409bc36134b8db1096921c9720062f9075e9d29a8c7e8202e7e9726e8b519f460365a33628254885b92babf240277561734a
+  checksum: 10/d30ab1e981dcb55fcdfcc807276c82266ff38c27e40037b1459aa2c48581942e78fa65c60d3af5dba4670060d6df1977ab2ded348c6b9436279bc0465c245b9f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,9 +1101,9 @@ __metadata:
   linkType: hard
 
 "@chain-registry/types@npm:^0.50.14":
-  version: 0.50.15
-  resolution: "@chain-registry/types@npm:0.50.15"
-  checksum: 10/49e7035a45a755355a2f9c154befc67d5af4a7a24aa8b28de71430e3546aa5af27cdefff1e24e40d7195aa664fdc6ad565132a69aae4af7c2e7c6513f1dcae24
+  version: 0.50.122
+  resolution: "@chain-registry/types@npm:0.50.122"
+  checksum: 10/c416f737f40cf4180e6f05bd86d5a636a2549f3947ba4f2c9208a12895597a658047cb017775bca5a4f947b6be9b6fa5785c2fed8dc2ef53a64eaff90ede8a28
   languageName: node
   linkType: hard
 
@@ -4580,9 +4580,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/sdk@npm:12.1.0":
+"@hyperlane-xyz/sdk@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
   version: 12.1.0
-  resolution: "@hyperlane-xyz/sdk@npm:12.1.0"
+  resolution: "@hyperlane-xyz/sdk@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk::hash=c5fce3&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
   dependencies:
     "@arbitrum/sdk": "npm:^4.0.0"
     "@aws-sdk/client-s3": "npm:^3.577.0"
@@ -4608,7 +4608,22 @@ __metadata:
   peerDependencies:
     "@ethersproject/abi": "*"
     "@ethersproject/providers": "*"
-  checksum: 10/9416031867a5b4eb2bced1903c0b6c3e6c6d79e7c16bfd6e719505970b0a3f42d45dd3cf273f0f99fc40fc5da87220f77ae1dac9c7aab3d46f70a46c21337872
+  checksum: 10/14aeadf1f148a3e49c9e7250e4bea19be1bf7eac4aca77e449fdfc3359a772fe3ddb33fe457e99fa5dee03f179be76a03a8c034cecf69e5099ed1c741fa59994
+  languageName: node
+  linkType: hard
+
+"@hyperlane-xyz/utils@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
+  version: 12.1.0
+  resolution: "@hyperlane-xyz/utils@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils::hash=10e599&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
+  dependencies:
+    "@cosmjs/encoding": "npm:^0.32.4"
+    "@solana/web3.js": "npm:^1.95.4"
+    bignumber.js: "npm:^9.1.1"
+    ethers: "npm:^5.7.2"
+    lodash-es: "npm:^4.17.21"
+    pino: "npm:^8.19.0"
+    yaml: "npm:2.4.5"
+  checksum: 10/e0a7369e37bc09ddf97e5317d32906be2a7a796ff508d562f00734ef6ed04c78a3fda90b2cb7e2d9d72f6cf73241970e7f7537c433dacc0b6bde91ee73fd3841
   languageName: node
   linkType: hard
 
@@ -4645,9 +4660,9 @@ __metadata:
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
     "@hyperlane-xyz/registry": "npm:13.9.0"
-    "@hyperlane-xyz/sdk": "npm:12.1.0"
-    "@hyperlane-xyz/utils": "npm:12.1.0"
-    "@hyperlane-xyz/widgets": "npm:12.1.0"
+    "@hyperlane-xyz/sdk": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk"
+    "@hyperlane-xyz/utils": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils"
+    "@hyperlane-xyz/widgets": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets"
     "@interchain-ui/react": "npm:^1.23.28"
     "@metamask/post-message-stream": "npm:6.1.2"
     "@metamask/providers": "npm:10.2.1"
@@ -4704,9 +4719,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/widgets@npm:12.1.0":
+"@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
   version: 12.1.0
-  resolution: "@hyperlane-xyz/widgets@npm:12.1.0"
+  resolution: "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::hash=276d3d&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
   dependencies:
     "@cosmos-kit/react": "npm:^2.18.0"
     "@headlessui/react": "npm:^2.1.8"
@@ -4726,7 +4741,7 @@ __metadata:
   peerDependencies:
     react: ^18
     react-dom: ^18
-  checksum: 10/3d970537177d29bd77a4fbd0c75d247c115134795f4d9038dfcb602bad81c667646d4b70d0e8f68b7f6714042da4f1e5340371bb333670b86e3278e3960610b0
+  checksum: 10/177e0daeb7b0de1df64ea7ffbb68409bc36134b8db1096921c9720062f9075e9d29a8c7e8202e7e9726e8b519f460365a33628254885b92babf240277561734a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1100,10 +1100,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chain-registry/types@npm:^0.50.14":
-  version: 0.50.122
-  resolution: "@chain-registry/types@npm:0.50.122"
-  checksum: 10/c416f737f40cf4180e6f05bd86d5a636a2549f3947ba4f2c9208a12895597a658047cb017775bca5a4f947b6be9b6fa5785c2fed8dc2ef53a64eaff90ede8a28
+"@chain-registry/types@npm:^0.50.122":
+  version: 0.50.123
+  resolution: "@chain-registry/types@npm:0.50.123"
+  checksum: 10/ddfa8e37f28e64cabbf1c51de45e7fc68153fb851dda47b0b0e495d6275c4aba1b06bde3d159baa4ff483ed007e5e6199c5c4c9d680315ff77565ea38cbfe410
   languageName: node
   linkType: hard
 
@@ -4548,14 +4548,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/core@npm:7.1.0":
-  version: 7.1.0
-  resolution: "@hyperlane-xyz/core@npm:7.1.0"
+"@hyperlane-xyz/core@npm:7.1.2":
+  version: 7.1.2
+  resolution: "@hyperlane-xyz/core@npm:7.1.2"
   dependencies:
     "@arbitrum/nitro-contracts": "npm:^1.2.1"
     "@chainlink/contracts-ccip": "npm:^1.5.0"
     "@eth-optimism/contracts": "npm:^0.6.0"
-    "@hyperlane-xyz/utils": "npm:12.1.0"
+    "@hyperlane-xyz/utils": "npm:12.3.0"
     "@layerzerolabs/lz-evm-oapp-v2": "npm:2.0.2"
     "@matterlabs/hardhat-zksync-solc": "npm:1.2.5"
     "@matterlabs/hardhat-zksync-verify": "npm:1.7.1"
@@ -4566,31 +4566,52 @@ __metadata:
     "@ethersproject/abi": "*"
     "@ethersproject/providers": "*"
     "@types/sinon-chai": "*"
-  checksum: 10/fe76fa68ccecdb1832b58e8d91fd89c3f66ff7f99b37302a5a57e5efd1d160e73fb2a34f2b36050cc40384cedfb933ffa94c8c4a0698ee8bdf0d2b79ea849980
+  checksum: 10/037c8866fed2b73e02224335d09090ecbd69464307ac1a93d78cdbdd169ae64f142fa5429e1e6438bf39944cca72007d445d75707c1c81359402a64cb1124244
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:13.9.0":
-  version: 13.9.0
-  resolution: "@hyperlane-xyz/registry@npm:13.9.0"
+"@hyperlane-xyz/cosmos-sdk@npm:12.3.0":
+  version: 12.3.0
+  resolution: "@hyperlane-xyz/cosmos-sdk@npm:12.3.0"
+  dependencies:
+    "@cosmjs/stargate": "npm:^0.32.4"
+    "@hyperlane-xyz/cosmos-types": "npm:12.3.0"
+  checksum: 10/091edcf96ff0f5c7f2aad417cd8d77dc2c06c7f95558ff8efc93df9c60e47a478b7a3b7ab8ef4a43b74228cfaf2926c0bedef650a0f05e485b68fc20569ef31d
+  languageName: node
+  linkType: hard
+
+"@hyperlane-xyz/cosmos-types@npm:12.3.0":
+  version: 12.3.0
+  resolution: "@hyperlane-xyz/cosmos-types@npm:12.3.0"
+  dependencies:
+    long: "npm:^5.2.4"
+    protobufjs: "npm:^7.4.0"
+  checksum: 10/8ec102cd00e4e87bd8f4c85efe8bf9dd0d0e1de5c9fca11a431725f67ab1adbbba1a7762121e1c2271535e64b6c73eacd0cf9d385ff6f311fa84896e8372398e
+  languageName: node
+  linkType: hard
+
+"@hyperlane-xyz/registry@npm:13.10.0":
+  version: 13.10.0
+  resolution: "@hyperlane-xyz/registry@npm:13.10.0"
   dependencies:
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/df503ed73525a489488f112802f969db1ef9d32662558a539de3b66141374e1bc2df077dcba639bac55881b8a7c609f22eb4693676d3ec1b3e6dac2905afe73d
+  checksum: 10/e2d41d42c52f5e3f5a4ab09e9b448894dad710ff2243e6567ea840ccd46316f35172dfb280a10800435495d2c86beae00cfde213774fba054609c03eb09ef679
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/sdk@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
-  version: 12.1.0
-  resolution: "@hyperlane-xyz/sdk@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk::hash=c5fce3&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
+"@hyperlane-xyz/sdk@npm:12.3.0":
+  version: 12.3.0
+  resolution: "@hyperlane-xyz/sdk@npm:12.3.0"
   dependencies:
     "@arbitrum/sdk": "npm:^4.0.0"
     "@aws-sdk/client-s3": "npm:^3.577.0"
-    "@chain-registry/types": "npm:^0.50.14"
+    "@chain-registry/types": "npm:^0.50.122"
     "@cosmjs/cosmwasm-stargate": "npm:^0.32.4"
     "@cosmjs/stargate": "npm:^0.32.4"
-    "@hyperlane-xyz/core": "npm:7.1.0"
-    "@hyperlane-xyz/utils": "npm:12.1.0"
+    "@hyperlane-xyz/core": "npm:7.1.2"
+    "@hyperlane-xyz/cosmos-sdk": "npm:12.3.0"
+    "@hyperlane-xyz/utils": "npm:12.3.0"
     "@safe-global/api-kit": "npm:1.3.0"
     "@safe-global/protocol-kit": "npm:1.3.0"
     "@safe-global/safe-deployments": "npm:1.37.23"
@@ -4608,13 +4629,13 @@ __metadata:
   peerDependencies:
     "@ethersproject/abi": "*"
     "@ethersproject/providers": "*"
-  checksum: 10/14aeadf1f148a3e49c9e7250e4bea19be1bf7eac4aca77e449fdfc3359a772fe3ddb33fe457e99fa5dee03f179be76a03a8c034cecf69e5099ed1c741fa59994
+  checksum: 10/bf0d91d612922b38e0ff5b5cae0815a0b9672da3520208692aa71393d298c03d7a42d3a83be8945bdf8268187fc21a869b25e944868f68b28aa005bbffb6140c
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/utils@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
-  version: 12.1.0
-  resolution: "@hyperlane-xyz/utils@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils::hash=10e599&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
+"@hyperlane-xyz/utils@npm:12.3.0":
+  version: 12.3.0
+  resolution: "@hyperlane-xyz/utils@npm:12.3.0"
   dependencies:
     "@cosmjs/encoding": "npm:^0.32.4"
     "@solana/web3.js": "npm:^1.95.4"
@@ -4623,22 +4644,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     pino: "npm:^8.19.0"
     yaml: "npm:2.4.5"
-  checksum: 10/e0a7369e37bc09ddf97e5317d32906be2a7a796ff508d562f00734ef6ed04c78a3fda90b2cb7e2d9d72f6cf73241970e7f7537c433dacc0b6bde91ee73fd3841
-  languageName: node
-  linkType: hard
-
-"@hyperlane-xyz/utils@npm:12.1.0":
-  version: 12.1.0
-  resolution: "@hyperlane-xyz/utils@npm:12.1.0"
-  dependencies:
-    "@cosmjs/encoding": "npm:^0.32.4"
-    "@solana/web3.js": "npm:^1.95.4"
-    bignumber.js: "npm:^9.1.1"
-    ethers: "npm:^5.7.2"
-    lodash-es: "npm:^4.17.21"
-    pino: "npm:^8.19.0"
-    yaml: "npm:2.4.5"
-  checksum: 10/628225400fad5fe43db506939f8ecfc0dabfffc0c29f64a7ed2a47c45898abce7134e2d8787a971939c0416b660f06b9d2fbf30454dc32dce315a8dcb83174ed
+  checksum: 10/997a7ae769e0466aa6b7cf4aeedb0b8f1d883c344bf73cef5fec228dda49c2d50f12901aa7866e531dce108fcbb10c8831c8a6c895b5197374842455e2d1126c
   languageName: node
   linkType: hard
 
@@ -4659,10 +4665,10 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:13.9.0"
-    "@hyperlane-xyz/sdk": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/sdk"
-    "@hyperlane-xyz/utils": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/utils"
-    "@hyperlane-xyz/widgets": "file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets"
+    "@hyperlane-xyz/registry": "npm:13.10.0"
+    "@hyperlane-xyz/sdk": "npm:12.3.0"
+    "@hyperlane-xyz/utils": "npm:12.3.0"
+    "@hyperlane-xyz/widgets": "npm:12.3.0"
     "@interchain-ui/react": "npm:^1.23.28"
     "@metamask/post-message-stream": "npm:6.1.2"
     "@metamask/providers": "npm:10.2.1"
@@ -4719,14 +4725,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
-  version: 12.1.0
-  resolution: "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::hash=0eeae6&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
+"@hyperlane-xyz/widgets@npm:12.3.0":
+  version: 12.3.0
+  resolution: "@hyperlane-xyz/widgets@npm:12.3.0"
   dependencies:
+    "@cosmjs/stargate": "npm:^0.32.4"
     "@cosmos-kit/react": "npm:^2.18.0"
     "@headlessui/react": "npm:^2.1.8"
-    "@hyperlane-xyz/sdk": "npm:12.1.0"
-    "@hyperlane-xyz/utils": "npm:12.1.0"
+    "@hyperlane-xyz/cosmos-sdk": "npm:12.3.0"
+    "@hyperlane-xyz/sdk": "npm:12.3.0"
+    "@hyperlane-xyz/utils": "npm:12.3.0"
     "@interchain-ui/react": "npm:^1.23.28"
     "@rainbow-me/rainbowkit": "npm:^2.2.0"
     "@solana/wallet-adapter-react": "npm:^0.15.32"
@@ -4741,7 +4749,7 @@ __metadata:
   peerDependencies:
     react: ^18
     react-dom: ^18
-  checksum: 10/8aedfc0ed6e90623b34af2352f413970016f014929cff04503c3c7dce96ac856b4f3e4211ca822bcff5a6a69163c62cbee83178784a49904b9339c32ba22bdde
+  checksum: 10/bcc4f383d2917a8c2c4d388a4180299292842de687c4c273b2f782dc5b36de867ec1881895581a9d0520d7f639239fd9c98795575415c0a827a0df93d4a6bc8c
   languageName: node
   linkType: hard
 
@@ -20202,6 +20210,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"long@npm:^5.2.4":
+  version: 5.3.2
+  resolution: "long@npm:5.3.2"
+  checksum: 10/b6b55ddae56fcce2864d37119d6b02fe28f6dd6d9e44fd22705f86a9254b9321bd69e9ffe35263b4846d54aba197c64882adcb8c543f2383c1e41284b321ea64
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -22479,6 +22494,26 @@ __metadata:
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
   checksum: 10/408423506610f70858d7593632f4a6aa4f05796c90fd632be9b9252457c795acc71aa6d3b54bb7f48a890141728fee4ca3906723ccea6c202ad71f21b3879b8b
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:^7.4.0":
+  version: 7.5.0
+  resolution: "protobufjs@npm:7.5.0"
+  dependencies:
+    "@protobufjs/aspromise": "npm:^1.1.2"
+    "@protobufjs/base64": "npm:^1.1.2"
+    "@protobufjs/codegen": "npm:^2.0.4"
+    "@protobufjs/eventemitter": "npm:^1.1.0"
+    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/float": "npm:^1.0.2"
+    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/path": "npm:^1.1.2"
+    "@protobufjs/pool": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.0"
+    "@types/node": "npm:>=13.7.0"
+    long: "npm:^5.0.0"
+  checksum: 10/c4fcc116b7aa5f15250420cf95a669969e1e29379d70ff2f4e3e2f5dbbc2dab2be0adef9ade02d1d6ea94179b34bac8b8458f30b089fe040e4e9fc2a29fdb713
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4721,7 +4721,7 @@ __metadata:
 
 "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A.":
   version: 12.1.0
-  resolution: "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::hash=30b5e6&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
+  resolution: "@hyperlane-xyz/widgets@file:/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets#/Users/troykessler/work/hyperlane/hyperlane-monorepo/typescript/widgets::hash=0eeae6&locator=%40hyperlane-xyz%2Fwarp-ui-template%40workspace%3A."
   dependencies:
     "@cosmos-kit/react": "npm:^2.18.0"
     "@headlessui/react": "npm:^2.1.8"
@@ -4741,7 +4741,7 @@ __metadata:
   peerDependencies:
     react: ^18
     react-dom: ^18
-  checksum: 10/d30ab1e981dcb55fcdfcc807276c82266ff38c27e40037b1459aa2c48581942e78fa65c60d3af5dba4670060d6df1977ab2ded348c6b9436279bc0465c245b9f
+  checksum: 10/8aedfc0ed6e90623b34af2352f413970016f014929cff04503c3c7dce96ac856b4f3e4211ca822bcff5a6a69163c62cbee83178784a49904b9339c32ba22bdde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR improves the way cosmos addresses are displayed. In cosmos there is like in Ethereum a private public key pair, but for every cosmos chain there is a different address prefix. Example Osmosis osmo1sduu..., Cosmos Hub cosmos1j48f33.., KYVE kyve1jhf738... and so on. Right now always the address of the first chain gets displayed which often has nothing to do with the chain the user has funds on and wants to swap from/to. This has caused confusion in the past.

This PR addresses this issue by showing the Cosmos Hub address by default if the user is connected with a cosmos wallet since Cosmos Hub is still the standard in the cosmos ecosystem. Once the user selects a cosmos origin chain that address is displayed instead.

TODO: once the monorepo PR https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/6022 is merged and released we can switch out the dependencies to the newest hyperlane widgets version to make it ready for review.