### PR TITLE
chore: remove smol route

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -111,9 +111,6 @@ export const warpRouteWhitelist: Array<string> | null = [
   // rstETH routes
   'rstETH/ethereum-zircuit',
 
-  // SMOL routes
-  'SMOL/arbitrum-ethereum-solanamainnet-treasure',
-
   // WETH routes
   'WETH.a/artela-base',
 


### PR DESCRIPTION
Remove `SMOL/arbitrum-ethereum-solanamainnet-treasure` route