### PR TITLE
chore: add SVM rent estimate

### DIFF
--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -56,3 +56,12 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
   //   logoURI: '/logo.svg',
   // },
 };
+
+// rent account payment for SVM chains added on top of IGP, not exact but should be
+// pretty close to actual payment
+export const rentEstimate: ChainMap<bigint> = {
+  eclipsemainnet: BigInt(Math.round(0.00004019 * 10 ** 9)),
+  solanamainnet: BigInt(Math.round(0.004114 * 10 ** 9)),
+  sonicsvm: BigInt(Math.round(0.004114 * 10 ** 9)),
+  soon: BigInt(Math.round(0.00000343 * 10 ** 9)),
+};

--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -61,7 +61,7 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
 // not exact but should be pretty close to actual payment
 export const chainsRentEstimate: ChainMap<bigint> = {
   eclipsemainnet: BigInt(Math.round(0.00004019 * 10 ** 9)),
-  solanamainnet: BigInt(Math.round(0.004114 * 10 ** 9)),
-  sonicsvm: BigInt(Math.round(0.004114 * 10 ** 9)),
+  solanamainnet: BigInt(Math.round(0.00411336 * 10 ** 9)),
+  sonicsvm: BigInt(Math.round(0.00411336 * 10 ** 9)),
   soon: BigInt(Math.round(0.00000355 * 10 ** 9)),
 };

--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -57,11 +57,11 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
   // },
 };
 
-// rent account payment for SVM chains added on top of IGP, not exact but should be
-// pretty close to actual payment
-export const rentEstimate: ChainMap<bigint> = {
+// rent account payment for (mostly for) SVM chains added on top of IGP,
+// not exact but should be pretty close to actual payment
+export const chainsRentEstimate: ChainMap<bigint> = {
   eclipsemainnet: BigInt(Math.round(0.00004019 * 10 ** 9)),
   solanamainnet: BigInt(Math.round(0.004114 * 10 ** 9)),
   sonicsvm: BigInt(Math.round(0.004114 * 10 ** 9)),
-  soon: BigInt(Math.round(0.00000343 * 10 ** 9)),
+  soon: BigInt(Math.round(0.00000355 * 10 ** 9)),
 };

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -19,7 +19,7 @@ import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareS
 import { SolidButton } from '../../components/buttons/SolidButton';
 import { TextField } from '../../components/input/TextField';
 import { WARP_QUERY_PARAMS } from '../../consts/args';
-import { rentEstimate } from '../../consts/chains';
+import { chainsRentEstimate } from '../../consts/chains';
 import { config } from '../../consts/config';
 import { Color } from '../../styles/Color';
 import { logger } from '../../utils/logger';
@@ -452,8 +452,8 @@ function ReviewDetails({ visible }: { visible: boolean }) {
   const isLoading = isApproveLoading || isQuoteLoading;
 
   const interchainQuote =
-    originToken && objKeys(rentEstimate).includes(originToken.chainName)
-      ? fees?.interchainQuote.plus(rentEstimate[originToken.chainName])
+    originToken && objKeys(chainsRentEstimate).includes(originToken.chainName)
+      ? fees?.interchainQuote.plus(chainsRentEstimate[originToken.chainName])
       : fees?.interchainQuote;
 
   return (

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -1,5 +1,5 @@
 import { TokenAmount, WarpCore } from '@hyperlane-xyz/sdk';
-import { ProtocolType, errorToString, isNullish, toWei } from '@hyperlane-xyz/utils';
+import { ProtocolType, errorToString, isNullish, objKeys, toWei } from '@hyperlane-xyz/utils';
 import {
   AccountInfo,
   ChevronIcon,
@@ -19,6 +19,7 @@ import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareS
 import { SolidButton } from '../../components/buttons/SolidButton';
 import { TextField } from '../../components/input/TextField';
 import { WARP_QUERY_PARAMS } from '../../consts/args';
+import { rentEstimate } from '../../consts/chains';
 import { config } from '../../consts/config';
 import { Color } from '../../styles/Color';
 import { logger } from '../../utils/logger';
@@ -450,6 +451,11 @@ function ReviewDetails({ visible }: { visible: boolean }) {
 
   const isLoading = isApproveLoading || isQuoteLoading;
 
+  const interchainQuote =
+    originToken && objKeys(rentEstimate).includes(originToken.chainName)
+      ? fees?.interchainQuote.plus(rentEstimate[originToken.chainName])
+      : fees?.interchainQuote;
+
   return (
     <div
       className={`${
@@ -496,11 +502,11 @@ function ReviewDetails({ visible }: { visible: boolean }) {
                     }`}</span>
                   </p>
                 )}
-                {fees?.interchainQuote && fees.interchainQuote.amount > 0n && (
+                {interchainQuote && interchainQuote.amount > 0n && (
                   <p className="flex">
                     <span className="min-w-[6.5rem]">Interchain Gas</span>
-                    <span>{`${fees.interchainQuote.getDecimalFormattedAmount().toFixed(4) || '0'} ${
-                      fees.interchainQuote.token.symbol || ''
+                    <span>{`${interchainQuote.getDecimalFormattedAmount().toFixed(4) || '0'} ${
+                      interchainQuote.token.symbol || ''
                     }`}</span>
                   </p>
                 )}


### PR DESCRIPTION
Add SVM chains rent estimate amount on top of the IGP payment quoting, **this is purely presentational and the UI does not add on top of the actual transactions, the rent comes from the payment itself**. This is mean purely as a way to represent the actual fee paid for SVM bridging as close as possible

You can check the transactions and look at the rent paid to see how the estimates are taken:
[Solana](https://solscan.io/tx/53mvkbN21SM7PCv7CY98CDCXqxEhCXMPjtdsVZT6YNuRg98DEji7tkzXPsqjXpMGW3rAsdzZmwERv8CLrBX1BnsC#solBalanceChange): 0.00187224 + 0.00224112 = 0.00411336
[Eclipse](https://eclipsescan.xyz/tx/4xza8yohGKqBNd5QytFWRKLCgycJpYqohnhpKUB4Aen8Yx83jA28pPSE9naT7SHuvcUT2ytximkWF4G3559kvSj#balanceChange): 0.000018292 + 0.000021896 = 0.00004019
[Soon](https://explorer.soo.network/tx/3LwvSmxkca9tFz9CF8YAmLjE1ZL9f1EiV9zCBaSZacr82kACb1zrG3eA49pCKtDFHpszoWGJy3qkJMSPEmiJYNvH): 0.000001932 + 0.000001614 = 0.00000355
[SonicSVM](https://explorer.sonic.game/tx/3fRkH2h2To6ZPnk2PdpkmUs27S79EAVueCcuisV6EcZEi5tbvgyLkaWnDpsLSvhnUaw6rJyqEhcAXE46hiQvg47y?cluster=custom&customUrl=https%3A%2F%2Fapi.mainnet-alpha.sonic.game): 0.00224112 + 0.00187224 = 0.00411336 

as you can see below, the IGP shown would be inaccurate because it does not take into account the rent:
![image](https://github.com/user-attachments/assets/fe1e878e-9b4e-43bd-9bf6-8ff9b95439aa)
when you sign, you would notice this:
![Screenshot 2025-05-22 at 11 29 04 AM](https://github.com/user-attachments/assets/7d79d32f-96b9-49eb-8c04-2c5da7caa772)



and this is the estimation after adding the rent:
![image](https://github.com/user-attachments/assets/24a446b2-5f94-49e0-8670-92023766354f)
