### PR TITLE
chore: set fail-fast to false for create-merge-prs

### DIFF
--- a/.github/workflows/create-merge-prs.yaml
+++ b/.github/workflows/create-merge-prs.yaml
@@ -9,6 +9,7 @@ jobs:
   create-merge-prs:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         name: [ezeth, injective, nexus, trump, ousdt]
     steps:


### PR DESCRIPTION
Set `fail-fast` to `false` for strategy, this will allow all branches to independently run instead of the matrix canceling in progress branches/pr creation if one of them fails. Ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast