### PR TITLE
chore: bump registry to 15.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "15.8.1",
+    "@hyperlane-xyz/registry": "15.9.0",
     "@hyperlane-xyz/sdk": "13.1.1",
     "@hyperlane-xyz/utils": "13.1.1",
     "@hyperlane-xyz/widgets": "13.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,14 +4590,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:15.8.1":
-  version: 15.8.1
-  resolution: "@hyperlane-xyz/registry@npm:15.8.1"
+"@hyperlane-xyz/registry@npm:15.9.0":
+  version: 15.9.0
+  resolution: "@hyperlane-xyz/registry@npm:15.9.0"
   dependencies:
     jszip: "npm:^3.10.1"
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/9f8cb167de0ee42200b0f8cc54553b05f79445dfefbd32ec37ffd5152262e3fa4eca86a35e51ef77313b30775a4769882eb832003a3185c56097a16cb963bb9f
+  checksum: 10/f92d098cd0c5a16eddc7b0b3c59a291c363806bfb695262a44020183e7aa76b46886da430e6a2fc78427085df90ad6cc1c4ae257a54099d11b6230b5b0a35240
   languageName: node
   linkType: hard
 
@@ -4677,7 +4677,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:15.8.1"
+    "@hyperlane-xyz/registry": "npm:15.9.0"
     "@hyperlane-xyz/sdk": "npm:13.1.1"
     "@hyperlane-xyz/utils": "npm:13.1.1"
     "@hyperlane-xyz/widgets": "npm:13.1.1"


### PR DESCRIPTION
This pull request updates the version of the `@hyperlane-xyz/registry` dependency in `package.json` from `15.8.1` to `15.9.0`.