### PR TITLE
chore: main to nexus 15.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "15.8.0",
+    "@hyperlane-xyz/registry": "15.9.0",
     "@hyperlane-xyz/sdk": "13.0.0",
     "@hyperlane-xyz/utils": "13.0.0",
     "@hyperlane-xyz/widgets": "13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4608,14 +4608,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:15.8.0":
-  version: 15.8.0
-  resolution: "@hyperlane-xyz/registry@npm:15.8.0"
+"@hyperlane-xyz/registry@npm:15.9.0":
+  version: 15.9.0
+  resolution: "@hyperlane-xyz/registry@npm:15.9.0"
   dependencies:
     jszip: "npm:^3.10.1"
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/5d493328ffea5d21ea1000b0fa50c7602e14c8170665ad78f86444eaec7f27e0626b8400c5fadf4563ed67b27869a041063ba8a5a9471bf6d4d5a5af848a2106
+  checksum: 10/f92d098cd0c5a16eddc7b0b3c59a291c363806bfb695262a44020183e7aa76b46886da430e6a2fc78427085df90ad6cc1c4ae257a54099d11b6230b5b0a35240
   languageName: node
   linkType: hard
 
@@ -4695,7 +4695,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:15.8.0"
+    "@hyperlane-xyz/registry": "npm:15.9.0"
     "@hyperlane-xyz/sdk": "npm:13.0.0"
     "@hyperlane-xyz/utils": "npm:13.0.0"
     "@hyperlane-xyz/widgets": "npm:13.0.0"


### PR DESCRIPTION
This pull request updates the version of the `@hyperlane-xyz/registry` dependency in the `package.json` file from `15.8.0` to `15.9.0`.
