### PR TITLE
chore: Add RDO to nexus

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -235,4 +235,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // KYVE
   'KYVE/base-kyve',
+
+  // RDO routes
+  'RDO/bsc-ethereum',
 ];


### PR DESCRIPTION
This pull request updates the `warpRouteWhitelist` constant in `src/consts/warpRouteWhitelist.ts` to include a new route for RDO.

* Added the `RDO/bsc-ethereum` route to the `warpRouteWhitelist` array.