### PR TITLE
chore: prevent transfer from being sent to router addresses

### DIFF
--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -254,9 +254,7 @@ function getRouterAddressesByChain(
 ): Record<ChainName, Set<string>> {
   return tokens.reduce<Record<ChainName, Set<string>>>((acc, token) => {
     acc[token.chainName] ||= new Set<string>();
-
     if (token.addressOrDenom) acc[token.chainName].add(token.addressOrDenom);
-
     return acc;
   }, {});
 }

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -56,9 +56,10 @@ export function TransferTokenForm() {
   const multiProvider = useMultiProvider();
   const warpCore = useWarpCore();
 
-  const { originChainName, setOriginChainName } = useStore((s) => ({
+  const { originChainName, setOriginChainName, routerAddresses } = useStore((s) => ({
     originChainName: s.originChainName,
     setOriginChainName: s.setOriginChainName,
+    routerAddresses: s.routerAddresses,
   }));
 
   const initialValues = useFormInitialValues();
@@ -75,7 +76,8 @@ export function TransferTokenForm() {
     isOpen: isConfirmationModalOpen,
   } = useModal();
 
-  const validate = (values: TransferFormValues) => validateForm(warpCore, values, accounts);
+  const validate = (values: TransferFormValues) =>
+    validateForm(warpCore, values, accounts, routerAddresses);
 
   const onSubmitForm = async (values: TransferFormValues) => {
     logger.debug('Checking destination native balance for:', values.destination, values.recipient);
@@ -579,6 +581,7 @@ async function validateForm(
   warpCore: WarpCore,
   values: TransferFormValues,
   accounts: Record<ProtocolType, AccountInfo>,
+  routerAddresses: Set<string>,
 ) {
   try {
     const { origin, destination, tokenIndex, amount, recipient } = values;
@@ -590,6 +593,10 @@ async function validateForm(
       origin,
       accounts,
     );
+
+    if (routerAddresses.has(recipient))
+      return { recipient: 'Warp Route address is not valid as recipient' };
+
     const result = await warpCore.validateTransfer({
       originTokenAmount: token.amount(amountWei),
       destination,

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -28,7 +28,6 @@ export function assembleWarpCoreConfig(storeOverrides: WarpCoreConfig[]): WarpCo
     ...storeOverrideTokens,
   ];
   const tokens = dedupeTokens(combinedTokens);
-  console.log('tokens', tokens);
 
   const combinedOptions = [
     ...filteredRegistryOptions,

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -28,6 +28,7 @@ export function assembleWarpCoreConfig(storeOverrides: WarpCoreConfig[]): WarpCo
     ...storeOverrideTokens,
   ];
   const tokens = dedupeTokens(combinedTokens);
+  console.log('tokens', tokens);
 
   const combinedOptions = [
     ...filteredRegistryOptions,


### PR DESCRIPTION
Fixes #595, this PR prevents the user from sending funds to a warp route address from the tokens list

- Create a `routerAddressesByChainMap` variable in store that host all the known `addressOrDenom` in a given chain
- Check if recipient is one of these addresses and if so, prevent transfer from being made