### PR TITLE
fix: remove unused variable

### DIFF
--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -119,7 +119,6 @@ export const useStore = create<AppState>()(
         chainMetadata: chainMetadata,
       }),
       warpCore: new WarpCore(new MultiProtocolProvider({}), []),
-      routerAddresses: {},
       setWarpContext: (context) => {
         logger.debug('Setting warp context in store');
         set(context);


### PR DESCRIPTION
removed `routerAddreses` from `zustand` store because it is not used and was left after the rename