### PR TITLE
chore: Bump registry to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "15.10.1",
+    "@hyperlane-xyz/registry": "16.0.0",
     "@hyperlane-xyz/sdk": "13.1.1",
     "@hyperlane-xyz/utils": "13.1.1",
     "@hyperlane-xyz/widgets": "13.1.1",

--- a/src/features/warpCore/AddWarpConfigModal.tsx
+++ b/src/features/warpCore/AddWarpConfigModal.tsx
@@ -1,4 +1,4 @@
-import { warpRouteConfigToId } from '@hyperlane-xyz/registry';
+import { BaseRegistry } from '@hyperlane-xyz/registry';
 import { MultiProtocolProvider, WarpCoreConfig, WarpCoreConfigSchema } from '@hyperlane-xyz/sdk';
 import { failure, Result, success, tryParseJsonOrYaml } from '@hyperlane-xyz/utils';
 import { Button, CopyButton, IconButton, Modal, PlusIcon, XIcon } from '@hyperlane-xyz/widgets';
@@ -110,7 +110,7 @@ function ConfigList({
     <div className="mt-2 flex w-full flex-col gap-2 border-t pt-3">
       {warpCoreConfigOverrides.map((config, i) => (
         <div key={i} className="flex items-center justify-between gap-1">
-          <span className="truncate text-xs">{warpRouteConfigToId(config)}</span>
+          <span className="truncate text-xs">{BaseRegistry.warpRouteConfigToId(config)}</span>
           <IconButton onClick={() => onRemove(i)} title="Remove config">
             <XIcon width={10} height={10} color={Color.gray['800']} />
           </IconButton>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4590,14 +4590,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:15.10.1":
-  version: 15.10.1
-  resolution: "@hyperlane-xyz/registry@npm:15.10.1"
+"@hyperlane-xyz/registry@npm:16.0.0":
+  version: 16.0.0
+  resolution: "@hyperlane-xyz/registry@npm:16.0.0"
   dependencies:
     jszip: "npm:^3.10.1"
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/cafd861d93bd02f79489f3a6b0d45d4cc6e40c46ed35dda2d903799259eafa648a1d7c0d600debee7fc2ed0a0692eb814bf6e5fb1b5bc74632dfebf0280f7840
+  checksum: 10/db4e12d264768147544f01c1dfbe2dd6f5aea7101ee92ed16d7af6513f127c0043683f01225b53e97154e813829bb3fb1bc456dd6510356fd6e4c9c986c72bf2
   languageName: node
   linkType: hard
 
@@ -4677,7 +4677,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:15.10.1"
+    "@hyperlane-xyz/registry": "npm:16.0.0"
     "@hyperlane-xyz/sdk": "npm:13.1.1"
     "@hyperlane-xyz/utils": "npm:13.1.1"
     "@hyperlane-xyz/widgets": "npm:13.1.1"


### PR DESCRIPTION
This PR bump registry to v16. The goal is to enable REZ (uniswap) but also update import to use BaseRegistry