### PR TITLE
chore: uppercase warpRouteIds and whiteList

### DIFF
--- a/src/consts/warpRouteWhitelist.test.ts
+++ b/src/consts/warpRouteWhitelist.test.ts
@@ -1,10 +1,13 @@
 import { warpRouteConfigs } from '@hyperlane-xyz/registry';
+import { objKeys } from '@hyperlane-xyz/utils';
 import { assert, test } from 'vitest';
 import { warpRouteWhitelist } from './warpRouteWhitelist';
 
 test('warpRouteWhitelist', () => {
   if (!warpRouteWhitelist) return;
+
+  const uppercaseConfigKeys = new Set(objKeys(warpRouteConfigs).map((key) => key.toUpperCase()));
   for (const id of warpRouteWhitelist) {
-    assert(warpRouteConfigs[id], `No route with id ${id} found in registry.`);
+    assert(uppercaseConfigKeys.has(id.toUpperCase()), `No route with id ${id} found in registry.`);
   }
 });

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -49,7 +49,9 @@ function filterToIds(
   config: Record<string, WarpCoreConfig>,
   idWhitelist: string[],
 ): Record<string, WarpCoreConfig> {
-  return objFilter(config, (id, c): c is WarpCoreConfig => idWhitelist.includes(id));
+  return objFilter(config, (id, c): c is WarpCoreConfig =>
+    idWhitelist.map((id) => id.toUpperCase()).includes(id.toUpperCase()),
+  );
 }
 
 // Separate warp configs may contain duplicate definitions of the same token.


### PR DESCRIPTION
uppercase `warpRouteIds` and `whiteList` ids to fix discrepancy 