### PR TITLE
feat: multi-collateral limits 

### DIFF
--- a/src/features/limits/const.ts
+++ b/src/features/limits/const.ts
@@ -1,0 +1,9 @@
+import { RouteLimit } from './types';
+
+export const multiCollateralTokenLimits: RouteLimit[] = [
+  {
+    amountWei: 100000,
+    symbol: 'USDC',
+    chains: ['optimism', 'arbitrum'],
+  },
+];

--- a/src/features/limits/const.ts
+++ b/src/features/limits/const.ts
@@ -2,7 +2,7 @@ import { RouteLimit } from './types';
 
 export const multiCollateralTokenLimits: RouteLimit[] = [
   {
-    amount: 50000n,
+    amountWei: 1000000n, // 1 USDC
     symbol: 'USDC',
     chains: ['optimism', 'arbitrum'],
   },

--- a/src/features/limits/const.ts
+++ b/src/features/limits/const.ts
@@ -2,7 +2,7 @@ import { RouteLimit } from './types';
 
 export const multiCollateralTokenLimits: RouteLimit[] = [
   {
-    amountWei: 100000,
+    amount: 50000n,
     symbol: 'USDC',
     chains: ['optimism', 'arbitrum'],
   },

--- a/src/features/limits/types.ts
+++ b/src/features/limits/types.ts
@@ -1,0 +1,5 @@
+export type RouteLimit = {
+  symbol: string;
+  amountWei: number;
+  chains: ChainName[];
+};

--- a/src/features/limits/types.ts
+++ b/src/features/limits/types.ts
@@ -1,5 +1,5 @@
 export type RouteLimit = {
   symbol: string;
-  amount: bigint;
+  amountWei: bigint;
   chains: ChainName[];
 };

--- a/src/features/limits/types.ts
+++ b/src/features/limits/types.ts
@@ -1,5 +1,5 @@
 export type RouteLimit = {
   symbol: string;
-  amountWei: number;
+  amount: bigint;
   chains: ChainName[];
 };

--- a/src/features/limits/utils.test.ts
+++ b/src/features/limits/utils.test.ts
@@ -1,0 +1,70 @@
+import { TestChainName, TokenStandard } from '@hyperlane-xyz/sdk';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createMockToken, createTokenConnectionMock } from '../../utils/test';
+import { RouteLimit } from './types';
+import { getMultiCollateralTokenLimit, isMultiCollateralLimitExceeded } from './utils';
+
+const mockLimits: RouteLimit[] = [
+  {
+    amountWei: 100000n,
+    chains: [TestChainName.test1, TestChainName.test2],
+    symbol: 'FAKE',
+  },
+];
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getMultiCollateralTokenLimit', () => {
+  test('returns null if destinationToken is not found', () => {
+    const token = createMockToken({ connections: [createTokenConnectionMock()] });
+    expect(getMultiCollateralTokenLimit(token, TestChainName.test3, mockLimits)).toBeNull();
+  });
+
+  test('should return null if tokens are not multi-collateral', () => {
+    const token = createMockToken({
+      connections: [createTokenConnectionMock()],
+      standard: TokenStandard.CosmosIbc,
+    });
+    expect(getMultiCollateralTokenLimit(token, TestChainName.test2, mockLimits)).toBeNull();
+  });
+
+  test('should return null if no matching limit in routeLimits', () => {
+    const token = createMockToken({
+      symbol: 'NOMATCH',
+      connections: [createTokenConnectionMock()],
+    });
+    expect(getMultiCollateralTokenLimit(token, TestChainName.test2, mockLimits)).toBeNull();
+  });
+
+  test('should return the correct limit if token pair matches', () => {
+    const token = createMockToken({
+      connections: [createTokenConnectionMock()],
+    });
+    expect(getMultiCollateralTokenLimit(token, TestChainName.test2, mockLimits)).toEqual(
+      mockLimits[0],
+    );
+  });
+});
+
+describe('isMultiCollateralLimitExceeded', () => {
+  test('should return null if limit is not exceeded', () => {
+    const token = createMockToken({
+      connections: [createTokenConnectionMock()],
+    });
+    expect(
+      isMultiCollateralLimitExceeded(token, TestChainName.test2, '1000', mockLimits),
+    ).toBeNull();
+  });
+
+  test('should return the limit if exceeded', () => {
+    const token = createMockToken({
+      connections: [createTokenConnectionMock()],
+    });
+
+    expect(
+      isMultiCollateralLimitExceeded(token, TestChainName.test2, '10000000', mockLimits),
+    ).toEqual(BigInt(mockLimits[0].amountWei));
+  });
+});

--- a/src/features/limits/utils.ts
+++ b/src/features/limits/utils.ts
@@ -2,14 +2,10 @@ import { IToken, Token } from '@hyperlane-xyz/sdk';
 import { isValidMultiCollateralToken } from '../tokens/utils';
 import { multiCollateralTokenLimits } from './const';
 
-export function isMultiCollateralLimitExceeded(
-  originToken: Token,
-  destinationToken: IToken,
-  amountWei: string,
-) {
+function getMultiCollateralTokenLimit(originToken: Token, destinationToken: IToken) {
   const isMultiCollateralToken = isValidMultiCollateralToken(originToken, destinationToken);
 
-  if (!isMultiCollateralToken) return false;
+  if (!isMultiCollateralToken) return null;
 
   const limitExists = multiCollateralTokenLimits.find((limit) => {
     if (limit.symbol !== originToken.symbol || limit.symbol !== destinationToken.symbol)
@@ -24,7 +20,17 @@ export function isMultiCollateralLimitExceeded(
     return true;
   });
 
-  if (!limitExists) return false;
+  return limitExists || null;
+}
 
-  return amountWei <= limitExists.amountWei.toString();
+export function isMultiCollateralLimitExceeded(
+  originToken: Token,
+  destinationToken: IToken,
+  amount: string,
+): bigint | null {
+  const limitExists = getMultiCollateralTokenLimit(originToken, destinationToken);
+
+  if (!limitExists) return null;
+
+  return BigInt(amount) > limitExists.amount ? limitExists.amount : null;
 }

--- a/src/features/limits/utils.ts
+++ b/src/features/limits/utils.ts
@@ -1,15 +1,22 @@
 import { IToken, Token } from '@hyperlane-xyz/sdk';
+import { logger } from '../../utils/logger';
 import { isValidMultiCollateralToken } from '../tokens/utils';
 import { multiCollateralTokenLimits } from './const';
+import { RouteLimit } from './types';
 
-function getMultiCollateralTokenLimit(originToken: Token | IToken, destination: ChainName) {
+export function getMultiCollateralTokenLimit(
+  originToken: Token | IToken,
+  destination: ChainName,
+  routeLimits: RouteLimit[] = multiCollateralTokenLimits,
+) {
   const destinationToken = originToken.getConnectionForChain(destination)?.token;
   if (!destinationToken) return null;
 
   const isMultiCollateralToken = isValidMultiCollateralToken(originToken, destinationToken);
   if (!isMultiCollateralToken) return null;
+  logger.debug('hello', destinationToken);
 
-  const limitExists = multiCollateralTokenLimits.find((limit) => {
+  const limitExists = routeLimits.find((limit) => {
     if (limit.symbol !== originToken.symbol || limit.symbol !== destinationToken.symbol)
       return false;
 
@@ -29,10 +36,10 @@ export function isMultiCollateralLimitExceeded(
   originToken: Token | IToken,
   destination: ChainName,
   amountWei: string,
+  routeLimits: RouteLimit[] = multiCollateralTokenLimits,
 ): bigint | null {
-  const limitExists = getMultiCollateralTokenLimit(originToken, destination);
+  const limitExists = getMultiCollateralTokenLimit(originToken, destination, routeLimits);
 
-  console.log('limitsExist', limitExists);
   if (!limitExists) return null;
 
   return BigInt(amountWei) > limitExists.amountWei ? limitExists.amountWei : null;

--- a/src/features/limits/utils.ts
+++ b/src/features/limits/utils.ts
@@ -1,0 +1,30 @@
+import { IToken, Token } from '@hyperlane-xyz/sdk';
+import { isValidMultiCollateralToken } from '../tokens/utils';
+import { multiCollateralTokenLimits } from './const';
+
+export function isMultiCollateralLimitExceeded(
+  originToken: Token,
+  destinationToken: IToken,
+  amountWei: string,
+) {
+  const isMultiCollateralToken = isValidMultiCollateralToken(originToken, destinationToken);
+
+  if (!isMultiCollateralToken) return false;
+
+  const limitExists = multiCollateralTokenLimits.find((limit) => {
+    if (limit.symbol !== originToken.symbol || limit.symbol !== destinationToken.symbol)
+      return false;
+
+    if (
+      !limit.chains.includes(originToken.chainName) ||
+      !limit.chains.includes(destinationToken.chainName)
+    )
+      return false;
+
+    return true;
+  });
+
+  if (!limitExists) return false;
+
+  return amountWei <= limitExists.amountWei.toString();
+}

--- a/src/features/limits/utils.ts
+++ b/src/features/limits/utils.ts
@@ -1,5 +1,4 @@
 import { IToken, Token } from '@hyperlane-xyz/sdk';
-import { logger } from '../../utils/logger';
 import { isValidMultiCollateralToken } from '../tokens/utils';
 import { multiCollateralTokenLimits } from './const';
 import { RouteLimit } from './types';
@@ -14,7 +13,6 @@ export function getMultiCollateralTokenLimit(
 
   const isMultiCollateralToken = isValidMultiCollateralToken(originToken, destinationToken);
   if (!isMultiCollateralToken) return null;
-  logger.debug('hello', destinationToken);
 
   const limitExists = routeLimits.find((limit) => {
     if (limit.symbol !== originToken.symbol || limit.symbol !== destinationToken.symbol)

--- a/src/features/limits/utils.ts
+++ b/src/features/limits/utils.ts
@@ -2,9 +2,11 @@ import { IToken, Token } from '@hyperlane-xyz/sdk';
 import { isValidMultiCollateralToken } from '../tokens/utils';
 import { multiCollateralTokenLimits } from './const';
 
-function getMultiCollateralTokenLimit(originToken: Token, destinationToken: IToken) {
-  const isMultiCollateralToken = isValidMultiCollateralToken(originToken, destinationToken);
+function getMultiCollateralTokenLimit(originToken: Token | IToken, destination: ChainName) {
+  const destinationToken = originToken.getConnectionForChain(destination)?.token;
+  if (!destinationToken) return null;
 
+  const isMultiCollateralToken = isValidMultiCollateralToken(originToken, destinationToken);
   if (!isMultiCollateralToken) return null;
 
   const limitExists = multiCollateralTokenLimits.find((limit) => {
@@ -24,13 +26,14 @@ function getMultiCollateralTokenLimit(originToken: Token, destinationToken: ITok
 }
 
 export function isMultiCollateralLimitExceeded(
-  originToken: Token,
-  destinationToken: IToken,
-  amount: string,
+  originToken: Token | IToken,
+  destination: ChainName,
+  amountWei: string,
 ): bigint | null {
-  const limitExists = getMultiCollateralTokenLimit(originToken, destinationToken);
+  const limitExists = getMultiCollateralTokenLimit(originToken, destination);
 
+  console.log('limitsExist', limitExists);
   if (!limitExists) return null;
 
-  return BigInt(amount) > limitExists.amount ? limitExists.amount : null;
+  return BigInt(amountWei) > limitExists.amountWei ? limitExists.amountWei : null;
 }

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -1,46 +1,7 @@
-import {
-  TestChainName,
-  Token,
-  TokenArgs,
-  TokenConnection,
-  TokenConnectionType,
-  TokenStandard,
-} from '@hyperlane-xyz/sdk';
+import { TestChainName, TokenStandard } from '@hyperlane-xyz/sdk';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createMockToken, createTokenConnectionMock } from '../../utils/test';
 import { isValidMultiCollateralToken } from './utils';
-
-const mockCollateralAddress = '0xabc';
-const addressZero = '0x0000000000000000000000000000000000000000';
-
-const defaultTokenArgs: TokenArgs = {
-  chainName: TestChainName.test1,
-  standard: TokenStandard.EvmHypCollateral,
-  addressOrDenom: addressZero,
-  decimals: 6,
-  symbol: 'FAKE',
-  name: 'Fake Token',
-  collateralAddressOrDenom: mockCollateralAddress,
-};
-
-const defaultTokenArgs2: TokenArgs = {
-  ...defaultTokenArgs,
-  chainName: TestChainName.test2,
-};
-
-const createMockToken = (args?: Partial<TokenArgs>) => {
-  return new Token({ ...defaultTokenArgs, ...args });
-};
-
-const createTokenConnectionMock = (
-  args?: Partial<TokenConnection>,
-  tokenArgs?: Partial<TokenArgs>,
-): TokenConnection => {
-  return {
-    type: TokenConnectionType.Hyperlane,
-    token: createMockToken({ ...defaultTokenArgs2, ...tokenArgs }),
-    ...args,
-  } as TokenConnection;
-};
 
 beforeEach(() => {
   vi.restoreAllMocks();

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -35,8 +35,15 @@ export function assembleTokensBySymbolChainMap(
   }, {});
 }
 
-export function isValidMultiCollateralToken(originToken: Token, destination: ChainName | IToken) {
-  if (!originToken.collateralAddressOrDenom || !originToken.isCollateralized()) return false;
+export function isValidMultiCollateralToken(
+  originToken: Token | IToken,
+  destination: ChainName | IToken,
+) {
+  if (
+    !originToken.collateralAddressOrDenom ||
+    !TOKEN_COLLATERALIZED_STANDARDS.includes(originToken.standard)
+  )
+    return false;
 
   const destinationToken =
     typeof destination === 'string'

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -1,5 +1,12 @@
 import { IToken, Token, TokenAmount, WarpCore } from '@hyperlane-xyz/sdk';
-import { ProtocolType, errorToString, isNullish, objKeys, toWei } from '@hyperlane-xyz/utils';
+import {
+  ProtocolType,
+  errorToString,
+  fromWei,
+  isNullish,
+  objKeys,
+  toWei,
+} from '@hyperlane-xyz/utils';
 import {
   AccountInfo,
   ChevronIcon,
@@ -644,15 +651,13 @@ async function validateForm(
     }
 
     const transferToken = await getTransferToken(warpCore, token, destinationToken);
-
     const amountWei = toWei(amount, transferToken.decimals);
-
-    const multiCollateralLimit = isMultiCollateralLimitExceeded(token, destinationToken, amount);
+    const multiCollateralLimit = isMultiCollateralLimitExceeded(token, destination, amountWei);
 
     if (multiCollateralLimit) {
       return [
         {
-          amount: `Transfer limit is ${multiCollateralLimit} ${token.symbol}`,
+          amount: `Transfer limit is ${fromWei(multiCollateralLimit.toString(), token.decimals)} ${token.symbol}`,
         },
         null,
       ];

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -29,6 +29,7 @@ import { ChainSelectField } from '../chains/ChainSelectField';
 import { ChainWalletWarning } from '../chains/ChainWalletWarning';
 import { useChainDisplayName, useMultiProvider } from '../chains/hooks';
 import { getNumRoutesWithSelectedChain, tryGetValidChainName } from '../chains/utils';
+import { isMultiCollateralLimitExceeded } from '../limits/utils';
 import { useIsAccountSanctioned } from '../sanctions/hooks/useIsAccountSanctioned';
 import { useStore } from '../store';
 import { SelectOrInputTokenIds } from '../tokens/SelectOrInputTokenIds';
@@ -645,6 +646,18 @@ async function validateForm(
     const transferToken = await getTransferToken(warpCore, token, destinationToken);
 
     const amountWei = toWei(amount, transferToken.decimals);
+
+    const multiCollateralLimit = isMultiCollateralLimitExceeded(token, destinationToken, amount);
+
+    if (multiCollateralLimit) {
+      return [
+        {
+          amount: `Transfer limit is ${multiCollateralLimit} ${token.symbol}`,
+        },
+        null,
+      ];
+    }
+
     const { address, publicKey: senderPubKey } = getAccountAddressAndPubKey(
       warpCore.multiProvider,
       origin,

--- a/src/features/transfer/maxAmount.ts
+++ b/src/features/transfer/maxAmount.ts
@@ -5,6 +5,7 @@ import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
+import { isMultiCollateralLimitExceeded } from '../limits/utils';
 import { useWarpCore } from '../tokens/hooks';
 
 interface FetchMaxParams {
@@ -39,6 +40,15 @@ async function fetchMaxAmount(
       sender: address,
       senderPubKey: await publicKey,
     });
+
+    const multiCollateralLimitExceeded = isMultiCollateralLimitExceeded(
+      maxAmount.token,
+      destination,
+      maxAmount.amount.toString(),
+    );
+    if (multiCollateralLimitExceeded)
+      return new TokenAmount(multiCollateralLimitExceeded, maxAmount.token);
+
     return maxAmount;
   } catch (error) {
     logger.warn('Error fetching fee quotes for max amount', error);

--- a/src/features/transfer/maxAmount.ts
+++ b/src/features/transfer/maxAmount.ts
@@ -41,13 +41,12 @@ async function fetchMaxAmount(
       senderPubKey: await publicKey,
     });
 
-    const multiCollateralLimitExceeded = isMultiCollateralLimitExceeded(
+    const multiCollateralLimit = isMultiCollateralLimitExceeded(
       maxAmount.token,
       destination,
       maxAmount.amount.toString(),
     );
-    if (multiCollateralLimitExceeded)
-      return new TokenAmount(multiCollateralLimitExceeded, maxAmount.token);
+    if (multiCollateralLimit) return new TokenAmount(multiCollateralLimit, maxAmount.token);
 
     return maxAmount;
   } catch (error) {

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -1,0 +1,41 @@
+import {
+  TestChainName,
+  Token,
+  TokenArgs,
+  TokenConnection,
+  TokenConnectionType,
+  TokenStandard,
+} from '@hyperlane-xyz/sdk';
+
+export const mockCollateralAddress = '0xabc';
+export const addressZero = '0x0000000000000000000000000000000000000000';
+
+export const defaultTokenArgs: TokenArgs = {
+  chainName: TestChainName.test1,
+  standard: TokenStandard.EvmHypCollateral,
+  addressOrDenom: addressZero,
+  decimals: 6,
+  symbol: 'FAKE',
+  name: 'Fake Token',
+  collateralAddressOrDenom: mockCollateralAddress,
+};
+
+export const defaultTokenArgs2: TokenArgs = {
+  ...defaultTokenArgs,
+  chainName: TestChainName.test2,
+};
+
+export const createMockToken = (args?: Partial<TokenArgs>) => {
+  return new Token({ ...defaultTokenArgs, ...args });
+};
+
+export const createTokenConnectionMock = (
+  args?: Partial<TokenConnection>,
+  tokenArgs?: Partial<TokenArgs>,
+): TokenConnection => {
+  return {
+    type: TokenConnectionType.Hyperlane,
+    token: createMockToken({ ...defaultTokenArgs2, ...tokenArgs }),
+    ...args,
+  } as TokenConnection;
+};


### PR DESCRIPTION
This PR adds limit to certain multi-collateral routes 

fixes [ENG-1699](https://linear.app/hyperlane-xyz/issue/ENG-1699/limit-transfer-size-of-a-route-on-the-ui)

- Sets limit to multi-collateral tokens that matches symbol, origin and destination with the array `multiCollateralTokenLimits`
- Create tests for this
- Form validation now includes a message if this limit is exceeded
- Pressing Max button will instead now set the given limits if it exists and exceeds the account current balance
- Move mocks creation functions to its own file

You can currently test this by sending USDC from Arbitrum <> Optimism, the max transfer amount is 1 USDC as a test