### PR TITLE
chore: Bump registry to v17.5.0 and add taiko warp route

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "17.4.0",
+    "@hyperlane-xyz/registry": "17.5.0",
     "@hyperlane-xyz/sdk": "13.2.1",
     "@hyperlane-xyz/utils": "13.2.1",
     "@hyperlane-xyz/widgets": "13.2.1",

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -251,4 +251,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // adraSOL
   'adraSOL/solanamainnet-sonicsvm',
+
+  // TAIKO
+  'TAIKO/taiko',
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4699,14 +4699,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hyperlane-xyz/registry@npm:17.4.0":
-  version: 17.4.0
-  resolution: "@hyperlane-xyz/registry@npm:17.4.0"
+"@hyperlane-xyz/registry@npm:17.5.0":
+  version: 17.5.0
+  resolution: "@hyperlane-xyz/registry@npm:17.5.0"
   dependencies:
     jszip: "npm:^3.10.1"
     yaml: "npm:2.4.5"
     zod: "npm:^3.21.2"
-  checksum: 10/4899eb332087c814e61d46d2b502aaff01251f85254a92ba26c7be412d12c52f4824238cec2a2a8ce55f4a74a0041c505b75a21a9720ae9ee49a7453b73a7af1
+  checksum: 10/43bd8958b0b130c0975003955c64f5a01b3def442d605a7374bbfaf9630f145458e436a6dcf688aa67d962dd15ad4662bc747517dc7090a99d1945f69b239349
   languageName: node
   linkType: hard
 
@@ -4786,7 +4786,7 @@ __metadata:
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
     "@headlessui/react": "npm:^2.2.0"
-    "@hyperlane-xyz/registry": "npm:17.4.0"
+    "@hyperlane-xyz/registry": "npm:17.5.0"
     "@hyperlane-xyz/sdk": "npm:13.2.1"
     "@hyperlane-xyz/utils": "npm:13.2.1"
     "@hyperlane-xyz/widgets": "npm:13.2.1"


### PR DESCRIPTION
This PR bumps registry to v17.5.0 and add taiko warp route