### PR TITLE
chore: update warp route white list test to include github registry

### DIFF
--- a/src/consts/warpRouteWhitelist.test.ts
+++ b/src/consts/warpRouteWhitelist.test.ts
@@ -1,10 +1,23 @@
-import { warpRouteConfigs } from '@hyperlane-xyz/registry';
+import {
+  GithubRegistry,
+  warpRouteConfigs as publishedWarpRouteConfigs,
+} from '@hyperlane-xyz/registry';
+import { WarpCoreConfig } from '@hyperlane-xyz/sdk';
 import { objKeys } from '@hyperlane-xyz/utils';
 import { assert, test } from 'vitest';
 import { warpRouteWhitelist } from './warpRouteWhitelist';
 
-test('warpRouteWhitelist', () => {
+test('warpRouteWhitelist', async () => {
   if (!warpRouteWhitelist) return;
+
+  const registry = new GithubRegistry();
+  let warpRouteConfigs: Record<string, WarpCoreConfig>;
+
+  try {
+    warpRouteConfigs = await registry.getWarpRoutes();
+  } catch {
+    warpRouteConfigs = publishedWarpRouteConfigs;
+  }
 
   const uppercaseConfigKeys = new Set(objKeys(warpRouteConfigs).map((key) => key.toUpperCase()));
   for (const id of warpRouteWhitelist) {

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -2,7 +2,7 @@
 // Warp Route IDs use format `SYMBOL/chainname1-chainname2...` where chains are ordered alphabetically
 // If left null, all warp routes in the configured registry will be included
 // If set to a list (including an empty list), only the specified routes will be included
-export const warpRouteWhitelist: Array<string> | null = ["SOLX/nitro"];
+export const warpRouteWhitelist: Array<string> | null = null;
 // Example:
 // [
 //   // 'ETH/ethereum-viction'

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -2,7 +2,7 @@
 // Warp Route IDs use format `SYMBOL/chainname1-chainname2...` where chains are ordered alphabetically
 // If left null, all warp routes in the configured registry will be included
 // If set to a list (including an empty list), only the specified routes will be included
-export const warpRouteWhitelist: Array<string> | null = null;
+export const warpRouteWhitelist: Array<string> | null = ["SOLX/nitro"];
 // Example:
 // [
 //   // 'ETH/ethereum-viction'


### PR DESCRIPTION
Now instead of only relying on published warp routes, it will first attempt to fetch warp routes from the registry for the warp route white list test