### PR TITLE
chore: add limits to USDC multi-collateral route

### DIFF
--- a/src/features/limits/const.ts
+++ b/src/features/limits/const.ts
@@ -1,3 +1,9 @@
 import { RouteLimit } from './types';
 
-export const multiCollateralTokenLimits: RouteLimit[] = [];
+export const multiCollateralTokenLimits: RouteLimit[] = [
+  {
+    amountWei: 1000000000n,
+    chains: ['arbitrum', 'base', 'ethereum', 'optimism'],
+    symbol: 'USDC',
+  },
+];


### PR DESCRIPTION
Add `1000 USDC` as a limit to multi-collateral routes for `arbitrum`, `base`, `ethereum` and `optimism`. These chains match the collateral chains from `USDC/lumia` route