### PR TITLE
chore: increase limit for USDC

### DIFF
--- a/src/features/limits/const.ts
+++ b/src/features/limits/const.ts
@@ -2,7 +2,7 @@ import { RouteLimit } from './types';
 
 export const multiCollateralTokenLimits: RouteLimit[] = [
   {
-    amountWei: 5000000000n, // 1000 USDC
+    amountWei: 5000000000n, // 5000 USDC
     chains: ['arbitrum', 'base', 'ethereum', 'optimism'],
     symbol: 'USDC',
   },

--- a/src/features/limits/const.ts
+++ b/src/features/limits/const.ts
@@ -2,7 +2,7 @@ import { RouteLimit } from './types';
 
 export const multiCollateralTokenLimits: RouteLimit[] = [
   {
-    amountWei: 1000000000n,
+    amountWei: 5000000000n, // 1000 USDC
     chains: ['arbitrum', 'base', 'ethereum', 'optimism'],
     symbol: 'USDC',
   },


### PR DESCRIPTION
Increase limit to 5000 USDC for multi-collateral USDC routes