### PR TITLE
chore: add seda route to whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -276,4 +276,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // RCADE route
   'RCADE/arbitrum-bsc',
+
+  // SEDA
+  'SEDA/base-ethereum',
 ];


### PR DESCRIPTION
Include `SEDA/base-ethereum` to nexus

[base -> ethereum](https://explorer.hyperlane.xyz/message/0xb37bee8572082838db97f88b11f315cb59f67269075259187832ba1dc4ac5015)
[ethereum -> base](https://explorer.hyperlane.xyz/message/0x8115bd726f8658b3e19d67f0e307bb50156586d33eabe338b693e8fbdde95601)