### PR TITLE
feat: Update webpack config to ignore fs and path

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -68,11 +68,18 @@ const securityHeaders = [
 ];
 
 const nextConfig = {
-  webpack(config) {
+  webpack(config, { isServer }) {
     config.module.rules.push({
       test: /\.ya?ml$/,
       use: 'yaml-loader',
     });
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+        path: false,
+      };
+    }
     return config;
   },
 


### PR DESCRIPTION
The idea with this update is to allow fs in the sdk without any "tricks" as done in the Registry, namely adding this in the SDK package.json:
```
...
"exports": {
    ".": "./dist/index.js",
    "./fs": "./dist/fs/index.js"
  },
```

Since "Webpack 5 no longer polyfills Node.js core modules automatically which means if you use them in your code running in browsers or alike, you will have to install compatible modules from npm and include them yourself". 
 
According to GPT, using `false` for a module tells webpack that if it fails to find `fs` or `path`, then it should not throw. It instead returns an empty object. 

Since we do not intend to call these node modules, this should be fine. 

Sources:
- https://webpack.js.org/configuration/resolve/#resolvefallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved client-side build configuration to prevent unnecessary inclusion of certain Node.js modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->