### PR TITLE
fix: patch starknekit with ready wallet name update

### DIFF
--- a/.yarn/patches/starknetkit-npm-2.6.1-61cd76646d.patch
+++ b/.yarn/patches/starknetkit-npm-2.6.1-61cd76646d.patch
@@ -1,0 +1,22 @@
+diff --git a/dist/starknetkit.js b/dist/starknetkit.js
+index 9fee9301ba99263b32be70b492787671eb9a2d26..6cfeb4756cdb7e2ddcd39f3b292d0b123fc56a2b 100644
+--- a/dist/starknetkit.js
++++ b/dist/starknetkit.js
+@@ -4563,7 +4563,7 @@ const mapModalWallets = ({
+     if (d) {
+       const g = d.id === "argentX" ? { light: ARGENT_X_ICON, dark: ARGENT_X_ICON } : isString(d.icon) ? { light: d.icon, dark: d.icon } : d.icon;
+       return {
+-        name: d.name,
++        name: d.id === "argentX" ? "Ready Wallet (formerly Argent)" : d.name,
+         id: d.id,
+         icon: g,
+         connector: c
+@@ -4575,7 +4575,7 @@ const mapModalWallets = ({
+     if (m) {
+       const { downloads: g } = m, p = m.id === "argentX" ? ARGENT_X_ICON : m.icon;
+       return {
+-        name: m.name,
++        name: m.id === "argentX" ? "Ready Wallet (formerly Argent)" : m.name,
+         id: m.id,
+         icon: { light: p, dark: p },
+         connector: c,

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-toastify": "^10.0.6",
-    "starknetkit": "2.6.1",
+    "starknetkit": "patch:starknetkit@npm%3A2.6.1#~/.yarn/patches/starknetkit-npm-2.6.1-61cd76646d.patch",
     "viem": "^2.21.41",
     "wagmi": "^2.12.26",
     "zod": "3.21.4",
@@ -108,6 +108,7 @@
     "lit-html": "2.8.0",
     "react-fast-compare": "^3.2",
     "viem": "^2.21.41",
-    "zustand": "^4.4"
+    "zustand": "^4.4",
+    "starknetkit@npm:2.6.1": "patch:starknetkit@npm%3A2.6.1#~/.yarn/patches/starknetkit-npm-2.6.1-61cd76646d.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4820,7 +4820,7 @@ __metadata:
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     react-toastify: "npm:^10.0.6"
-    starknetkit: "npm:2.6.1"
+    starknetkit: "patch:starknetkit@npm%3A2.6.1#~/.yarn/patches/starknetkit-npm-2.6.1-61cd76646d.patch"
     tailwindcss: "npm:^3.4.15"
     ts-node: "npm:^10.9.2"
     typescript: "npm:5.6.3"
@@ -24612,6 +24612,29 @@ __metadata:
   peerDependencies:
     starknet: ^6.9.0
   checksum: 10/fa4302296999604134810f56951d3e016d6425dbbf1d08eea8cb2c16d4c64d62e240f874ea1418df3aa187fab02b32540b8c4b416f5334a711645da2dc59bb12
+  languageName: node
+  linkType: hard
+
+"starknetkit@patch:starknetkit@npm%3A2.6.1#~/.yarn/patches/starknetkit-npm-2.6.1-61cd76646d.patch":
+  version: 2.6.1
+  resolution: "starknetkit@patch:starknetkit@npm%3A2.6.1#~/.yarn/patches/starknetkit-npm-2.6.1-61cd76646d.patch::version=2.6.1&hash=c82884"
+  dependencies:
+    "@starknet-io/get-starknet": "npm:^4.0.4"
+    "@starknet-io/get-starknet-core": "npm:^4.0.4"
+    "@starknet-io/types-js": "npm:^0.7.7"
+    "@trpc/client": "npm:^10.38.1"
+    "@trpc/server": "npm:^10.38.1"
+    "@walletconnect/sign-client": "npm:^2.11.0"
+    bowser: "npm:^2.11.0"
+    detect-browser: "npm:^5.3.0"
+    eventemitter3: "npm:^5.0.1"
+    events: "npm:^3.3.0"
+    lodash-es: "npm:^4.17.21"
+    svelte-forms: "npm:^2.3.1"
+    trpc-browser: "npm:^1.3.2"
+  peerDependencies:
+    starknet: ^6.9.0
+  checksum: 10/f6ab123907deefee9e1571d0f401316f1e049dc0520d54986159ad831178e6aeed0914e07f6bfc85b67eb3d2d716ce3ef635995193bfb673334f2d76f5821f80
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Now shows Ready Wallet (formerly Argent) properly with the patch update for starknekit
<img width="445" height="492" alt="image" src="https://github.com/user-attachments/assets/def840ec-4062-48f9-ac48-25d1a2b327fe" />
