### PR TITLE
fix: remove auto switch to Base network when connecting wallet

### DIFF
--- a/src/features/wallet/context/EvmWalletContext.tsx
+++ b/src/features/wallet/context/EvmWalletContext.tsx
@@ -1,5 +1,4 @@
 import { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
 import { getWagmiChainConfigs } from '@hyperlane-xyz/widgets';
 import { RainbowKitProvider, connectorsForWallets, lightTheme } from '@rainbow-me/rainbowkit';
 import '@rainbow-me/rainbowkit/styles.css';
@@ -21,7 +20,6 @@ import { APP_NAME } from '../../../consts/app';
 import { config } from '../../../consts/config';
 import { Color } from '../../../styles/Color';
 import { useMultiProvider } from '../../chains/hooks';
-import { useWarpCore } from '../../tokens/hooks';
 
 function initWagmi(multiProvider: MultiProtocolProvider) {
   const chains = getWagmiChainConfigs(multiProvider);
@@ -55,15 +53,7 @@ function initWagmi(multiProvider: MultiProtocolProvider) {
 
 export function EvmWalletContext({ children }: PropsWithChildren<unknown>) {
   const multiProvider = useMultiProvider();
-  const warpCore = useWarpCore();
-
   const { wagmiConfig } = useMemo(() => initWagmi(multiProvider), [multiProvider]);
-
-  const initialChain = useMemo(() => {
-    const tokens = warpCore.tokens;
-    const firstEvmToken = tokens.filter((token) => token.protocol === ProtocolType.Ethereum)?.[0];
-    return multiProvider.tryGetChainMetadata(firstEvmToken?.chainName)?.chainId as number;
-  }, [multiProvider, warpCore]);
 
   return (
     <WagmiProvider config={wagmiConfig}>
@@ -73,7 +63,6 @@ export function EvmWalletContext({ children }: PropsWithChildren<unknown>) {
           borderRadius: 'small',
           fontStack: 'system',
         })}
-        initialChain={initialChain}
       >
         {children}
       </RainbowKitProvider>


### PR DESCRIPTION
This PR addresses an issue where users are automatically prompted to switch to the Base Mainnet when connecting with their wallet on the Hyperlane Warp bridge UI.

## 📋 Context

When attempting to connect a wallet, users were forced to switch to the Base network regardless of the chain selected, or the previous chain selected in their wallet. 

This is due to the fact that the code of the Hyperlane UI fetches the list of available warp routes, and pass the first origin chain of the first warp route as initial chain to rainbow kit configuration in the wallet connector.

Although Metamask performs the chain switch in the background in the wallet, this still causes confusion for users expecting to use the origin chain from the selected dropdown. For instance when using the Universal Profile browser extension, the user gets automatically prompted to switch network, which leads to confusion.

<img width="3012" height="1646" alt="image" src="https://github.com/user-attachments/assets/b5f95982-8df3-4df1-ad51-620f847ef692" />


https://github.com/user-attachments/assets/114d703d-1cd3-4316-bab8-b51027970a0a



## ✅ Fix

Removed the logic that enforced a network switch to Base on wallet connection. The code now does not provide an initial chain to switch to when connecting. The last network selected in the wallet is now used. Wallets now connect without triggering an automatic network change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed logic related to deriving and passing an initial chain based on Ethereum protocol tokens in wallet context setup. No visible changes to the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->