### PR TITLE
feat: filter tokens with no connections

### DIFF
--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -50,7 +50,7 @@ export async function assembleWarpCoreConfig(
     ...yamlConfig.tokens,
     ...storeOverrideTokens,
   ];
-  const tokens = dedupeTokens(combinedTokens);
+  const tokens = filterUnconnectedToken(dedupeTokens(combinedTokens));
 
   const combinedOptions = [
     ...filteredRegistryOptions,
@@ -97,4 +97,9 @@ function reduceOptions(optionsList: Array<WarpCoreConfig['options']>): WarpCoreC
     }
     return acc;
   }, {});
+}
+
+// Remove tokens that have no connections from the token list
+function filterUnconnectedToken(tokens: WarpCoreConfig['tokens']): WarpCoreConfig['tokens'] {
+  return tokens.filter((token) => token.connections);
 }


### PR DESCRIPTION
Remove tokens that have no connections from the warp core config tokens, with these chains with no connection will not be shown from `assembleChainMetadata`