### PR TITLE
fix: include destination token in token list

### DIFF
--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -2,7 +2,12 @@ import {
   IRegistry,
   warpRouteConfigs as publishedRegistryWarpRoutes,
 } from '@hyperlane-xyz/registry';
-import { WarpCoreConfig, WarpCoreConfigSchema, validateZodResult } from '@hyperlane-xyz/sdk';
+import {
+  TOKEN_STANDARD_TO_PROTOCOL,
+  WarpCoreConfig,
+  WarpCoreConfigSchema,
+  validateZodResult,
+} from '@hyperlane-xyz/sdk';
 import { isObjEmpty, objFilter, objMerge } from '@hyperlane-xyz/utils';
 import { config } from '../../consts/config.ts';
 import { warpRouteWhitelist } from '../../consts/warpRouteWhitelist.ts';
@@ -99,7 +104,27 @@ function reduceOptions(optionsList: Array<WarpCoreConfig['options']>): WarpCoreC
   }, {});
 }
 
-// Remove tokens that have no connections from the token list
+// Remove tokens that have no connections from the token list, but preserve tokens that are destinations
 function filterUnconnectedToken(tokens: WarpCoreConfig['tokens']): WarpCoreConfig['tokens'] {
-  return tokens.filter((token) => token.connections && token.connections.length);
+  const destinationTokenIds = new Set<string>();
+
+  tokens.forEach((token) => {
+    if (token.connections && token.connections.length > 0) {
+      token.connections.forEach((conn) => {
+        destinationTokenIds.add(conn.token);
+      });
+    }
+  });
+
+  // Keep tokens with connections OR tokens that are destinations
+  return tokens.filter((token) => {
+    // Has connections - keep it
+    if (token.connections && token.connections.length > 0) return true;
+
+    const protocol = TOKEN_STANDARD_TO_PROTOCOL[token.standard];
+
+    // Is a destination token - keep it
+    const tokenId = `${protocol}|${token.chainName}|${token.addressOrDenom}`;
+    return destinationTokenIds.has(tokenId);
+  });
 }


### PR DESCRIPTION
Fixes an issue created by this feature https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/701

Removing tokens with no connections would mean that the destination token could be removed and would trigger the assert here: 
https://github.com/hyperlane-xyz/hyperlane-monorepo/blob/288b7799d3cc35bdf60eac632c7015971d6f2021/typescript/sdk/src/warp/WarpCore.ts#L108-L115
And example config would be this, where `sepolia` has no connections but `basesepolia` still needs the token to connect.
```
tokens:
  - addressOrDenom: '0x5c12ADC734699C07b095fe30B8312F1A7bbaA788'
    chainName: basesepolia
    connections:
      - token: ethereum|sepolia|0x95878Fd41bC26f7045C0b98e381c22f010745A75
    decimals: 18
    name: Ether
    standard: EvmHypNative
    symbol: ETH
  - addressOrDenom: '0x95878Fd41bC26f7045C0b98e381c22f010745A75'
    chainName: sepolia
    decimals: 18
    name: Ether
    standard: EvmHypNative
    symbol: ETH
```

The fix will now include tokens that are destination tokens in the list and truly only remove those that have no connections nor dependencies (an example would be some of the chains in `oUSDT/production`)