### PR TITLE
feat: add warnings for smart wallets if bridging to same address on destination chain that is not a smart contract

### DIFF
--- a/src/components/banner/RecipientWarningBanner.tsx
+++ b/src/components/banner/RecipientWarningBanner.tsx
@@ -1,0 +1,49 @@
+import { WarningIcon } from '@hyperlane-xyz/widgets';
+import { useStore } from '../../features/store';
+
+export function RecipientWarningBanner({
+  isVisible,
+  destinationChain,
+}: {
+  isVisible: boolean;
+  destinationChain: string;
+  className?: string;
+}) {
+  const store = useStore();
+
+  return (
+    <div
+      className={`mt-3 gap-2 bg-amber-400 px-4 text-sm ${
+        isVisible ? 'max-h-35 py-2' : 'max-h-0'
+      } overflow-hidden transition-all duration-500`}
+    >
+      <div className="flex items-center gap-3">
+        <WarningIcon width={40} height={40} />
+        <div>
+          <p className="my-2">
+            The recipient address is the same as the currently connected smart contract wallet,{' '}
+            <strong>but it does not exist as a smart contract on {destinationChain}</strong>.
+          </p>
+          <p className="my-2">This may result in losing access to your bridged tokens.</p>
+          <p className="my-2">
+            <strong>
+              Only proceed if you are certain you have control over this address on{' '}
+              {destinationChain}
+            </strong>
+          </p>
+          <div className="justify-left flex w-max gap-2 rounded bg-white/30 px-2.5 py-1 text-center hover:bg-white/50 active:bg-white/60">
+            <input
+              onChange={({ target: { checked } }) => store.setRecipientAddressConfirmed(checked)}
+              type="checkbox"
+              id="confirm-address"
+              name="confirm-recipient"
+            />
+            <label htmlFor="confirm-address">
+              I have control and want to bridge to this address
+            </label>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/banner/RecipientWarningBanner.tsx
+++ b/src/components/banner/RecipientWarningBanner.tsx
@@ -1,47 +1,34 @@
 import { WarningIcon } from '@hyperlane-xyz/widgets';
-import { useStore } from '../../features/store';
 
 export function RecipientWarningBanner({
-  isVisible,
   destinationChain,
+  confirmRecipientHandler,
 }: {
-  isVisible: boolean;
   destinationChain: string;
-  className?: string;
+  confirmRecipientHandler: (checked: boolean) => void;
 }) {
-  const store = useStore();
-
   return (
-    <div
-      className={`mt-3 gap-2 bg-amber-400 px-4 text-sm ${
-        isVisible ? 'max-h-35 py-2' : 'max-h-0'
-      } overflow-hidden transition-all duration-500`}
-    >
-      <div className="flex items-center gap-3">
-        <WarningIcon width={40} height={40} />
-        <div>
-          <p className="my-2">
-            The recipient address is the same as the currently connected smart contract wallet,{' '}
-            <strong>but it does not exist as a smart contract on {destinationChain}</strong>.
-          </p>
-          <p className="my-2">This may result in losing access to your bridged tokens.</p>
-          <p className="my-2">
-            <strong>
-              Only proceed if you are certain you have control over this address on{' '}
-              {destinationChain}
-            </strong>
-          </p>
-          <div className="justify-left flex w-max gap-2 rounded bg-white/30 px-2.5 py-1 text-center hover:bg-white/50 active:bg-white/60">
-            <input
-              onChange={({ target: { checked } }) => store.setRecipientAddressConfirmed(checked)}
-              type="checkbox"
-              id="confirm-address"
-              name="confirm-recipient"
-            />
-            <label htmlFor="confirm-address">
-              I have control and want to bridge to this address
-            </label>
-          </div>
+    <div className="flex items-center gap-3">
+      <WarningIcon width={40} height={40} />
+      <div>
+        <p className="my-2">
+          The recipient address is the same as the currently connected smart contract wallet,{' '}
+          <strong>but it does not exist as a smart contract on {destinationChain}</strong>.
+        </p>
+        <p className="my-2">This may result in losing access to your bridged tokens.</p>
+        <p className="my-2">
+          <strong>
+            Only proceed if you are certain you have control over this address on {destinationChain}
+          </strong>
+        </p>
+        <div className="justify-left flex w-max gap-2 rounded bg-white/30 px-2.5 py-1 text-center hover:bg-white/50 active:bg-white/60">
+          <input
+            onChange={({ target: { checked } }) => confirmRecipientHandler(checked)}
+            type="checkbox"
+            id="confirm-address"
+            name="confirm-recipient"
+          />
+          <label htmlFor="confirm-address">I have control and want to bridge to this address</label>
         </div>
       </div>
     </div>

--- a/src/components/buttons/ConnectAwareSubmitButton.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.tsx
@@ -9,9 +9,15 @@ interface Props {
   chainName: ChainName;
   text: string;
   classes?: string;
+  disabled?: boolean;
 }
 
-export function ConnectAwareSubmitButton<FormValues = any>({ chainName, text, classes }: Props) {
+export function ConnectAwareSubmitButton<FormValues = any>({
+  chainName,
+  text,
+  classes,
+  disabled,
+}: Props) {
   const protocol = useChainProtocol(chainName) || ProtocolType.Ethereum;
   const connectFns = useConnectFns();
   const connectFn = connectFns[protocol];
@@ -40,7 +46,13 @@ export function ConnectAwareSubmitButton<FormValues = any>({ chainName, text, cl
   useTimeout(clearErrors, 3500);
 
   return (
-    <SolidButton type={type} color={color} onClick={onClick} className={classes}>
+    <SolidButton
+      disabled={disabled}
+      type={type}
+      color={color}
+      onClick={onClick}
+      className={classes}
+    >
       {content}
     </SolidButton>
   );

--- a/src/components/buttons/ConnectAwareSubmitButton.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.tsx
@@ -33,7 +33,11 @@ export function ConnectAwareSubmitButton<FormValues = any>({
 
   const color = hasError ? 'red' : 'accent';
   const content = hasError ? firstError : isAccountReady ? text : 'Connect wallet';
-  const type = isAccountReady ? 'submit' : 'button';
+  const type =
+    disabled || !isAccountReady
+      ? 'button' // never submits when deliberately disabled
+      : 'submit';
+
   const onClick = isAccountReady ? undefined : connectFn;
 
   // Automatically clear error state after a timeout

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -63,6 +63,8 @@ export interface AppState {
     options?: { msgId?: string; originTxHash?: string },
   ) => void;
   failUnconfirmedTransfers: () => void;
+  recipientAddressConfirmed: boolean;
+  setRecipientAddressConfirmed: (confirmed: boolean) => void;
 
   // Shared component state
   transferLoading: boolean;
@@ -173,6 +175,10 @@ export const useStore = create<AppState>()(
       showEnvSelectModal: false,
       setShowEnvSelectModal: (showEnvSelectModal) => {
         set(() => ({ showEnvSelectModal }));
+      },
+      recipientAddressConfirmed: true,
+      setRecipientAddressConfirmed: (recipientAddressConfirmed) => {
+        set(() => ({ recipientAddressConfirmed }));
       },
       originChainName: '',
       setOriginChainName: (originChainName: ChainName) => {

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -63,8 +63,6 @@ export interface AppState {
     options?: { msgId?: string; originTxHash?: string },
   ) => void;
   failUnconfirmedTransfers: () => void;
-  recipientAddressConfirmed: boolean;
-  setRecipientAddressConfirmed: (confirmed: boolean) => void;
 
   // Shared component state
   transferLoading: boolean;
@@ -175,10 +173,6 @@ export const useStore = create<AppState>()(
       showEnvSelectModal: false,
       setShowEnvSelectModal: (showEnvSelectModal) => {
         set(() => ({ showEnvSelectModal }));
-      },
-      recipientAddressConfirmed: true,
-      setRecipientAddressConfirmed: (recipientAddressConfirmed) => {
-        set(() => ({ recipientAddressConfirmed }));
       },
       originChainName: '',
       setOriginChainName: (originChainName: ChainName) => {

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -396,11 +396,12 @@ function ButtonSection({
         sourceProtocol !== ProtocolType.Ethereum ||
         destinationProtocol !== ProtocolType.Ethereum
       ) {
+        setRecipientInfos({ showWarning: false, addressConfirmed: true });
         return;
       }
 
       if (!isValidAddressEvm(recipient)) {
-        setRecipientInfos({ showWarning: false, addressConfirmed: false });
+        setRecipientInfos({ showWarning: false, addressConfirmed: true });
         return;
       }
 

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -469,12 +469,13 @@ function ButtonSection({
     setIsReview(false);
     cleanOverrideToken();
   };
+
   if (!isReview) {
     return (
       <>
         <div
           className={`mt-3 gap-2 bg-amber-400 px-4 text-sm ${
-            showWarning ? 'max-h-36 py-2' : 'max-h-0'
+            showWarning ? 'max-h-38 py-2' : 'max-h-0'
           } overflow-hidden transition-all duration-500`}
         >
           <RecipientWarningBanner
@@ -495,25 +496,40 @@ function ButtonSection({
   }
 
   return (
-    <div className="mt-4 flex items-center justify-between space-x-4">
-      <SolidButton
-        type="button"
-        color="primary"
-        onClick={onEdit}
-        className="px-6 py-1.5"
-        icon={<ChevronIcon direction="w" width={10} height={6} color={Color.white} />}
+    <>
+      <div
+        className={`mt-3 gap-2 bg-amber-400 px-4 text-sm ${
+          showWarning ? 'max-h-38 py-2' : 'max-h-0'
+        } overflow-hidden transition-all duration-500`}
       >
-        <span>Edit</span>
-      </SolidButton>
-      <SolidButton
-        type="button"
-        color="accent"
-        onClick={triggerTransactionsHandler}
-        className="flex-1 px-3 py-1.5"
-      >
-        {`Send to ${chainDisplayName}`}
-      </SolidButton>
-    </div>
+        <RecipientWarningBanner
+          destinationChain={chainDisplayName}
+          confirmRecipientHandler={(checked) =>
+            setRecipientInfos((state) => ({ ...state, addressConfirmed: checked }))
+          }
+        />
+      </div>
+      <div className="mt-4 flex items-center justify-between space-x-4">
+        <SolidButton
+          type="button"
+          color="primary"
+          onClick={onEdit}
+          className="px-6 py-1.5"
+          icon={<ChevronIcon direction="w" width={10} height={6} color={Color.white} />}
+        >
+          <span>Edit</span>
+        </SolidButton>
+        <SolidButton
+          disabled={!addressConfirmed}
+          type="button"
+          color="accent"
+          onClick={triggerTransactionsHandler}
+          className="flex-1 px-3 py-1.5"
+        >
+          {`Send to ${chainDisplayName}`}
+        </SolidButton>
+      </div>
+    </>
   );
 }
 

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -6,6 +6,7 @@ import {
   errorToString,
   fromWei,
   isNullish,
+  isValidAddressEvm,
   objKeys,
   toWei,
 } from '@hyperlane-xyz/utils';
@@ -24,7 +25,6 @@ import BigNumber from 'bignumber.js';
 import { Form, Formik, useFormikContext } from 'formik';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
-import { isAddress } from 'viem';
 import { RecipientWarningBanner } from '../../components/banner/RecipientWarningBanner';
 import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareSubmitButton';
 import { SolidButton } from '../../components/buttons/SolidButton';
@@ -399,7 +399,7 @@ function ButtonSection({
         return;
       }
 
-      if (!isAddress(recipient)) {
+      if (!isValidAddressEvm(recipient)) {
         setRecipientInfos({ showWarning: false, addressConfirmed: false });
         return;
       }

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -24,6 +24,7 @@ import BigNumber from 'bignumber.js';
 import { Form, Formik, useFormikContext } from 'formik';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
+import { isAddress } from 'viem';
 import { RecipientWarningBanner } from '../../components/banner/RecipientWarningBanner';
 import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareSubmitButton';
 import { SolidButton } from '../../components/buttons/SolidButton';
@@ -395,6 +396,11 @@ function ButtonSection({
         sourceProtocol !== ProtocolType.Ethereum ||
         destinationProtocol !== ProtocolType.Ethereum
       ) {
+        return;
+      }
+
+      if (!isAddress(recipient)) {
+        setRecipientInfos({ showWarning: false, addressConfirmed: false });
         return;
       }
 

--- a/src/features/transfer/utils.ts
+++ b/src/features/transfer/utils.ts
@@ -76,7 +76,8 @@ import {
   ProviderType,
   TypedTransactionReceipt,
 } from '@hyperlane-xyz/sdk';
-import { getAddress, isAddress } from 'viem';
+import { isValidAddressEvm } from '@hyperlane-xyz/utils';
+import { getAddress } from 'viem';
 import { logger } from '../../utils/logger';
 import { getChainDisplayName } from '../chains/utils';
 
@@ -137,7 +138,7 @@ export async function isSmartContract(
   chain: string,
   address: string,
 ): Promise<{ isContract: boolean; error?: string }> {
-  if (!isAddress(address)) {
+  if (!isValidAddressEvm(address)) {
     return { isContract: false };
   }
 

--- a/src/features/transfer/utils.ts
+++ b/src/features/transfer/utils.ts
@@ -76,7 +76,7 @@ import {
   ProviderType,
   TypedTransactionReceipt,
 } from '@hyperlane-xyz/sdk';
-import { getAddress } from 'viem';
+import { getAddress, isAddress } from 'viem';
 import { logger } from '../../utils/logger';
 import { getChainDisplayName } from '../chains/utils';
 
@@ -137,7 +137,7 @@ export async function isSmartContract(
   chain: string,
   address: string,
 ): Promise<{ isContract: boolean; error?: string }> {
-  if (!address) {
+  if (!isAddress(address)) {
     return { isContract: false };
   }
 


### PR DESCRIPTION
# Context

When users bridge tokens between chains (e.g. from Base to Ethereum) using a smart contract wallet, they might enter their own wallet address as the recipient on the destination chain.

But if that smart wallet is only deployed on the source chain (e.g. Base ✅) and not on the destination chain (e.g. Ethereum ❌), there's no contract on the destination side to control the funds.

This can result in the user loosing its bridged tokens, as they cannot be accessed on the destination chain in this scenario, **since the smart contract wallet is not deployed on the destination chain**.



# ☑️ How does this PR mitigates this issue?

This PR prevents accidental loss by checking the bytecode at the recipient address on the destination chain, if a smart contract wallet is connected to the UI and the same recipient address is used.

# 🔄 Flow

1. User connects a smart contract wallet to the dApp.
2. They select the source/destination chain, token, and enter an amount to bridge.
2. They enter their own wallet address as the recipient.

Then the app checks:

- ✅ Is the connected wallet a smart contract? _Yes_
- ✅ Is the recipient address the same? _Yes_
- ❌ Is there any bytecode at that address on the destination chain? Is it a smart contract at that address on the destination chain? _No_

> If so, the "Continue" button is disabled and a warning message is shown.
> The user can tick a checkbox to proceed only if they are sure they can control the recipient address on the destination chain.

<img width="1328" height="1564" alt="image" src="https://github.com/user-attachments/assets/ff9d710e-f1bd-4a14-abaf-9831c1485986" />

# Demo

https://github.com/user-attachments/assets/562da9bb-64e9-4601-b48b-5784811fc70b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recipient warning banner for Ethereum→Ethereum transfers with explanatory text and a confirmation checkbox that gates submission.
  * Submit button disabled until the user confirms control of the recipient address.
  * On-chain contract checks and friendly chain names with clear error feedback; wallet disconnect hides the banner and resets confirmation.

* **Bug Fixes**
  * Reduces accidental transfers by blocking submission until recipient ownership is confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->