### PR TITLE
chore: add USDT/matchain to Nexus

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -48,13 +48,14 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/matchain',
 
   // USDT routes
-  'USDT/ethereum-inevm',
-  'USDT/ethereum-viction',
   'USDT/eclipsemainnet-ethereum-solanamainnet',
   'USDT/ethereum-form',
   'USDT/ethereum-hyperevm',
-  'USDT/solanamainnet-sonicsvm',
+  'USDT/ethereum-inevm',
   'USDT/ethereum-lumiaprism',
+  'USDT/ethereum-viction',
+  'USDT/matchain',
+  'USDT/solanamainnet-sonicsvm',
 
   // oUSDT routes
   'oUSDT/production',


### PR DESCRIPTION
This PR adds USDC/matchain to the Nexus whitelist.

The diffs looks bigger because it's also sorting all USDT routes alphabetically.