### PR TITLE
feat: multi-collateral warp routes maxTransfer

### DIFF
--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -730,15 +730,15 @@ async function validateForm(
       origin,
       accounts,
     );
+    const amountWei = toWei(amount, token.decimals);
     const transferToken = await getLowestFeeTransferToken(
       warpCore,
       token,
       destinationToken,
-      values.amount,
-      values.recipient,
+      amountWei,
+      recipient,
       sender,
     );
-    const amountWei = toWei(amount, transferToken.decimals);
     const multiCollateralLimit = isMultiCollateralLimitExceeded(token, destination, amountWei);
 
     if (multiCollateralLimit) {

--- a/src/features/transfer/fees.ts
+++ b/src/features/transfer/fees.ts
@@ -61,7 +61,7 @@ export async function getLowestFeeTransferToken(
   warpCore: WarpCore,
   originToken: Token,
   destinationToken: IToken,
-  amount: string,
+  amounWei: string,
   recipient: string,
   sender: string | undefined,
 ) {
@@ -85,12 +85,12 @@ export async function getLowestFeeTransferToken(
   const feeResults = await Promise.allSettled(
     tokensWithSameCollateralAddresses.map(async ({ originToken, destinationToken }) => {
       try {
-        const originTokenAmount = new TokenAmount(amount, originToken);
+        const originTokenAmount = new TokenAmount(amounWei, originToken);
         const fees = await warpCore.getInterchainTransferFee({
           originTokenAmount,
           destination: destinationToken.chainName,
           recipient,
-          sender,
+          sender: sender,
         });
         return { token: originToken, fees };
       } catch {

--- a/src/features/transfer/fees.ts
+++ b/src/features/transfer/fees.ts
@@ -90,7 +90,7 @@ export async function getLowestFeeTransferToken(
           originTokenAmount,
           destination: destinationToken.chainName,
           recipient,
-          sender: sender,
+          sender,
         });
         return { token: originToken, fees };
       } catch {

--- a/src/features/transfer/useFeeQuotes.ts
+++ b/src/features/transfer/useFeeQuotes.ts
@@ -8,7 +8,7 @@ import { useWarpCore } from '../tokens/hooks';
 import { getLowestFeeTransferToken } from './fees';
 import { TransferFormValues } from './types';
 
-const FEE_QUOTE_REFRESH_INTERVAL = 15_000; // 10s
+const FEE_QUOTE_REFRESH_INTERVAL = 30_000; // 30s
 
 export function useFeeQuotes(
   { destination, amount, recipient, tokenIndex }: TransferFormValues,
@@ -72,6 +72,7 @@ async function fetchFeeQuotes(
 ): Promise<WarpCoreFeeEstimate | null> {
   if (!originToken || !destination || !sender || !originToken || !amount || !recipient) return null;
   let transferToken = originToken;
+  const amountWei = toWei(amount, transferToken.decimals);
 
   // when true attempt to get route with lowest fee
   if (searchForLowestFee) {
@@ -81,14 +82,13 @@ async function fetchFeeQuotes(
         warpCore,
         originToken,
         destinationToken,
-        amount,
+        amountWei,
         recipient,
         sender,
       );
     }
   }
 
-  const amountWei = toWei(amount, transferToken.decimals);
   const originTokenAmount = transferToken.amount(amountWei);
   logger.debug('Fetching fee quotes');
   return warpCore.estimateTransferRemoteFees({


### PR DESCRIPTION
This PR allows the maxTransfer button to check for route with lowest fee before setting the amount

- Gets route with lowest fee for max transfer button
- Fixed a bug where `getLowestFeeTransferToken` would use plain `amount` instead of `amountWei`