### PR TITLE
chore: enable hyperlane explorer link after tx in nexus

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -37,7 +37,7 @@ interface Config {
 export const config: Config = Object.freeze({
   addressBlacklist: ADDRESS_BLACKLIST.map((address) => address.toLowerCase()),
   chainWalletWhitelists,
-  enableExplorerLink: false,
+  enableExplorerLink: true,
   defaultOriginChain: 'ethereum',
   defaultDestinationChain: 'bsc',
   isDevMode,


### PR DESCRIPTION
Now allows nexus to show a link to hyperlane explorer after txs