### PR TITLE
fix: switch network on origin chain change

### DIFF
--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -19,11 +19,12 @@ import {
   getAccountAddressAndPubKey,
   useAccountAddressForChain,
   useAccounts,
+  useEthereumSwitchNetwork,
   useModal,
 } from '@hyperlane-xyz/widgets';
 import BigNumber from 'bignumber.js';
 import { Form, Formik, useFormikContext } from 'formik';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 import { RecipientWarningBanner } from '../../components/banner/RecipientWarningBanner';
 import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareSubmitButton';
@@ -205,12 +206,15 @@ function SwapChainsButton({
 
 function ChainSelectSection({ isReview }: { isReview: boolean }) {
   const warpCore = useWarpCore();
+  const multiProvider = useMultiProvider();
 
-  const { setOriginChainName } = useStore((s) => ({
+  const { setOriginChainName, originChainName } = useStore((s) => ({
     setOriginChainName: s.setOriginChainName,
+    originChainName: s.originChainName,
   }));
 
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
+  const { switchNetwork } = useEthereumSwitchNetwork(multiProvider);
 
   const { originToken, destinationToken } = useMemo(() => {
     const originToken = getTokenByIndex(warpCore, values.tokenIndex);
@@ -242,6 +246,21 @@ function ChainSelectSection({ isReview }: { isReview: boolean }) {
     setTokenOnChainChange(origin, destination);
     setOriginChainName(origin);
   };
+
+  const handleSwitchNetwork = useCallback(
+    async (chainName: ChainName) => {
+      try {
+        await switchNetwork(chainName);
+      } catch (err) {
+        logger.error('failed to switch network', err);
+      }
+    },
+    [switchNetwork],
+  );
+
+  useEffect(() => {
+    handleSwitchNetwork(originChainName);
+  }, [originChainName, handleSwitchNetwork]);
 
   return (
     <div className="mt-2 flex items-center justify-between gap-4">


### PR DESCRIPTION
Temporal fix for switching network when origin chain changes. 

`WalletConnect` requires the app to be on the same network as the app it is trying to connect to. In the case of the Warp UI, it uses the default network until a transaction it's triggered where `switchNetwork` is called, that is why it is not able to approve a connection from WalletConnect that has a different network than the UI.

This changes makes it so that whenever a chain is selected it will trigger `switchNetwork` instead of waiting for a transaction to happen first. 