### PR TITLE
fix: return token with enough collateral if no fee token found

### DIFF
--- a/src/features/transfer/fees.ts
+++ b/src/features/transfer/fees.ts
@@ -131,7 +131,8 @@ export async function getLowestFeeTransferToken(
       tokenFees.push({ token: result.value.token, tokenFee: result.value.fees.tokenFeeQuote });
     }
   }
-  if (!tokenFees.length) return originToken;
+  // if no token was found with fees, just return the first token with enough collateral
+  if (!tokenFees.length) return tokenBalances[0].originToken;
 
   // sort by token fees, no fees routes take precedence, then lowest fee to highest
   tokenFees.sort((a, b) => {


### PR DESCRIPTION
Fixed an issue where it would return the originToken if no token with fees was found instead of tokens that have enough collateral to bridge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback token selection logic for transfers when no fee-enabled routes are available. The system now prioritizes selecting from available token balances instead of defaulting to the original token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->