### PR TITLE
chore: fallback to published chain metadata

### DIFF
--- a/src/features/chains/metadata.ts
+++ b/src/features/chains/metadata.ts
@@ -38,8 +38,16 @@ export async function assembleChainMetadata(
 
   let registryChainMetadata: ChainMap<ChainMetadata>;
   if (config.registryUrl) {
-    logger.debug('Using custom registry chain metadata from:', config.registryUrl);
-    registryChainMetadata = await registry.getMetadata();
+    try {
+      logger.debug('Using custom registry chain metadata from:', config.registryUrl);
+      registryChainMetadata = await registry.getMetadata();
+    } catch {
+      logger.debug(
+        'Failed fetching chain metadata from GH registry, using published registry',
+        config.registryUrl,
+      );
+      registryChainMetadata = publishedChainMetadata;
+    }
   } else {
     logger.debug('Using default published registry for chain metadata');
     registryChainMetadata = publishedChainMetadata;


### PR DESCRIPTION
This was already done for warp route data but not chain metadata