### PR TITLE
feat: search by collateral address

### DIFF
--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -130,7 +130,8 @@ export function TokenList({
         return (
           t.token.name.toLowerCase().includes(q) ||
           t.token.symbol.toLowerCase().includes(q) ||
-          t.token.addressOrDenom.toLowerCase().includes(q)
+          t.token.addressOrDenom.toLowerCase().includes(q) ||
+          t.token.collateralAddressOrDenom?.toLowerCase().includes(q)
         );
       })
       // Hide/show disabled tokens
@@ -143,11 +144,14 @@ export function TokenList({
     const tokenSymbols = tokens.map((item) => item.token.symbol);
     const q = searchQuery?.trim().toLowerCase();
     return objFilter(tokensBySymbolChainMap, (symbol, value): value is TokenChainMap => {
+      const token = value.tokenInformation;
       return (
         !tokenSymbols.includes(symbol) &&
         (q === '' ||
-          value.tokenInformation.name.toLowerCase().includes(q) ||
-          value.tokenInformation.symbol.toLowerCase().includes(q))
+          token.name.toLowerCase().includes(q) ||
+          token.symbol.toLowerCase().includes(q) ||
+          token.collateralAddressOrDenom?.toLowerCase().includes(q) ||
+          token.addressOrDenom.toLowerCase().includes(q))
       );
     });
   }, [tokens, tokensBySymbolChainMap, searchQuery]);


### PR DESCRIPTION
This PR update TokenListModal to:

- Search by token `collateralAddressOrDenom`
- Include both `addressOrDenom` and `collateralAddressOrDenom` to unsupported token list search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token search functionality with expanded filtering criteria, allowing users to discover tokens using additional identifiers beyond name and symbol search.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->