### PR TITLE
fix: temporary check m0 standard for dedupeTokens

### DIFF
--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -120,7 +120,7 @@ function dedupeTokens(tokens: WarpCoreConfig['tokens']): WarpCoreConfig['tokens'
     let id = '';
     // Temporary fix issue for M0 routes where addressOrDenom can be the same
     if (token.standard === TokenStandard.EvmM0PortalLite) {
-      id = id = `${token.chainName}|${token.symbol}|${token.addressOrDenom?.toLowerCase()}`;
+      id = `${token.chainName}|${token.symbol}|${token.addressOrDenom?.toLowerCase()}`;
     } else {
       id = `${token.chainName}|${token.addressOrDenom?.toLowerCase()}`;
     }


### PR DESCRIPTION
Using the current version of the `dedupeToken` causes `WarpCore.findToken()` to fail because it returns two results from the `gasAddressOrDenom` returned from the adapter, this temporary fix the issue by separating m0 tokens `dedupeToken` id as I figured out the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token deduplication so M0 Portal Lite tokens are distinguished from other token types (uses token symbol plus chain to avoid collisions when address/denom overlaps).  

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->