### PR TITLE
chore: deprecate injective by removing from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: ci
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [main, nautilus, nexus, injective, trump, ousdt]
+    branches: [main, nexus, trump, ousdt]
   pull_request:
-    branches: [main, nautilus, nexus, injective, trump, ousdt]
+    branches: [main, nexus, trump, ousdt]
   merge_group:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/create-merge-prs.yaml
+++ b/.github/workflows/create-merge-prs.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        name: [injective, nexus, trump, ousdt]
+        name: [nexus, trump, ousdt]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Remove injective (and nautilus) from workflows file as inEVM will no longer be supported.