### PR TITLE
fix: correct gonk auth order in create-merge-prs workflow

### DIFF
--- a/.github/workflows/create-merge-prs.yaml
+++ b/.github/workflows/create-merge-prs.yaml
@@ -21,11 +21,6 @@ jobs:
       matrix:
         branch: [injective, nexus, trump, ousdt]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
       - name: Generate GitHub App Token
         id: generate-token
         uses: actions/create-github-app-token@v2
@@ -33,10 +28,22 @@ jobs:
           app-id: ${{ secrets.HYPER_GONK_APP_ID }}
           private-key: ${{ secrets.HYPER_GONK_PRIVATE_KEY }}
 
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api /users/${{ steps.generate-token.outputs.app-slug }}[bot] --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
       - name: Configure Git for Hyper Gonk
         run: |
           git config user.name "${{ steps.generate-token.outputs.app-slug }}[bot]"
-          git config user.email "${{ secrets.HYPER_GONK_APP_ID }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git config user.email "${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com"
 
       - name: Check if merge is needed
         id: check-merge


### PR DESCRIPTION
## Summary
Fixes the authentication order in the `create-merge-prs.yaml` workflow so that gonk token is used correctly for pushes.

**Problem:** The workflow was checking out the repo before generating the gonk token, so the remote URL was configured with the default `GITHUB_TOKEN` instead of gonk credentials.

**Solution:**
- Move token generation **before** checkout
- Add `token:` parameter to checkout step
- Add user ID lookup for proper email format (consistent with other workflows)

This should fix the issue Jason identified in #829 where the workflow wasn't using gonk credentials correctly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal CI/CD workflow for pull request automation, improving authentication handling and Git configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->