### PR TITLE
feat: enable USDC/paradex in nexus

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -49,6 +49,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/subtensor',
   'USDC/lumia',
   'USDC/matchain',
+  'USDC/paradex',
 
   // USDT routes
   'USDT/eclipsemainnet-ethereum-solanamainnet',


### PR DESCRIPTION
enable `USDC/paradex` route in nexus

tested txs are in this [registry PR](https://github.com/hyperlane-xyz/hyperlane-registry/pull/1279)