### PR TITLE
fix: isSmartContract check for EIP-7702 addresses to not show banner

### DIFF
--- a/src/features/transfer/utils.ts
+++ b/src/features/transfer/utils.ts
@@ -75,6 +75,7 @@ import {
   MultiProtocolProvider,
   ProviderType,
   TypedTransactionReceipt,
+  ViemProvider,
 } from '@hyperlane-xyz/sdk';
 import { isValidAddressEvm } from '@hyperlane-xyz/utils';
 import { getAddress } from 'viem';
@@ -133,6 +134,20 @@ export function tryGetMsgIdFromTransferReceipt(
   }
 }
 
+export async function isEvmContractAddress(
+  viemProvider: ViemProvider['provider'],
+  address: string,
+): Promise<
+  { isContractAddress: false; code: undefined } | { isContractAddress: true; code: string }
+> {
+  const code = await viemProvider.getCode({ address: getAddress(address) });
+  if (!code || code === '0x') {
+    return { isContractAddress: false, code: undefined };
+  }
+  return { isContractAddress: true, code };
+}
+
+const eip7702AccountSelector = '0xef0100';
 export async function isSmartContract(
   multiProvider: MultiProtocolProvider,
   chain: string,
@@ -149,11 +164,16 @@ export async function isSmartContract(
       throw new Error(`No viem provider for chain ${chain}`);
     }
 
-    const code = await provider.getCode({ address: getAddress(address) });
+    const { isContractAddress, code } = await isEvmContractAddress(provider, address);
 
-    if (!code || code === '0x') {
-      return { isContract: false };
-    }
+    if (!isContractAddress && !code) return { isContract: false };
+
+    // Checks if an address is also an EIP-7702 which is a smart account but not an smart contract
+    // It would technically be correct to check if the delegated contract address is also a valid
+    // contract address, but for our use case which is showing a banner to warn users
+    // if the address is a Smart Contract, this wouldn't be necessary since `0xef0100`
+    // is only reserved for Smart Accounts
+    if (code.startsWith(eip7702AccountSelector)) return { isContract: false };
 
     return { isContract: true };
   } catch (error) {


### PR DESCRIPTION
With the inclusion of Smart Accounts ([EIP-7702](https://eip7702.io/)) the UI was incorrectly showing the recipient banner check for address that are smart accounts and not smart contracts

- This PR introduces check if the contract code starts with the EIP-7702 selector to decide if the UI should show the warning banner or not
- Refactors contract address check into its own util function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved contract address detection to accurately distinguish between smart accounts and regular contracts.
  * Enhanced error reporting with clearer contextual messages during address validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->