### PR TITLE
fix: improve merge detection for squash-merged branches

### DIFF
--- a/.github/workflows/create-merge-prs.yaml
+++ b/.github/workflows/create-merge-prs.yaml
@@ -49,13 +49,54 @@ jobs:
         id: check-merge
         run: |
           git fetch origin ${{ matrix.branch }}
+
+          # First check commit ancestry (handles regular merges)
           if git merge-base --is-ancestor origin/main origin/${{ matrix.branch }}; then
-            echo "Branch ${{ matrix.branch }} is already up-to-date with main"
+            echo "Branch ${{ matrix.branch }} is already up-to-date with main (via ancestry)"
             echo "needs_merge=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Ancestry check failed - could be squash merge or actual changes needed
+          # Try a merge to see if it would produce any changes
+          git checkout -B temp-merge-check origin/${{ matrix.branch }}
+
+          if git merge --no-commit --no-ff origin/main 2>/dev/null; then
+            # Merge succeeded without conflicts - check if there are actual changes
+            if git diff --cached --quiet HEAD; then
+              echo "Branch ${{ matrix.branch }} is already up-to-date with main (no changes from merge)"
+              echo "needs_merge=false" >> $GITHUB_OUTPUT
+            else
+              echo "Branch ${{ matrix.branch }} needs updates from main"
+              echo "needs_merge=true" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "Branch ${{ matrix.branch }} needs updates from main"
+            # Merge had conflicts - definitely needs merge
+            echo "Branch ${{ matrix.branch }} needs updates from main (merge has conflicts)"
             echo "needs_merge=true" >> $GITHUB_OUTPUT
           fi
+
+          # Clean up
+          git merge --abort 2>/dev/null || true
+          git checkout main 2>/dev/null || true
+
+      - name: Close stale PR and delete branch if no merge needed
+        if: steps.check-merge.outputs.needs_merge == 'false'
+        run: |
+          PR_NUMBER=$(gh pr list --base ${{ matrix.branch }} --head main-to-${{ matrix.branch }} --json number --jq '.[0].number')
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Closing stale PR #$PR_NUMBER as ${{ matrix.branch }} is already up-to-date with main"
+            gh pr close "$PR_NUMBER" --comment "Closing: ${{ matrix.branch }} is already up-to-date with main."
+          fi
+
+          # Delete the merge branch if it exists
+          if git ls-remote --exit-code --heads origin main-to-${{ matrix.branch }} > /dev/null 2>&1; then
+            echo "Deleting stale branch main-to-${{ matrix.branch }}"
+            git push origin --delete main-to-${{ matrix.branch }} || true
+          fi
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Create and push merge branch
         if: steps.check-merge.outputs.needs_merge == 'true'
@@ -82,7 +123,7 @@ jobs:
       - name: Create or update PR
         if: steps.check-merge.outputs.needs_merge == 'true'
         run: |
-          PR_EXISTS=$(gh pr list --base ${{ matrix.branch }} --head main-to-${{ matrix.branch }} --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --base ${{ matrix.branch }} --head main-to-${{ matrix.branch }} --json number --jq '.[0].number')
 
           if [ "${{ steps.merge.outputs.has_conflicts }}" == "true" ]; then
             BODY="⚠️ **This PR has merge conflicts that need to be resolved manually.**
@@ -92,7 +133,7 @@ jobs:
             BODY="This PR was automatically created to merge changes from \`main\` into \`${{ matrix.branch }}\`."
           fi
 
-          if [ -z "$PR_EXISTS" ]; then
+          if [ -z "$PR_NUMBER" ]; then
             gh pr create \
               --base ${{ matrix.branch }} \
               --head main-to-${{ matrix.branch }} \
@@ -101,7 +142,8 @@ jobs:
               --draft
             echo "Created new PR for ${{ matrix.branch }}"
           else
-            echo "PR #$PR_EXISTS already exists for ${{ matrix.branch }}"
+            echo "PR #$PR_NUMBER already exists for ${{ matrix.branch }}, updating..."
+            gh pr edit "$PR_NUMBER" --body "$BODY"
           fi
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Add dry-run merge check to detect when content is already merged even if commit ancestry differs (handles squash merges)
- Close stale PRs and delete merge branches when no merge is needed
- Update existing PRs instead of skipping when branch is updated

## Problem
The `create-merge-prs` workflow was using `git merge-base --is-ancestor` to check if a merge was needed. This only works for regular merge commits - if a branch was squash-merged with main, the commit SHAs differ, so the workflow thought all those commits still needed merging (e.g., showing 40 commits in PRs like #855).

## Solution
1. **Smarter merge detection**: First tries ancestry check (fast path), then does a dry-run merge to check for actual file changes
2. **Closes stale PRs**: When no merge is needed, closes any existing PR and deletes the merge branch
3. **Updates existing PRs**: If a PR exists and needs updating, updates the body instead of skipping

## Test plan
- [ ] Merge this PR
- [ ] Trigger the workflow (push to main or manual dispatch)
- [ ] Verify PRs #855-858 are closed if branches are already up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic closure of stale pull requests and cleanup of associated merge branches
  * Enhanced merge conflict detection to identify potential issues before finalizing merges

* **Improvements**
  * Streamlined merge decision workflow with early exit when targets are already up-to-date

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->