### PR TITLE
feat: add Krown to Nexus

### DIFF
--- a/src/consts/chains.yaml
+++ b/src/consts/chains.yaml
@@ -18,3 +18,24 @@
 #   protocol: ethereum
 #   rpcUrls:
 #     - http: http://127.0.0.1:8555
+krown:
+  blocks:
+    confirmations: 1
+    estimateBlockTime: 12
+    reorgPeriod: 1
+  chainId: 1983
+  deployer:
+    name: Abacus Works
+    url: https://www.hyperlane.xyz
+  displayName: Krown
+  domainId: 1983
+  gasCurrencyCoinGeckoId: krown-network
+  name: krown
+  nativeToken:
+    decimals: 18
+    name: KROWN
+    symbol: KROWN
+  protocol: ethereum
+  rpcUrls:
+    - http: http://18.134.110.61:8545
+  technicalStack: other

--- a/src/consts/warpRoutes.yaml
+++ b/src/consts/warpRoutes.yaml
@@ -2,5 +2,64 @@
 # These configs will be merged with the warp routes in the configured registry
 # The input here is typically the output of the Hyperlane CLI warp deploy command
 ---
-tokens: []
+tokens:
+  - addressOrDenom: '0xE78fA49bE021e533cd8f6E10931b796D89cd80DD'
+    chainName: ethereum
+    collateralAddressOrDenom: '0xdac17f958d2ee523a2206206994597c13d831ec7'
+    connections:
+      - token: ethereum|krown|0x59973ae98D340cA0577ed92502402E82E987Ba2E
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    standard: EvmHypCollateral
+    symbol: USDT
+  - addressOrDenom: '0x59973ae98D340cA0577ed92502402E82E987Ba2E'
+    chainName: krown
+    connections: [] # temporarily deposit-only to krown
+    # - token: ethereum|ethereum|0xE78fA49bE021e533cd8f6E10931b796D89cd80DD
+    decimals: 6
+    logoURI: /deployments/warp_routes/USDT/logo.svg
+    name: Tether USD
+    standard: EvmHypSynthetic
+    symbol: USDT
+
+  - addressOrDenom: '0xbdE0801a78f9c4BC360C34aaf98043EA0cdF4fB0'
+    chainName: ethereum
+    collateralAddressOrDenom: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+    connections:
+      - token: ethereum|krown|0xa3D9cfa4220d6a5ba7b9067D33ebEdbF2DE6F1CF
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypCollateral
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+    symbol: USDC
+  - addressOrDenom: '0xa3D9cfa4220d6a5ba7b9067D33ebEdbF2DE6F1CF'
+    chainName: krown
+    connections: [] # temporarily deposit-only to krown
+    # - token: ethereum|ethereum|0xbdE0801a78f9c4BC360C34aaf98043EA0cdF4fB0
+    decimals: 6
+    name: USD Coin
+    standard: EvmHypSynthetic
+    symbol: USDC
+    logoURI: /deployments/warp_routes/USDC/logo.svg
+
+  - addressOrDenom: '0x95Abf44e0B9166348A9ed8797a7f20CC32Fd9C26'
+    chainName: ethereum
+    connections:
+      - token: ethereum|krown|0x6F9eC4f83ef69b923Fa1Dc00189e591728DF0ac0
+    decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    name: Ether
+    standard: EvmHypNative
+    symbol: ETH
+  - addressOrDenom: '0x6F9eC4f83ef69b923Fa1Dc00189e591728DF0ac0'
+    chainName: krown
+    connections: [] # temporarily deposit-only to krown
+    # - token: ethereum|ethereum|0x95Abf44e0B9166348A9ed8797a7f20CC32Fd9C26
+    decimals: 18
+    logoURI: /deployments/warp_routes/ETH/logo.svg
+    name: ETH
+    standard: EvmHypSynthetic
+    symbol: ETH
+
 options: {}


### PR DESCRIPTION
- Adds Krown assets to Nexus
- Because of tight deadlines, doing so directly and will later move to registry

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR integrates the Krown chain into Nexus by adding chain metadata and three warp routes (USDT, USDC, ETH) from Ethereum.

**Key Changes:**
- Added `krown` chain config to `chains.yaml` with domain ID 1983 and standard metadata
- Configured three token bridges from Ethereum to Krown as deposit-only (empty connections array on Krown side)
- Used proper collateral addresses for USDT (`0xdac...ec7`) and USDC (`0xA0b...B48`) on Ethereum mainnet
- Set up synthetic tokens on Krown side with matching decimals

**Approach:**
The deposit-only setup (commented-out reverse connections) makes sense for an initial integration under tight deadlines. This prevents withdrawals until the system is properly tested. The config follows existing patterns from the codebase and uses legitimate token addresses.

<details><summary><h3>Confidence Score: 4/5</h3></summary>


- This PR is safe to merge with minimal risk for a controlled rollout
- The configuration follows existing patterns and uses verified token addresses. The deposit-only setup is a sensible approach for initial integration. Minor concern about HTTP RPC endpoint but this is likely handled at infrastructure level.
- Verify that the RPC endpoint at `chains.yaml:40` has proper HTTPS handling
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/consts/chains.yaml | Adds Krown chain config with standard metadata; uses bare HTTP RPC endpoint |
| src/consts/warpRoutes.yaml | Configures three token routes (USDT, USDC, ETH) from Ethereum to Krown as deposit-only with proper collateral addresses |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant EthereumUI as Nexus UI
    participant EthCollateral as Ethereum Collateral Contracts
    participant HyperlaneBridge as Hyperlane Bridge
    participant KrownSynthetic as Krown Synthetic Tokens
    
    Note over User,KrownSynthetic: Deposit Flow (Ethereum → Krown)
    
    User->>EthereumUI: Initiate deposit (USDT/USDC/ETH)
    EthereumUI->>EthCollateral: Lock collateral tokens
    EthCollateral->>EthCollateral: Lock USDT (0xdac...ec7)<br/>or USDC (0xA0b...B48)<br/>or ETH (native)
    EthCollateral->>HyperlaneBridge: Emit bridge message
    HyperlaneBridge->>KrownSynthetic: Relay message to Krown (chain 1983)
    KrownSynthetic->>KrownSynthetic: Mint synthetic tokens
    KrownSynthetic->>User: Transfer tokens on Krown
    
    Note over User,KrownSynthetic: Withdrawal Flow (Currently Disabled)
    
    User->>EthereumUI: Attempt withdrawal from Krown
    EthereumUI-->>User: ❌ No reverse connection configured
    Note over KrownSynthetic: connections: [] prevents withdrawals
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->