### PR TITLE
chore: update superseed warpRouteId

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -43,7 +43,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/arbitrum-base-endurance',
   'USDC/artela-base',
   'USDC/solanamainnet-sonicsvm',
-  'USDC/arbitrum-base-ethereum-ink-optimism-solanamainnet-superseed',
+  'USDC/superseed',
   'USDC/subtensor',
   'USDC/lumia',
   'USDC/matchain',


### PR DESCRIPTION
Update `superseed` route with new `ink` leg and new warp route id