### PR TITLE
fix: show native token symbol in insufficient gas error message

### DIFF
--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -904,7 +904,9 @@ async function validateForm(
     let errorMsg = errorToString(error, 40);
     const fullError = `${errorMsg} ${error.message}`;
     if (insufficientFundsErrMsg.test(fullError) || emptyAccountErrMsg.test(fullError)) {
-      errorMsg = 'Insufficient funds for gas fees';
+      const chainMetadata = warpCore.multiProvider.getChainMetadata(values.origin);
+      const nativeToken = Token.FromChainMetadataNativeToken(chainMetadata);
+      errorMsg = `Insufficient ${nativeToken.symbol} for gas fees`;
     }
     return [{ form: errorMsg }, null];
   }


### PR DESCRIPTION
## Summary
- Updates the "Insufficient funds for gas fees" error to display the specific native token symbol (e.g., "Insufficient ETH for gas fees")
- Improves UX by making it clear which token the user needs for gas

## Test plan
- [ ] Trigger the insufficient gas error on an EVM chain (should show "Insufficient ETH for gas fees")
- [ ] Trigger the error on Solana (should show "Insufficient SOL for gas fees")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when insufficient funds are available for gas fees, now displaying the specific native token symbol required instead of a generic message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->