### PR TITLE
fix(build): disable Sentry source map upload to prevent build hangs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -122,6 +122,7 @@ const sentryOptions = {
   authToken: process.env.SENTRY_AUTH_TOKEN,
   hideSourceMaps: true,
   tunnelRoute: '/monitoring-tunnel',
+  sourcemaps: { disable: true },
   bundleSizeOptimizations: {
     excludeDebugStatements: true,
     excludeReplayIframe: true,


### PR DESCRIPTION
## Summary

- Adds `sourcemaps: { disable: true }` to Sentry config in `next.config.js`

## Context

Vercel builds randomly hang 45+ minutes, getting stuck on "sending sentry telemetry info" during source map upload. The Sentry API has variable response times with no timeout configured, causing indefinite waits.

## What this changes

Disables Sentry source map upload during build. Error tracking via the tunnel route (`/monitoring-tunnel`) and all other Sentry configuration remain intact.

## Verification

- `pnpm build` completes successfully
- Tunnel route confirmed present in build output
- All other Sentry config preserved (org, project, authToken, hideSourceMaps, tunnelRoute, bundleSizeOptimizations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error tracking configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->