### PR TITLE
fix: M0PortalLite token key collision in balance fetching

### DIFF
--- a/src/features/tokens/balances.ts
+++ b/src/features/tokens/balances.ts
@@ -27,7 +27,13 @@ export function useBalance(chain?: ChainName, token?: IToken, address?: Address)
   const { isLoading, isError, error, data } = useQuery({
     // The Token and Multiprovider classes are not serializable, so we can't use it as a key
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
-    queryKey: ['useBalance', chain, address, token?.addressOrDenom],
+    queryKey: [
+      'useBalance',
+      chain,
+      address,
+      token?.addressOrDenom,
+      token?.collateralAddressOrDenom,
+    ],
     queryFn: () => {
       if (!chain || !token || !address || !isValidAddress(address, token.protocol)) return null;
       return token.getBalance(multiProvider, address);
@@ -139,8 +145,10 @@ type Aggregate3Result = Array<{ success: boolean; returnData: Hex }>;
 
 // ─── Pure helpers ────────────────────────────────────────────────────────────
 
+/** Includes symbol to distinguish tokens sharing the same addressOrDenom
+ *  (e.g. M0PortalLite wM/mUSD/USDSC all use the same portal contract). */
 function tokenKey(token: Token): string {
-  return `${token.chainName}:${normalizeAddress(token.addressOrDenom, token.protocol)}`;
+  return `${token.chainName}-${normalizeAddress(token.addressOrDenom, token.protocol)}-${token.symbol}`;
 }
 
 function classifyToken(token: Token): { type: TokenClassification; erc20Address?: Hex } {


### PR DESCRIPTION
## Summary

Fixes balance display bugs for M0PortalLite tokens (wM, mUSD, USDSC) which all share the same `addressOrDenom` (the portal contract `0x36f586...`) but have different underlying ERC20s via `collateralAddressOrDenom`.

- **`tokenKey` collision**: Include `symbol` in the token key so wM/mUSD/USDSC on the same chain get unique entries in the balance map. Matches the existing dedup pattern in `warpCoreConfig.ts`.
- **`useBalance` query key collision**: Add `collateralAddressOrDenom` to the React Query key so switching between M0 tokens on the same chain triggers a fresh balance fetch instead of returning a stale cached result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved token balance caching mechanism to better differentiate between tokens in the system.

* **Documentation**
  * Added documentation clarifying token identification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->