### PR TITLE
feat: batch CoinGecko price fetching with 5min cache

### DIFF
--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -42,6 +42,8 @@ interface WarpContext {
   tokensBySymbolChainMap: Record<string, TokenChainMap>;
   // Map of chain -> address -> router info
   routerAddressesByChainMap: Record<ChainName, Record<string, RouterAddressInfo>>;
+  // Deduplicated, sorted CoinGecko IDs for all tokens
+  coinGeckoIds: string[];
 }
 
 // Keeping everything here for now as state is simple
@@ -85,6 +87,8 @@ export interface AppState {
   // Map of chain -> address -> router info
   // Used to: 1) prevent sending to warp route addresses, 2) format amounts with correct decimals
   routerAddressesByChainMap: Record<ChainName, Record<string, RouterAddressInfo>>;
+  // Deduplicated, sorted CoinGecko IDs for all tokens (used by useTokenPrices)
+  coinGeckoIds: string[];
 }
 
 export const useStore = create<AppState>()(
@@ -99,33 +103,45 @@ export const useStore = create<AppState>()(
       ) => {
         logger.debug('Setting chain overrides in store');
         const filtered = objFilter(overrides, (_, metadata) => !!metadata);
-        const { multiProvider, warpCore, routerAddressesByChainMap, tokensBySymbolChainMap } =
-          await initWarpContext({
-            ...get(),
-            chainMetadataOverrides: filtered,
-          });
+        const {
+          multiProvider,
+          warpCore,
+          routerAddressesByChainMap,
+          tokensBySymbolChainMap,
+          coinGeckoIds,
+        } = await initWarpContext({
+          ...get(),
+          chainMetadataOverrides: filtered,
+        });
         set({
           chainMetadataOverrides: filtered,
           multiProvider,
           warpCore,
           tokensBySymbolChainMap,
           routerAddressesByChainMap,
+          coinGeckoIds,
         });
       },
       warpCoreConfigOverrides: [],
       setWarpCoreConfigOverrides: async (overrides: WarpCoreConfig[] | undefined = []) => {
         logger.debug('Setting warp core config overrides in store');
-        const { multiProvider, warpCore, routerAddressesByChainMap, tokensBySymbolChainMap } =
-          await initWarpContext({
-            ...get(),
-            warpCoreConfigOverrides: overrides,
-          });
+        const {
+          multiProvider,
+          warpCore,
+          routerAddressesByChainMap,
+          tokensBySymbolChainMap,
+          coinGeckoIds,
+        } = await initWarpContext({
+          ...get(),
+          warpCoreConfigOverrides: overrides,
+        });
         set({
           warpCoreConfigOverrides: overrides,
           multiProvider,
           warpCore,
           tokensBySymbolChainMap,
           routerAddressesByChainMap,
+          coinGeckoIds,
         });
       },
       multiProvider: new MultiProtocolProvider({}),
@@ -187,6 +203,7 @@ export const useStore = create<AppState>()(
       },
       tokensBySymbolChainMap: {},
       routerAddressesByChainMap: {},
+      coinGeckoIds: [],
     }),
 
     // Store config
@@ -257,6 +274,9 @@ async function initWarpContext({
 
     const tokensBySymbolChainMap = assembleTokensBySymbolChainMap(warpCore.tokens, multiProvider);
     const routerAddressesByChainMap = getRouterAddressesByChain(warpCore.tokens, wireDecimalsMap);
+    const coinGeckoIds = Array.from(
+      new Set(coreConfig.tokens.map((t) => t.coinGeckoId).filter(Boolean)),
+    ).sort() as string[];
     return {
       registry: currentRegistry,
       chainMetadata,
@@ -264,6 +284,7 @@ async function initWarpContext({
       warpCore,
       tokensBySymbolChainMap,
       routerAddressesByChainMap,
+      coinGeckoIds,
     };
   } catch (error) {
     toast.error('Error initializing warp context. Please check connection status and configs.');
@@ -275,6 +296,7 @@ async function initWarpContext({
       warpCore: new WarpCore(new MultiProtocolProvider({}), []),
       tokensBySymbolChainMap: {},
       routerAddressesByChainMap: {},
+      coinGeckoIds: [],
     };
   }
 }

--- a/src/features/tokens/TokenListModal.tsx
+++ b/src/features/tokens/TokenListModal.tsx
@@ -129,7 +129,7 @@ export function TokenList({
     isLoading: balancesLoading,
     hasAnyAddress,
   } = useTokenBalances(routeTokenObjects, origin, destination);
-  const { prices } = useTokenPrices(routeTokenObjects, origin, destination);
+  const { prices } = useTokenPrices();
 
   // Search-filtered + sorted tokens for display
   const { tokens, sortedTokens } = useMemo(() => {

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -60,7 +60,7 @@ import {
   getTokenIndexFromChains,
   useWarpCore,
 } from '../tokens/hooks';
-import { useTokenPrice } from '../tokens/useTokenPrice';
+import { useTokenPrices } from '../tokens/useTokenPrice';
 import { WalletConnectionWarning } from '../wallet/WalletConnectionWarning';
 import { FeeSectionButton } from './FeeSectionButton';
 import { RecipientConfirmationModal } from './RecipientConfirmationModal';
@@ -295,7 +295,10 @@ function TokenSection({
 function AmountSection({ isNft, isReview }: { isNft: boolean; isReview: boolean }) {
   const { values } = useFormikContext<TransferFormValues>();
   const { balance } = useOriginBalance(values);
-  const { tokenPrice, isLoading } = useTokenPrice(values);
+  const warpCore = useWarpCore();
+  const { prices, isLoading } = useTokenPrices();
+  const originToken = getTokenByIndex(warpCore, values.tokenIndex);
+  const tokenPrice = originToken?.coinGeckoId ? prices[originToken.coinGeckoId] : undefined;
 
   const amount = parseFloat(values.amount);
   const totalTokenPrice = !isNullish(tokenPrice) && !isNaN(amount) ? amount * tokenPrice : 0;


### PR DESCRIPTION
## Summary
- With the addition of token balances and USD values in the token selection modal, CoinGecko's free API (5-15 req/min dynamic limit) was getting rate limited due to multiple independent price-fetching hooks each polling every 60s
- Consolidated `useTokenPrice` and `useTokenPrices` into a single `useTokenPrices()` hook that batch-fetches all token prices in one API call (~2KB response)
- Deduplicated CoinGecko IDs are extracted during warp context init and stored in Zustand, so no repeated iteration over tokens on every render
- Increased stale time from 60s to 5min — CoinGecko's free tier only updates prices every 1-2 min server-side anyway, and these are informational estimates not execution prices

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (60/60)
- [ ] Amount input shows ≈$X.XX USD estimate
- [ ] Token selection modal shows USD values and sorts by value
- [ ] Network tab: single CoinGecko request on load, next one after 5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved token price fetching mechanism for better performance and efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->