### PR TITLE
chore: remove hard-coded celestia <> eclipse,arbitrum interchain fee

### DIFF
--- a/src/consts/warpRoutes.ts
+++ b/src/consts/warpRoutes.ts
@@ -92,20 +92,8 @@ export const warpRouteConfigs: WarpCoreConfig = {
     interchainFeeConstants: [
       {
         origin: 'celestia',
-        destination: 'arbitrum',
-        amount: 270000,
-        addressOrDenom: 'utia',
-      },
-      {
-        origin: 'celestia',
         destination: 'mantapacific',
         amount: 270000,
-        addressOrDenom: 'utia',
-      },
-      {
-        origin: 'celestia',
-        destination: 'eclipsemainnet',
-        amount: 500000,
         addressOrDenom: 'utia',
       },
     ],


### PR DESCRIPTION
The webapp was throwing an error with fee estimation because of the hard-coded constant for celestia <> eclipse/arbitrum