### PR TITLE
fix: stub tron typechain to fix flaky build failure

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -102,6 +102,15 @@ const nextConfig = {
       layers: true,
     };
 
+    // TODO: Remove when @hyperlane-xyz/core fixes ethers v5/v6 compat in tron typechain.
+    // core's tron typechain does `import { utils } from 'ethers'` (v5 API) which
+    // flakily fails during barrel optimization with webpackBuildWorker enabled.
+    // See: https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/973
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@hyperlane-xyz/core/dist/tron': false,
+    };
+
     if (isServer) {
       config.resolve.alias = {
         ...config.resolve.alias,


### PR DESCRIPTION
## Summary

Fixes the flaky build failure introduced by #973 (dependency update to `@hyperlane-xyz/sdk@25.3.2`).

### Root cause

`sdk@25.3.2` transitively pulls in `tron-sdk@21.1.2` → `core@10.2.0`, whose tron typechain factories do `import { utils } from 'ethers'` (ethers v5 API). This fails at webpack bundle time because `utils` is not a named export in ethers v6.

### Why it's flaky

`webpackBuildWorker: true` + `optimizePackageImports` (barrel optimization) for `@hyperlane-xyz/sdk` creates a race condition. Webpack build workers non-deterministically trace into the `sdk → MultiProtocolProvider → MultiProvider → tron-sdk → core/dist/tron/typechain → ethers` import chain. Sometimes tree-shaking eliminates the path before resolution; sometimes it doesn't. Build cache can also mask it.

### Fix

Webpack alias `@hyperlane-xyz/core/dist/tron` → `false` (empty module). This app doesn't use tron, so the typechain is dead code. Temporary until the upstream ethers v5/v6 compat is fixed in `@hyperlane-xyz/core` (the tron typechain needs to be regenerated with `target: "ethers-v6"`).

### Other repos

- **hyperlane-explorer**: Not affected — uses `sdk@25.1.0` which predates tron-sdk.

## Test plan

- [ ] Verify Vercel build passes consistently (no more flakes)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only change that aliases `@hyperlane-xyz/core/dist/tron` to an empty module; main risk is breaking any runtime/compile-time usage of Tron-specific code paths if they exist.
> 
> **Overview**
> Prevents flaky Next.js webpack builds by **stubbing out Hyperlane’s Tron typechain**: adds a webpack `resolve.alias` mapping `@hyperlane-xyz/core/dist/tron` to `false` to avoid an ethers v5/v6 incompatibility being pulled in during package import optimization/build workers.
> 
> Includes TODO/commentary noting this is a temporary workaround until upstream fixes Tron typechain generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81ee9097a71e6e48cf1a083d2d0997b808bf743a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->