### PR TITLE
ci: enforce minimum package release age in pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# Reject packages published less than 7 days ago (supply chain protection)
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@hyperlane-xyz/*'


### PR DESCRIPTION
## Summary
- Added `minimumReleaseAge: 10080` (7 days in minutes) to `pnpm-workspace.yaml`
- Excludes `@hyperlane-xyz/*` packages so our own releases aren't blocked
- pnpm does not honor npm's `min-release-age` from `.npmrc` — requires native config

## Test plan
- [ ] Verify `pnpm install` still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but may cause `pnpm install` failures if the repo depends on newly published third-party packages.
> 
> **Overview**
> Introduces `minimumReleaseAge: 10080` in `pnpm-workspace.yaml` to reject installing packages published within the last 7 days as a supply-chain hardening measure.
> 
> Adds `minimumReleaseAgeExclude` for `@hyperlane-xyz/*` so internal packages aren’t blocked by the new policy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acbd53164d15c4d57dbfb70850968606d48f17bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->