### PR TITLE
refactor: clean up token routing logic and remove dead code

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when committing changes to ensure quality and correctness.
 
 Run these in order. **Do not commit if any fail.**
 
-1. **`pnpm prettier`** — Format all source files
+1. **`pnpm format`** — Format all source files
 2. **`pnpm lint`** — Check for ESLint errors
 3. **`pnpm typecheck`** — Verify TypeScript compiles
 4. **`pnpm build`** — Ensure production build succeeds (optional for small changes, required before PR)
@@ -35,12 +35,12 @@ Run these in order. **Do not commit if any fail.**
 
 - **Secrets**: Never commit `.env`, credentials, or API keys
 - **Large files**: Don't commit binaries, build artifacts, or font files (check `.gitignore`)
-- **Formatting drift**: If prettier changed files you didn't touch, stage them separately or skip them
+- **Formatting drift**: If oxfmt changed files you didn't touch, stage them separately or skip them
 
 ## Example Flow
 
 ```bash
-pnpm prettier
+pnpm format
 pnpm lint
 pnpm typecheck
 git status                    # review what changed

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -22,9 +22,7 @@ import { persist } from 'zustand/middleware';
 import { config } from '../consts/config';
 import { logger } from '../utils/logger';
 import { assembleChainMetadata } from './chains/metadata';
-import { TokenChainMap } from './tokens/types';
 import {
-  assembleTokensBySymbolChainMap,
   buildTokensArray,
   getTokenKey,
   groupTokensByCollateral,
@@ -48,7 +46,6 @@ interface WarpContext {
   chainMetadata: ChainMap<ChainMetadata>;
   multiProvider: MultiProtocolProvider;
   warpCore: WarpCore;
-  tokensBySymbolChainMap: Record<string, TokenChainMap>;
   /** Unified tokens array (deduplicated, can be origin or destination) */
   tokens: Token[];
   /** Pre-computed collateral groups for fast route checking */
@@ -103,7 +100,6 @@ export interface AppState {
 
   originChainName: ChainName;
   setOriginChainName: (originChainName: ChainName) => void;
-  tokensBySymbolChainMap: Record<string, TokenChainMap>;
   // instead of moving the TipCard component inside the formik and an useEffect can be set to watch for it
   isTipCardActionTriggered: boolean;
   setIsTipCardActionTriggered: (isTipCardActionTriggered: boolean) => void;
@@ -136,7 +132,6 @@ export const useStore = create<AppState>()(
           multiProvider,
           warpCore,
           routerAddressesByChainMap,
-          tokensBySymbolChainMap,
           tokens,
           collateralGroups,
           tokenByKeyMap,
@@ -149,7 +144,6 @@ export const useStore = create<AppState>()(
           chainMetadataOverrides: filtered,
           multiProvider,
           warpCore,
-          tokensBySymbolChainMap,
           routerAddressesByChainMap,
           tokens,
           collateralGroups,
@@ -164,7 +158,6 @@ export const useStore = create<AppState>()(
           multiProvider,
           warpCore,
           routerAddressesByChainMap,
-          tokensBySymbolChainMap,
           tokens,
           collateralGroups,
           tokenByKeyMap,
@@ -177,7 +170,6 @@ export const useStore = create<AppState>()(
           warpCoreConfigOverrides: overrides,
           multiProvider,
           warpCore,
-          tokensBySymbolChainMap,
           routerAddressesByChainMap,
           tokens,
           collateralGroups,
@@ -244,7 +236,6 @@ export const useStore = create<AppState>()(
       setOriginChainName: (originChainName: ChainName) => {
         set(() => ({ originChainName }));
       },
-      tokensBySymbolChainMap: {},
       routerAddressesByChainMap: {},
       isTipCardActionTriggered: false,
       setIsTipCardActionTriggered: (isTipCardActionTriggered: boolean) => {
@@ -322,8 +313,6 @@ async function initWarpContext({
     const multiProvider = new MultiProtocolProvider(chainMetadataWithOverrides);
     const warpCore = WarpCore.FromConfig(multiProvider, coreConfig);
 
-    const tokensBySymbolChainMap = assembleTokensBySymbolChainMap(warpCore.tokens, multiProvider);
-
     // Resolve underlying addresses for lockbox/vault tokens so they group
     // with their non-wrapper counterparts (e.g., lockbox USDT = regular USDT)
     const resolvedMap = await resolveWrappedCollateralTokens(warpCore.tokens, multiProvider);
@@ -348,7 +337,6 @@ async function initWarpContext({
       chainMetadata,
       multiProvider,
       warpCore,
-      tokensBySymbolChainMap,
       routerAddressesByChainMap,
       tokens,
       collateralGroups,
@@ -363,7 +351,6 @@ async function initWarpContext({
       chainMetadata: {},
       multiProvider: new MultiProtocolProvider({}),
       warpCore: new WarpCore(new MultiProtocolProvider({}), []),
-      tokensBySymbolChainMap: {},
       routerAddressesByChainMap: {},
       tokens: [],
       collateralGroups: new Map(),

--- a/src/features/tokens/types.ts
+++ b/src/features/tokens/types.ts
@@ -1,13 +1,4 @@
-import { ChainMap, ChainMetadata, Token, TokenAmount } from '@hyperlane-xyz/sdk';
-
-export type MultiCollateralTokenMap = Record<string, Record<string, Token[]>>;
-
-export type TokenChainMap = {
-  chains: ChainMap<{ token: Token; metadata: ChainMetadata | null }>;
-  tokenInformation: Token;
-};
-
-export type Tokens = Array<{ token: Token; disabled: boolean }>;
+import { Token, TokenAmount } from '@hyperlane-xyz/sdk';
 
 export interface TokensWithDestinationBalance {
   originToken: Token;

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -1,6 +1,5 @@
 import {
   IToken,
-  MultiProtocolProvider,
   Token,
   TOKEN_COLLATERALIZED_STANDARDS,
   TokenStandard,
@@ -8,8 +7,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { eqAddress, isNullish, normalizeAddress, objKeys } from '@hyperlane-xyz/utils';
 
-import { isChainDisabled } from '../chains/utils';
-import { DefaultMultiCollateralRoutes, TokenChainMap } from './types';
+import { DefaultMultiCollateralRoutes } from './types';
 
 // Module-level caches for expensive key computations
 // WeakMap allows automatic garbage collection when token objects are no longer referenced
@@ -39,38 +37,6 @@ function isCollateralizedToken(token: IToken): boolean {
     EXTRA_COLLATERALIZED_STANDARDS.has(token.standard) ||
     token.isHypNative()
   );
-}
-
-// Map of token symbols and token chain map
-// Symbols are not duplicated to avoid the same symbol from being shown
-// TokenChainMap: An object containing token information and a map
-// chain names with its metadata and the related token
-export function assembleTokensBySymbolChainMap(
-  tokens: Token[],
-  multiProvider: MultiProtocolProvider,
-): Record<string, TokenChainMap> {
-  const multiChainTokens = tokens.filter((t) => t.isMultiChainToken());
-  return multiChainTokens.reduce<Record<string, TokenChainMap>>((acc, token) => {
-    if (!token.connections || !token.connections.length) return acc;
-
-    if (!acc[token.symbol]) {
-      acc[token.symbol] = {
-        chains: {},
-        tokenInformation: token,
-      };
-    }
-    if (!acc[token.symbol].chains[token.chainName]) {
-      const chainMetadata = multiProvider.tryGetChainMetadata(token.chainName);
-
-      // remove chain from map if it is disabled
-      const chainDisabled = isChainDisabled(chainMetadata);
-      if (chainDisabled) return acc;
-
-      acc[token.symbol].chains[token.chainName] = { token, metadata: chainMetadata };
-    }
-
-    return acc;
-  }, {});
 }
 
 export function isValidMultiCollateralToken(
@@ -301,13 +267,6 @@ export function getCollateralKey(token: IToken): string {
 }
 
 /**
- * Check if two tokens share the same collateral
- */
-export function sharesCollateral(tokenA: IToken, tokenB: IToken): boolean {
-  return getCollateralKey(tokenA) === getCollateralKey(tokenB);
-}
-
-/**
  * Check if a route exists between origin and destination tokens
  * Uses pre-computed collateral groups for fast O(1) lookups
  *
@@ -368,8 +327,7 @@ export function findRouteToken(
     if (exactMatch) return exactMatch;
   }
 
-  // Fallback: first collateral match, then symbol match
-  return collateralMatches[0] || routeTokens.find((t) => t.symbol === originToken.symbol);
+  return collateralMatches[0];
 }
 
 // Returns the default origin token from tokensWithSameCollateralAddresses if:

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -75,6 +75,24 @@ export function findConnectedDestinationToken(
   );
 }
 
+// Match collateral addresses, or fall back to symbol matching for HypNative tokens
+// (which have null collateral addresses) to avoid treating different native
+// deployments (e.g. ETH vs ETHSTAGE) as interchangeable.
+function matchesCollateral(
+  referenceAddress: string | null,
+  candidateAddress: string | null,
+  referenceSymbol: string,
+  candidateSymbol: string,
+): boolean {
+  if (isNullish(referenceAddress) && isNullish(candidateAddress)) {
+    return candidateSymbol === referenceSymbol;
+  }
+  if (referenceAddress && candidateAddress) {
+    return eqAddress(referenceAddress, candidateAddress);
+  }
+  return false;
+}
+
 export function getTokensWithSameCollateralAddresses(
   warpCore: WarpCore,
   origin: Token,
@@ -112,21 +130,18 @@ export function getTokensWithSameCollateralAddresses(
         ? normalizeAddress(destinationToken.collateralAddressOrDenom, destinationToken.protocol)
         : null;
 
-      // For HypNative tokens both collateral addresses are null — match by symbol
-      // to avoid treating different native deployments (e.g. ETH vs ETHSTAGE) as interchangeable
-      const originMatches =
-        isNullish(originCollateralAddress) && isNullish(currentOriginCollateralAddress)
-          ? originToken.symbol === origin.symbol
-          : originCollateralAddress && currentOriginCollateralAddress
-            ? eqAddress(originCollateralAddress, currentOriginCollateralAddress)
-            : false;
-
-      const destinationMatches =
-        isNullish(destinationCollateralAddress) && isNullish(currentDestinationCollateralAddress)
-          ? destinationToken.symbol === destination.symbol
-          : destinationCollateralAddress && currentDestinationCollateralAddress
-            ? eqAddress(destinationCollateralAddress, currentDestinationCollateralAddress)
-            : false;
+      const originMatches = matchesCollateral(
+        originCollateralAddress,
+        currentOriginCollateralAddress,
+        origin.symbol,
+        originToken.symbol,
+      );
+      const destinationMatches = matchesCollateral(
+        destinationCollateralAddress,
+        currentDestinationCollateralAddress,
+        destination.symbol,
+        destinationToken.symbol,
+      );
 
       return originMatches && destinationMatches;
     });
@@ -341,9 +356,7 @@ export function tryGetDefaultOriginToken(
   defaultMultiCollateralRoutes: DefaultMultiCollateralRoutes | undefined,
   tokensWithSameCollateralAddresses: { originToken: Token; destinationToken: Token }[],
 ): Token | null {
-  // this call might be repeated with getTransferToken but it ensures we are only dealing with valid
-  // multi-collateral tokens here
-  if (!isValidMultiCollateralToken(originToken, destinationToken)) return null;
+  // Caller (getTransferToken) already validated isValidMultiCollateralToken
   if (!defaultMultiCollateralRoutes) return null;
 
   const originChainName = originToken.chainName;

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -356,7 +356,9 @@ export function tryGetDefaultOriginToken(
   defaultMultiCollateralRoutes: DefaultMultiCollateralRoutes | undefined,
   tokensWithSameCollateralAddresses: { originToken: Token; destinationToken: Token }[],
 ): Token | null {
-  // Caller (getTransferToken) already validated isValidMultiCollateralToken
+  // this call might be repeated with getTransferToken but it ensures we are only dealing with valid
+  // multi-collateral tokens here
+  if (!isValidMultiCollateralToken(originToken, destinationToken)) return null;
   if (!defaultMultiCollateralRoutes) return null;
 
   const originChainName = originToken.chainName;

--- a/src/features/transfer/maxAmount.ts
+++ b/src/features/transfer/maxAmount.ts
@@ -9,7 +9,7 @@ import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { isMultiCollateralLimitExceeded } from '../limits/utils';
 import { useWarpCore } from '../tokens/hooks';
-import { findConnectedDestinationToken, findRouteToken } from '../tokens/utils';
+import { findConnectedDestinationToken } from '../tokens/utils';
 import { getTransferToken } from './fees';
 
 interface FetchMaxParams {
@@ -56,17 +56,10 @@ async function fetchMaxAmount(
     );
     const recipient = formRecipient || connectedDestAddress || address;
 
-    // Find the actual warpCore token that has the route (handles deduplicated tokens)
-    const originRouteToken = findRouteToken(warpCore, originToken, destToken);
-    if (!originRouteToken) return undefined;
-
-    const connectedDestinationToken = findConnectedDestinationToken(originRouteToken, destToken);
-    if (!connectedDestinationToken) return undefined;
-
     const transferToken = await getTransferToken(
       warpCore,
-      originRouteToken,
-      connectedDestinationToken,
+      originToken,
+      destToken,
       balance.amount.toString(),
       recipient,
       address,

--- a/src/features/transfer/maxAmount.ts
+++ b/src/features/transfer/maxAmount.ts
@@ -65,7 +65,7 @@ async function fetchMaxAmount(
 
     const transferToken = await getTransferToken(
       warpCore,
-      originToken,
+      originRouteToken,
       connectedDestinationToken,
       balance.amount.toString(),
       recipient,


### PR DESCRIPTION
## Summary
- Remove unsafe symbol fallback in `findRouteToken()` — returns `undefined` instead of silently matching by symbol on misconfiguration
- Remove redundant `findRouteToken` + `findConnectedDestinationToken` pre-resolution in `maxAmount.ts` — let `getTransferToken` handle it (matches `validateForm` pattern)
- Extract `matchesCollateral` helper to replace nested ternaries in `getTokensWithSameCollateralAddresses`
- Remove dead code: `sharesCollateral`, `assembleTokensBySymbolChainMap`, `tokensBySymbolChainMap` state, unused types (`MultiCollateralTokenMap`, `TokenChainMap`, `Tokens`)
- Update commit skill to use `pnpm format` (oxfmt) instead of prettier

🤖 Generated with [Claude Code](https://claude.com/claude-code)