### PR TITLE
feat: rise/bsc-ethereum

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -395,6 +395,9 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // paradex
   'DIME/paradex',
+
+  // rise
+  'RISE/bsc-ethereum',
 ];
 
 /**


### PR DESCRIPTION
This PR adds the RISE/bsc-ethereum warp route to the whitelist