### PR TITLE
feat: add IKAS/igra, CCBTC/igra, WSTETH/igra, USDC/igra to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -85,7 +85,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'WBTC/coti-ethereum',
 
   // CCBTC routes
-  'CCBTC/igra',
+  'CBBTC/igra',
 
   // wstETH routes
   'WSTETH/igra',

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -45,6 +45,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/lumia',
   'USDC/matchain',
   'USDC/paradex',
+  'USDC/igra',
 
   // USDT routes
   'USDT/eclipsemainnet-ethereum-solanamainnet',
@@ -60,6 +61,9 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // oXAUT routes
   'oXAUT/production',
+
+  // IKAS routes
+  'IKAS/igra',
 
   // INJ routes
   'INJ/inevm-injective',
@@ -79,6 +83,12 @@ export const warpRouteWhitelist: Array<string> | null = [
   // WBTC routes
   'WBTC/eclipsemainnet-ethereum',
   'WBTC/coti-ethereum',
+
+  // CCBTC routes
+  'CCBTC/igra',
+
+  // wstETH routes
+  'WSTETH/igra',
 
   // ORCA routes
   'ORCA/eclipsemainnet-solanamainnet',

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -84,7 +84,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'WBTC/eclipsemainnet-ethereum',
   'WBTC/coti-ethereum',
 
-  // CCBTC routes
+  // CBBTC routes
   'CBBTC/igra',
 
   // wstETH routes


### PR DESCRIPTION
Adds Igra warp routes to the Nexus UI whitelist:
- `IKAS/igra`
- `CBBTC/igra`
- `WSTETH/igra`
- `USDC/igra`