### PR TITLE
feat: add USDS, WETH, USDT igra yield warp routes to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -47,10 +47,14 @@ export const warpRouteWhitelist: Array<string> | null = [
   'USDC/paradex',
   'USDC/igra',
 
+  // USDS routes
+  'USDS/ethereum-igra',
+
   // USDT routes
   'USDT/eclipsemainnet-ethereum-solanamainnet',
   'USDT/ethereum-hyperevm',
   'USDT/ethereum-inevm',
+  'USDT/ethereum-igra',
   'USDT/ethereum-lumiaprism',
   'USDT/ethereum-viction',
   'USDT/matchain',
@@ -125,6 +129,7 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // WETH routes
   'WETH/artela-base',
+  'WETH/ethereum-igra',
 
   // fastUSD routes
   'fastUSD/ethereum-sei',


### PR DESCRIPTION
Adds the following warp routes to the Nexus UI whitelist:

| Field | Value |
| ----- | ----- |
| **Linear** | [AW-548](https://linear.app/hyperlane-xyz/issue/AW-548/igra-usds-owner-yield-susds-sky-protocol) · [AW-551](https://linear.app/hyperlane-xyz/issue/AW-551/igra-owner-yield-morpho-gauntlet-weth) · [AW-545](https://linear.app/hyperlane-xyz/issue/AW-545/igra-morpho-steakhouse-usdt-yield-route) |

- `USDS/ethereum-igra`
- `WETH/ethereum-igra`
- `USDT/ethereum-igra`