### PR TITLE
fix: show validation errors on submit button

### DIFF
--- a/src/components/buttons/ConnectAwareSubmitButton.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.tsx
@@ -31,7 +31,7 @@ export function ConnectAwareSubmitButton<FormValues = any>({
 
   const { errors, setErrors, touched, setTouched } = useFormikContext<FormValues>();
 
-  const hasError = Object.keys(touched).length > 0 && Object.keys(errors).length > 0;
+  const hasError = Object.keys(errors).length > 0;
   const firstError = `${Object.values(errors)[0]}` || 'Unknown error';
 
   const color = hasError ? 'red' : 'accent';


### PR DESCRIPTION
## Summary

- Remove the `touched` guard from `ConnectAwareSubmitButton` error display
- Form-level validation errors (e.g. "Insufficient ETH for interchain gas") were silently swallowed because the `touched` object didn't contain matching field keys
- Since Formik is configured with `validateOnChange={false}` and `validateOnBlur={false}`, validation only runs on submit — the `touched` guard was redundant and just hiding legitimate errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)