### PR TITLE
chore: rename middleware.ts to proxy.ts for Next.js 16

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,7 +44,7 @@ const BLOCKED_REGIONS = [
   },
 ];
 
-export function middleware(req: NextRequest) {
+export function proxy(req: NextRequest) {
   const { country, region } = geolocation(req);
 
   if (country && BLOCKED_COUNTRIES.includes(country)) {


### PR DESCRIPTION
## Summary
- Renames `src/middleware.ts` → `src/proxy.ts` and `middleware()` → `proxy()` per Next.js 16's deprecated "middleware" file convention
- No logic changes — same geolocation-based sanctions blocking

## Test plan
- [ ] Verify no "middleware is deprecated" warning on `pnpm dev`
- [ ] Verify geo-blocking still works on Vercel preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure rename/entrypoint change with no logic changes; main risk is misconfiguration causing the handler not to run if Next.js expects a different export/file name.
> 
> **Overview**
> Renames the Next.js edge entrypoint by moving `src/middleware.ts` to `src/proxy.ts` and changing the exported handler from `middleware()` to `proxy()` to align with the updated Next.js 16 convention.
> 
> No behavioral changes were made to the geolocation-based redirects; only the exported function name/entrypoint is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e492f42dc41120b1d0a31714e2431efb32ffde22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->