### PR TITLE
fix: pin @ledgerhq/errors to 6.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
       "cipher-base": "1.0.5",
       "elliptic": "6.6.1",
       "pbkdf2": "3.1.3",
-      "form-data": "4.0.4"
+      "form-data": "4.0.4",
+      "@ledgerhq/errors": "6.31.0"
     },
     "patchedDependencies": {
       "starknetkit@2.6.1": "patches/starknetkit@2.6.1.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   elliptic: 6.6.1
   pbkdf2: 3.1.3
   form-data: 4.0.4
+  '@ledgerhq/errors': 6.31.0
 
 patchedDependencies:
   '@provablehq/sdk@0.9.15':


### PR DESCRIPTION
## Summary

Pins `@ledgerhq/errors` to `6.31.0` via `pnpm.overrides` to avoid an ESM resolution bug introduced in `6.32.0`.

## The bug

When the monorepo-linked dev flow pulls in `@ledgerhq/errors@6.32.0`, Next.js (on the server) throws at runtime:

```
Failed to load external module @solana/wallet-adapter-wallets-...:
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'.../@ledgerhq/errors/lib-es/helpers' imported from
'.../@ledgerhq/errors/lib-es/index.js'
```

The broken import is in `lib-es/index.js`:

```js
import { ... } from "./helpers";   // no .js extension
```

## Root cause

The extensionless import exists in **both 6.31.0 and 6.32.0** — the string is identical. What changed is how Node resolves it:

- **6.31.0**: no `exports` field → Node uses legacy `main`/`module` resolution, which tolerates extensionless relative specifiers.
- **6.32.0**: LedgerHQ PR #15316 added an `exports` map (to expose an `@ledgerhq/source` condition for IDEs). Once `exports` is present, Node switches to strict conditional-exports resolution, which requires explicit file extensions under ESM → `ERR_MODULE_NOT_FOUND`.

The upstream fix would require switching the `@ledgerhq/*` TS build to `moduleResolution: "NodeNext"` so `.js` extensions are emitted. Not on LedgerHQ's radar yet.

## Why this only surfaced with `link:monorepo`

Published `@hyperlane-xyz/*` packages resolve `@ledgerhq/errors` to `6.31.0` through their dep graph. The monorepo tarballs resolve to `6.32.0`. Same project, different dep tree → different version → different resolution path.

## Why pin to 6.31.0 instead of patching

`6.32.0` only adds five new error classes: `InvalidTransactionError` (for `coin-tron` expired-tx handling) and four `Concordium*` errors. None of them are referenced anywhere in this project's dep graph — verified across `@ledgerhq/hw-transport`, `@ledgerhq/devices`, `@ledgerhq/hw-transport-webhid`, `@solana/wallet-adapter-ledger`, `@tronweb3/tronwallet-adapter-ledger`, and `@ledgerhq/hw-app-*`. The only consumers are `@ledgerhq/coin-evm|tron|concordium` and Ledger Live apps — none of which we depend on. The pin is safe until upstream fixes the build.

## Alternatives considered

- **Patch `lib-es/index.js`** to append `.js` — works, but version-specific and brittle.
- **`transpilePackages: ['@ledgerhq/errors']`** in `next.config.js` — forces Next to bundle it (bundler resolver tolerates extensionless imports). Heavier-handed and depends on Next internals.

One-line override is the simplest fix with the smallest blast radius.