### PR TITLE
fix: restore WalletConnect QR modal by keeping real pino in browser

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -146,7 +146,13 @@ const nextConfig = {
       },
     },
     resolveAlias: {
-      pino: './src/utils/pino-noop.js',
+      // Only shim pino on SSR (Node) where its transport/worker resolution breaks
+      // under Turbopack. In the browser use the real pino browser build, which
+      // exports `levels` that @walletconnect/logger depends on.
+      pino: {
+        browser: 'pino/browser.js',
+        default: './src/utils/pino-noop.js',
+      },
     },
   },
 


### PR DESCRIPTION
## Summary

Clicking WalletConnect in the EVM wallet list crashed before the QR modal could render. Nothing in the UI surfaced — just an unhandled rejection in the console:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'values')
  at new BaseChunkLogger (...)
  at new ChunkLoggerController (...)
  at Core (...)
  at Client.init (...)
  at UniversalProvider.initialize (...)
```

## Root cause

`next.config.js` aliases `pino` to `src/utils/pino-noop.js` under Turbopack. That shim was added when we migrated to Turbopack to avoid pino's transport/worker resolution blowing up during SSR — but the alias applied to every bundling context, including the browser.

`@walletconnect/logger` does `import { levels } from 'pino'` and, inside its `BaseChunkLogger` constructor, reads `levels.values[this.level]`. Our shim didn't export `levels`, so the named import was `undefined` and the first access to `.values` threw. That constructor runs synchronously during `UniversalProvider.init()`, which runs when the user picks WalletConnect, which is why the QR modal never appeared.

## Fix

Scope the pino alias by resolution condition:

- **browser** → `pino/browser.js` (pino's own browser build, which exports `levels` with the expected `{ values, labels }` shape).
- **default (SSR/Node)** → the existing `pino-noop.js` shim, so the original transport resolution issue stays fixed.

No application code needed to be touched. The WalletConnect logger gets the real `levels` export in the browser, the server still avoids pino's transport code path, and we don't carry a forked `levels` table in our shim that would need to stay in sync with pino's.