### PR TITLE
docs: codify runtime review guidelines

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -16,6 +16,11 @@
 - API contract changes
 - **Deduplicate** - Move repeated code/types to shared files
 - **Extract utilities** - Shared functions belong in utils packages
+- **Keep lazy boundaries lazy** - Don't hoist runtime-only helpers/classes to module scope if it turns a dynamic import into a static import
+- **Metadata-first before runtime-first** - If a read path only needs metadata, don't force `warpCore`/runtime just to keep an older API shape
+- **Render-safe vs imperative runtime access** - Render paths should observe readiness (`useReadyWarpCore`, `useReadyMultiProvider`); async action paths should explicitly call `ensureWarpRuntime()`
+- **Protocol opt-in over all-VM wrappers** - Hot paths should import only the protocols they need; avoid both fat all-VM wrappers and unnecessary local map/switch indirection
+- **Prefer narrow public subpaths** - On hot/render-critical paths, prefer specific `@hyperlane-xyz/sdk/*` and `@hyperlane-xyz/widgets/*` subpaths over root barrels when equivalent exports exist
 
 ## Testing
 
@@ -34,7 +39,11 @@
 - **Chain-aware addresses** - Only lowercase EVM hex; Solana/Cosmos are case-sensitive
 - **CSP updates required** - New external scripts/styles need `next.config.js` CSP updates
 - **Avoid floating promises** - In useEffect, use IIFE or separate async function
+- **Lazy import caches must retry** - Promise caches around dynamic imports/loaders must clear themselves on rejection
 - **Use useQuery refetch** - Don't reinvent; use built-in refetch from TanStack Query
+- **Version async rebuilds** - If runtime/provider state can rebuild, include readiness/version in query keys and `enabled` guards instead of caching against a truthy object reference
+- **Use route tokens for route identity** - Address/router/connection-sensitive lookups should use raw `routeTokens`; use deduplicated `tokens` only for picker/read surfaces where route identity is not required
 - **Flatten rendering logic** - Avoid nested if; use early returns instead
 - **Zustand patterns** - Follow existing store patterns in `src/features/store.ts`
 - **Constants outside functions** - Move config/constants outside component functions
+- **Use `assert` for invariants** - Unexpected impossible states/config mismatches should fail loudly instead of silently falling through


### PR DESCRIPTION
## Summary

Codifies the review standards that [hyperlane-xyz/hyperlane-warp-ui-template#1030](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/1030) ended up enforcing.

## What changed

- added lazy-boundary guidance for runtime-only imports
- documented metadata-first vs runtime-first review expectations
- documented render-safe readiness hooks vs imperative `ensureWarpRuntime()` boundaries
- documented protocol opt-in / narrow subpath expectations for hot paths
- documented dynamic-import retry behavior for cached loaders
- documented readiness/version requirements for async rebuild-backed queries
- documented when route-specific logic must use raw `routeTokens`
- documented `assert` usage for invariants

## Why

[hyperlane-xyz/hyperlane-warp-ui-template#1030](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/1030) surfaced a set of recurring review themes around runtime splitting, query invalidation, token identity, and import hygiene. Those standards were real, but they were mostly implicit during review. This makes them explicit for future PRs.

## Impact

Docs only. No runtime behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that updates review guidance; no production code or behavior is modified.
> 
> **Overview**
> Updates `REVIEW.md` to codify additional review standards around runtime splitting and hot-path hygiene (keeping lazy boundaries lazy, preferring metadata-first reads, using render-safe readiness hooks vs `ensureWarpRuntime()`, and opting into narrow protocol/subpath imports).
> 
> Adds frontend guidance for dynamic-import cache retry behavior, query keying/`enabled` guards when runtime/providers can rebuild, using raw `routeTokens` for route identity, and using `assert` for invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4fd7c0eadae4c342c2127e4994f298597d0a589. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
