### PR TITLE
fix: include EvmM0Portal to dedupe tokens

### DIFF
--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -213,7 +213,10 @@ function dedupeTokens(tokens: NullableAddressWarpCoreToken[]): NullableAddressWa
   for (const token of tokens) {
     let id = '';
     // Temporary fix issue for M0 routes where addressOrDenom can be the same
-    if (token.standard === TokenStandard.EvmM0PortalLite) {
+    if (
+      token.standard === TokenStandard.EvmM0PortalLite ||
+      token.standard === TokenStandard.EvmM0Portal
+    ) {
       id = `${token.chainName}|${token.symbol}|${token.addressOrDenom?.toLowerCase()}`;
     } else {
       id = `${token.chainName}|${token.addressOrDenom?.toLowerCase()}`;


### PR DESCRIPTION
fixed an issue where the new standard for M0 tokens were not deduping properly