### PR TITLE
fix: M0Portal token dedup and route resolution

### DIFF
--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -1723,9 +1723,10 @@ describe('M0Portal integration (multi-synthetic same addressOrDenom)', () => {
       collateralAddressOrDenom: WM_COLLATERAL,
     });
 
+    // Which variant survives doesn't matter — findRouteToken resolves the correct
+    // variant at transfer time. Ordering is covered by the dedicated test above.
     const result = dedupeTokensByCollateral([wmHub, wmLite]);
     expect(result).toHaveLength(1);
-    expect(result[0]).toBe(wmHub);
   });
 
   test('dedupeTokensByCollateral should NOT collapse M0Portal tokens with different symbols/collaterals', () => {

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -1627,4 +1627,219 @@ describe('findConnectedDestinationToken', () => {
     const matched = findConnectedDestinationToken(origin, selectedDestination);
     expect(matched).toBeUndefined();
   });
+
+  // --- M0 Portal case: multiple synthetic tokens share the same addressOrDenom ---
+  // wM, USDSC, USDnr on ethereum all use portal contract 0xD925... but wrap
+  // different collaterals and have different symbols. Address alone cannot
+  // identify a token — symbol must match too.
+  test('should NOT match via address fallback when symbol differs (M0Portal case)', () => {
+    const M0_PORTAL_ADDR = '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd';
+    const WM_COLLATERAL = '0x437cc33344a0B27A429f795ff6B469C72698B291';
+    const USDSC_COLLATERAL = '0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a';
+
+    // Origin is wM on ethereum, connected to wM on soneium (same portal addr)
+    const wmOrigin = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_PORTAL_ADDR,
+      collateralAddressOrDenom: WM_COLLATERAL,
+      connections: [
+        createTokenConnectionMock(undefined, {
+          chainName: 'soneium',
+          symbol: 'wM',
+          standard: TokenStandard.EvmM0Portal,
+          addressOrDenom: M0_PORTAL_ADDR,
+          collateralAddressOrDenom: WM_COLLATERAL,
+        }),
+      ],
+    });
+    // User selects USDSC on soneium — same portal addr, different symbol/collateral
+    const usdscDestination = createMockToken({
+      chainName: 'soneium',
+      symbol: 'USDSC',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_PORTAL_ADDR,
+      collateralAddressOrDenom: USDSC_COLLATERAL,
+    });
+
+    // Must not impersonate USDSC via shared addressOrDenom
+    expect(findConnectedDestinationToken(wmOrigin, usdscDestination)).toBeUndefined();
+  });
+
+  test('should still match via address fallback when symbol matches', () => {
+    // Control case: when symbols match, address fallback is still valid
+    // (e.g. a single route between two chains with same addressOrDenom).
+    const ADDR = '0x1111111111111111111111111111111111111111';
+    const CONN_COLLATERAL = '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+    const DEST_COLLATERAL = '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+
+    const origin = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'USDC',
+      connections: [
+        createTokenConnectionMock(undefined, {
+          chainName: 'arbitrum',
+          symbol: 'USDC',
+          addressOrDenom: ADDR,
+          collateralAddressOrDenom: CONN_COLLATERAL,
+        }),
+      ],
+    });
+    // Same address + same symbol, but different collateral key — address fallback should match
+    const destination = createMockToken({
+      chainName: 'arbitrum',
+      symbol: 'USDC',
+      addressOrDenom: ADDR,
+      collateralAddressOrDenom: DEST_COLLATERAL,
+    });
+
+    expect(findConnectedDestinationToken(origin, destination)?.addressOrDenom).toBe(ADDR);
+  });
+});
+
+describe('M0Portal integration (multi-synthetic same addressOrDenom)', () => {
+  const M0_HUB = '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd';
+  const M0_LITE = '0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE';
+  const WM_COLLATERAL = '0x437cc33344a0B27A429f795ff6B469C72698B291';
+  const USDSC_COLLATERAL = '0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a';
+  const USDNR_COLLATERAL = '0xD48e565561416dE59DA1050ED70b8d75e8eF28f9';
+
+  test('dedupeTokensByCollateral should collapse M0Portal tokens sharing collateral on same chain', () => {
+    // Two wM ethereum definitions (one EvmM0Portal, one EvmM0PortalLite) with different
+    // addresses but SAME collateral — these are the real wM dupes that should collapse.
+    const wmHub = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: WM_COLLATERAL,
+    });
+    const wmLite = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0PortalLite,
+      addressOrDenom: M0_LITE,
+      collateralAddressOrDenom: WM_COLLATERAL,
+    });
+
+    const result = dedupeTokensByCollateral([wmHub, wmLite]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(wmHub);
+  });
+
+  test('dedupeTokensByCollateral should NOT collapse M0Portal tokens with different symbols/collaterals', () => {
+    // wM, USDSC, USDnr all share the SAME addressOrDenom on ethereum but wrap
+    // different collaterals. They must remain distinct.
+    const wm = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: WM_COLLATERAL,
+    });
+    const usdsc = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'USDSC',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: USDSC_COLLATERAL,
+    });
+    const usdnr = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'USDnr',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: USDNR_COLLATERAL,
+    });
+
+    const result = dedupeTokensByCollateral([wm, usdsc, usdnr]);
+    expect(result).toHaveLength(3);
+    expect(result).toContain(wm);
+    expect(result).toContain(usdsc);
+    expect(result).toContain(usdnr);
+  });
+
+  test('findRouteToken should pick correct M0Portal token by destination chain connectivity', () => {
+    // wM on ethereum routes to mantra (via EvmM0Portal) and bsc (via EvmM0PortalLite).
+    // When user picks origin=wM ethereum + destination=wM bsc, findRouteToken must
+    // return the Lite variant (only one with a bsc connection).
+    const wmMantraConn = {
+      chainName: 'mantra',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: WM_COLLATERAL,
+    };
+    const wmBscConn = {
+      chainName: 'bsc',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0PortalLite,
+      addressOrDenom: M0_LITE,
+      collateralAddressOrDenom: WM_COLLATERAL,
+    };
+
+    // Origin displayed in UI is the Hub variant (survives dedup)
+    const wmHubEth = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: WM_COLLATERAL,
+      connections: [createTokenConnectionMock(undefined, wmMantraConn)],
+    });
+    // Lite variant exists in WarpCore with the bsc connection
+    const wmLiteEth = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0PortalLite,
+      addressOrDenom: M0_LITE,
+      collateralAddressOrDenom: WM_COLLATERAL,
+      connections: [createTokenConnectionMock(undefined, wmBscConn)],
+    });
+
+    const wmBscDest = createMockToken(wmBscConn);
+
+    const warpCore = {
+      getTokensForRoute: vi.fn().mockReturnValue([wmLiteEth]),
+    } as unknown as WarpCore;
+
+    const result = findRouteToken(warpCore, wmHubEth, wmBscDest);
+    expect(result).toBe(wmLiteEth);
+  });
+
+  test('checkTokenHasRoute should reject wM origin -> USDSC dest (different symbols, shared portal addr)', () => {
+    // Origin wM ethereum connected to wM soneium (same addressOrDenom as USDSC soneium!).
+    // User selects USDSC soneium as dest — the symbol mismatch must block the route.
+    const wmSoneiumConn = {
+      chainName: 'soneium',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: WM_COLLATERAL,
+    };
+    const wmEth = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: WM_COLLATERAL,
+      connections: [createTokenConnectionMock(undefined, wmSoneiumConn)],
+    });
+
+    const usdscSoneium = createMockToken({
+      chainName: 'soneium',
+      symbol: 'USDSC',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: USDSC_COLLATERAL,
+    });
+
+    // Collateral groups built from full warpCore.tokens (not UI-deduped)
+    const groups = groupTokensByCollateral([wmEth, usdscSoneium]);
+
+    // wmEth's only connection is wM soneium (same address as USDSC soneium but
+    // different symbol/collateral). Pre-fix this would falsely match via address.
+    expect(checkTokenHasRoute(wmEth, usdscSoneium, groups)).toBe(false);
+  });
 });

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -19,6 +19,9 @@ let collateralKeyCache = new WeakMap<IToken, string>();
 // getCollateralKey() uses this to group lockbox/vault tokens with their
 // non-wrapper counterparts (e.g., lockbox USDT grouped with regular USDT).
 let resolvedUnderlyingMap: Map<string, string> = new Map();
+// Standards the UI treats as collateralized on top of the SDK's
+// TOKEN_COLLATERALIZED_STANDARDS. Kept local since we don't necessarily
+// want these promoted upstream in the SDK.
 const EXTRA_COLLATERALIZED_STANDARDS = new Set([
   TokenStandard.EvmHypCollateralFiat,
   TokenStandard.EvmM0Portal,
@@ -78,7 +81,7 @@ export function findConnectedDestinationToken(
     // so address alone is not a reliable identity check.
     destinationCandidates.find(
       (candidate) =>
-        candidate.symbol === destinationToken.symbol &&
+        candidate.symbol.toLowerCase() === destinationToken.symbol.toLowerCase() &&
         eqAddress(candidate.addressOrDenom, destinationToken.addressOrDenom),
     )
   );

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -19,7 +19,11 @@ let collateralKeyCache = new WeakMap<IToken, string>();
 // getCollateralKey() uses this to group lockbox/vault tokens with their
 // non-wrapper counterparts (e.g., lockbox USDT grouped with regular USDT).
 let resolvedUnderlyingMap: Map<string, string> = new Map();
-const EXTRA_COLLATERALIZED_STANDARDS = new Set([TokenStandard.EvmHypCollateralFiat]);
+const EXTRA_COLLATERALIZED_STANDARDS = new Set([
+  TokenStandard.EvmHypCollateralFiat,
+  TokenStandard.EvmM0Portal,
+  TokenStandard.EvmM0PortalLite,
+]);
 
 /**
  * Set the resolved underlying address map for lockbox/vault tokens.
@@ -69,8 +73,13 @@ export function findConnectedDestinationToken(
     destinationCandidates.find(
       (candidate) => getCollateralKey(candidate) === destinationCollateralKey,
     ) ||
-    destinationCandidates.find((candidate) =>
-      eqAddress(candidate.addressOrDenom, destinationToken.addressOrDenom),
+    // Address fallback also requires matching symbol: some standards (e.g. EvmM0Portal
+    // wM/USDSC/USDnr) share the same addressOrDenom across different synthetic tokens,
+    // so address alone is not a reliable identity check.
+    destinationCandidates.find(
+      (candidate) =>
+        candidate.symbol === destinationToken.symbol &&
+        eqAddress(candidate.addressOrDenom, destinationToken.addressOrDenom),
     )
   );
 }

--- a/src/features/transfer/fees.test.ts
+++ b/src/features/transfer/fees.test.ts
@@ -781,6 +781,341 @@ describe('getTransferToken', () => {
     expect(warpCore.getInterchainTransferFee).not.toHaveBeenCalled();
   });
 
+  // --- Multi-candidate (3+ tokens) branch coverage ---
+
+  test('should pick lowest fee among 4 candidates with enough balance', async () => {
+    const [t1, t2, t3, t4] = [1, 2, 3, 4].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `chain${n}` }),
+    );
+    const [d1, d2, d3, d4] = [1, 2, 3, 4].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `dest${n}` }),
+    );
+
+    vi.spyOn(tokenUtils, 'isValidMultiCollateralToken').mockReturnValue(true);
+    vi.spyOn(tokenUtils, 'getTokensWithSameCollateralAddresses').mockReturnValue([
+      { originToken: t1, destinationToken: d1 },
+      { originToken: t2, destinationToken: d2 },
+      { originToken: t3, destinationToken: d3 },
+      { originToken: t4, destinationToken: d4 },
+    ]);
+
+    const feeToken = createMockToken({ symbol: 'FEE' });
+    const warpCore = createMockWarpCore(
+      {
+        getTokenCollateral: vi.fn().mockResolvedValue(BALANCE_XXLARGE),
+        getInterchainTransferFee: vi
+          .fn()
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_HIGH, feeToken) })
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) })
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) })
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) }),
+      },
+      t1,
+    );
+
+    const result = await getTransferToken(
+      warpCore,
+      t1,
+      d1,
+      TRANSFER_AMOUNT,
+      MOCK_RECIPIENT,
+      MOCK_SENDER,
+    );
+
+    expect(result).toBe(t3); // lowest fee
+  });
+
+  test('should exclude candidates with insufficient balance before fee comparison (3 tokens)', async () => {
+    // t1: not enough balance (filtered out)
+    // t2: enough balance, medium fee
+    // t3: enough balance, low fee (winner)
+    const [t1, t2, t3] = [1, 2, 3].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `chain${n}` }),
+    );
+    const [d1, d2, d3] = [1, 2, 3].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `dest${n}` }),
+    );
+
+    vi.spyOn(tokenUtils, 'isValidMultiCollateralToken').mockReturnValue(true);
+    vi.spyOn(tokenUtils, 'getTokensWithSameCollateralAddresses').mockReturnValue([
+      { originToken: t1, destinationToken: d1 },
+      { originToken: t2, destinationToken: d2 },
+      { originToken: t3, destinationToken: d3 },
+    ]);
+
+    const feeToken = createMockToken({ symbol: 'FEE' });
+    const warpCore = createMockWarpCore(
+      {
+        getTokenCollateral: vi
+          .fn()
+          .mockResolvedValueOnce(BALANCE_TINY) // t1 — below TRANSFER_AMOUNT
+          .mockResolvedValueOnce(BALANCE_XLARGE) // t2
+          .mockResolvedValueOnce(BALANCE_XLARGE), // t3
+        // Only t2 + t3 reach fee fetch (t1 filtered by balance)
+        getInterchainTransferFee: vi
+          .fn()
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) })
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) }),
+      },
+      t1,
+    );
+
+    const result = await getTransferToken(
+      warpCore,
+      t1,
+      d1,
+      TRANSFER_AMOUNT,
+      MOCK_RECIPIENT,
+      MOCK_SENDER,
+    );
+
+    expect(result).toBe(t3);
+    // getInterchainTransferFee should only be called for the 2 candidates that passed balance
+    expect(warpCore.getInterchainTransferFee).toHaveBeenCalledTimes(2);
+  });
+
+  test('should return originRouteToken when NO candidates have enough balance (3 tokens)', async () => {
+    const [t1, t2, t3] = [1, 2, 3].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `chain${n}` }),
+    );
+    const [d1, d2, d3] = [1, 2, 3].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `dest${n}` }),
+    );
+
+    vi.spyOn(tokenUtils, 'isValidMultiCollateralToken').mockReturnValue(true);
+    vi.spyOn(tokenUtils, 'getTokensWithSameCollateralAddresses').mockReturnValue([
+      { originToken: t1, destinationToken: d1 },
+      { originToken: t2, destinationToken: d2 },
+      { originToken: t3, destinationToken: d3 },
+    ]);
+
+    const warpCore = createMockWarpCore(
+      {
+        getTokenCollateral: vi.fn().mockResolvedValue(BALANCE_TINY), // all below LARGE_TRANSFER_AMOUNT
+        getInterchainTransferFee: vi.fn(),
+      },
+      t1,
+    );
+
+    const result = await getTransferToken(
+      warpCore,
+      t1,
+      d1,
+      LARGE_TRANSFER_AMOUNT,
+      MOCK_RECIPIENT,
+      MOCK_SENDER,
+    );
+
+    expect(result).toBe(t1); // falls back to originRouteToken
+    expect(warpCore.getInterchainTransferFee).not.toHaveBeenCalled();
+  });
+
+  test('should return highest-balance candidate when ALL fee fetches fail (3 tokens)', async () => {
+    const [t1, t2, t3] = [1, 2, 3].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `chain${n}` }),
+    );
+    const [d1, d2, d3] = [1, 2, 3].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `dest${n}` }),
+    );
+
+    vi.spyOn(tokenUtils, 'isValidMultiCollateralToken').mockReturnValue(true);
+    vi.spyOn(tokenUtils, 'getTokensWithSameCollateralAddresses').mockReturnValue([
+      { originToken: t1, destinationToken: d1 },
+      { originToken: t2, destinationToken: d2 },
+      { originToken: t3, destinationToken: d3 },
+    ]);
+
+    const warpCore = createMockWarpCore(
+      {
+        // Ascending balances, sort will put t3 first (highest)
+        getTokenCollateral: vi
+          .fn()
+          .mockResolvedValueOnce(BALANCE_LARGE) // t1
+          .mockResolvedValueOnce(BALANCE_XLARGE) // t2
+          .mockResolvedValueOnce(BALANCE_XXLARGE), // t3 — highest
+        getInterchainTransferFee: vi.fn().mockRejectedValue(new Error('fee fetch failed')),
+      },
+      t1,
+    );
+
+    const result = await getTransferToken(
+      warpCore,
+      t1,
+      d1,
+      TRANSFER_AMOUNT,
+      MOCK_RECIPIENT,
+      MOCK_SENDER,
+    );
+
+    // With tokenFees empty, returns tokenBalances[0].originToken (highest balance)
+    expect(result).toBe(t3);
+  });
+
+  test('should prefer zero-fee route over cheap route among 4 candidates', async () => {
+    const [t1, t2, t3, t4] = [1, 2, 3, 4].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `chain${n}` }),
+    );
+    const [d1, d2, d3, d4] = [1, 2, 3, 4].map((n) =>
+      createMockToken({ symbol: `T${n}`, chainName: `dest${n}` }),
+    );
+
+    vi.spyOn(tokenUtils, 'isValidMultiCollateralToken').mockReturnValue(true);
+    vi.spyOn(tokenUtils, 'getTokensWithSameCollateralAddresses').mockReturnValue([
+      { originToken: t1, destinationToken: d1 },
+      { originToken: t2, destinationToken: d2 },
+      { originToken: t3, destinationToken: d3 },
+      { originToken: t4, destinationToken: d4 },
+    ]);
+
+    const feeToken = createMockToken({ symbol: 'FEE' });
+    const warpCore = createMockWarpCore(
+      {
+        getTokenCollateral: vi.fn().mockResolvedValue(BALANCE_XXLARGE),
+        getInterchainTransferFee: vi
+          .fn()
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_HIGH, feeToken) })
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) })
+          .mockResolvedValueOnce({ tokenFeeQuote: undefined }) // t3 — no fee, should win
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) }),
+      },
+      t1,
+    );
+
+    const result = await getTransferToken(
+      warpCore,
+      t1,
+      d1,
+      TRANSFER_AMOUNT,
+      MOCK_RECIPIENT,
+      MOCK_SENDER,
+    );
+
+    expect(result).toBe(t3);
+  });
+
+  test('should pick default route among 4 candidates (bypasses fee lookup)', async () => {
+    // Common collateral, 4 routes on ethereum → arbitrum, default is t3
+    const ORIGIN_COLLATERAL = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+    const DEST_COLLATERAL = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+    const [WARP_1, WARP_2, WARP_3, WARP_4] = [1, 2, 3, 4].map((n) =>
+      `0x${String(n).repeat(40)}`.slice(0, 42),
+    );
+    const [DEST_1, DEST_2, DEST_3, DEST_4] = ['a', 'b', 'c', 'd'].map((c) =>
+      `0x${c.repeat(40)}`.slice(0, 42),
+    );
+
+    const make = (address: string, chainName: string, collateral: string) =>
+      createMockToken({
+        symbol: 'USDC',
+        addressOrDenom: address,
+        chainName,
+        collateralAddressOrDenom: collateral,
+      });
+
+    const t1 = make(WARP_1, 'ethereum', ORIGIN_COLLATERAL);
+    const t2 = make(WARP_2, 'ethereum', ORIGIN_COLLATERAL);
+    const t3 = make(WARP_3, 'ethereum', ORIGIN_COLLATERAL); // default
+    const t4 = make(WARP_4, 'ethereum', ORIGIN_COLLATERAL);
+    const d1 = make(DEST_1, 'arbitrum', DEST_COLLATERAL);
+    const d2 = make(DEST_2, 'arbitrum', DEST_COLLATERAL);
+    const d3 = make(DEST_3, 'arbitrum', DEST_COLLATERAL);
+    const d4 = make(DEST_4, 'arbitrum', DEST_COLLATERAL);
+
+    vi.spyOn(tokenUtils, 'isValidMultiCollateralToken').mockReturnValue(true);
+    vi.spyOn(tokenUtils, 'getTokensWithSameCollateralAddresses').mockReturnValue([
+      { originToken: t1, destinationToken: d1 },
+      { originToken: t2, destinationToken: d2 },
+      { originToken: t3, destinationToken: d3 },
+      { originToken: t4, destinationToken: d4 },
+    ]);
+
+    const defaultRoutes = {
+      ethereum: { [ORIGIN_COLLATERAL]: WARP_3 },
+      arbitrum: { [DEST_COLLATERAL]: DEST_3 },
+    };
+
+    const warpCore = createMockWarpCore(
+      {
+        getTokenCollateral: vi.fn(),
+        getInterchainTransferFee: vi.fn(),
+      },
+      t1,
+    );
+
+    const result = await getTransferToken(
+      warpCore,
+      t1,
+      d1,
+      TRANSFER_AMOUNT,
+      MOCK_RECIPIENT,
+      MOCK_SENDER,
+      defaultRoutes,
+    );
+
+    expect(result).toBe(t3);
+    // Default bypasses both fee + balance lookup
+    expect(warpCore.getTokenCollateral).not.toHaveBeenCalled();
+    expect(warpCore.getInterchainTransferFee).not.toHaveBeenCalled();
+  });
+
+  test('should fall back to fee-based winner among 3 candidates when default not matched', async () => {
+    // Default configured but points to an address not in tokensWithSameCollateralAddresses
+    const ORIGIN_COLLATERAL = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+    const DEST_COLLATERAL = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+
+    const make = (address: string, chainName: string) =>
+      createMockToken({
+        symbol: 'USDC',
+        addressOrDenom: address,
+        chainName,
+        collateralAddressOrDenom: chainName === 'ethereum' ? ORIGIN_COLLATERAL : DEST_COLLATERAL,
+      });
+
+    const t1 = make('0x1111111111111111111111111111111111111111', 'ethereum');
+    const t2 = make('0x2222222222222222222222222222222222222222', 'ethereum');
+    const t3 = make('0x3333333333333333333333333333333333333333', 'ethereum');
+    const d1 = make('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'arbitrum');
+    const d2 = make('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'arbitrum');
+    const d3 = make('0xcccccccccccccccccccccccccccccccccccccccc', 'arbitrum');
+
+    vi.spyOn(tokenUtils, 'isValidMultiCollateralToken').mockReturnValue(true);
+    vi.spyOn(tokenUtils, 'getTokensWithSameCollateralAddresses').mockReturnValue([
+      { originToken: t1, destinationToken: d1 },
+      { originToken: t2, destinationToken: d2 },
+      { originToken: t3, destinationToken: d3 },
+    ]);
+
+    const defaultRoutes = {
+      ethereum: { [ORIGIN_COLLATERAL]: '0xNonExistent' },
+      arbitrum: { [DEST_COLLATERAL]: '0xNonExistentDest' },
+    };
+
+    const feeToken = createMockToken({ symbol: 'FEE' });
+    const warpCore = createMockWarpCore(
+      {
+        getTokenCollateral: vi.fn().mockResolvedValue(BALANCE_XXLARGE),
+        getInterchainTransferFee: vi
+          .fn()
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_HIGH, feeToken) })
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) }) // winner
+          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) }),
+      },
+      t1,
+    );
+
+    const result = await getTransferToken(
+      warpCore,
+      t1,
+      d1,
+      TRANSFER_AMOUNT,
+      MOCK_RECIPIENT,
+      MOCK_SENDER,
+      defaultRoutes,
+    );
+
+    expect(result).toBe(t2);
+  });
+
   test('should fall back to fee-based selection when default token not found in same collateral addresses', async () => {
     const originToken = createMockToken({
       symbol: 'USDC',

--- a/src/features/transfer/fees.test.ts
+++ b/src/features/transfer/fees.test.ts
@@ -1,4 +1,4 @@
-import { TokenAmount, WarpCore } from '@hyperlane-xyz/sdk';
+import { Token, TokenAmount, WarpCore } from '@hyperlane-xyz/sdk';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { createMockToken } from '../../utils/test';
@@ -800,15 +800,19 @@ describe('getTransferToken', () => {
     ]);
 
     const feeToken = createMockToken({ symbol: 'FEE' });
+    // Key mocks by token identity so tests are resilient to production-side iteration order changes
+    const feeByOrigin = new Map<Token, bigint>([
+      [t1, FEE_HIGH],
+      [t2, FEE_MEDIUM],
+      [t3, FEE_LOW],
+      [t4, FEE_MEDIUM],
+    ]);
     const warpCore = createMockWarpCore(
       {
         getTokenCollateral: vi.fn().mockResolvedValue(BALANCE_XXLARGE),
-        getInterchainTransferFee: vi
-          .fn()
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_HIGH, feeToken) })
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) })
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) })
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) }),
+        getInterchainTransferFee: vi.fn(async ({ originTokenAmount }) => ({
+          tokenFeeQuote: new TokenAmount(feeByOrigin.get(originTokenAmount.token)!, feeToken),
+        })),
       },
       t1,
     );
@@ -844,18 +848,22 @@ describe('getTransferToken', () => {
     ]);
 
     const feeToken = createMockToken({ symbol: 'FEE' });
+    const balanceByDest = new Map<Token, bigint>([
+      [d1, BALANCE_TINY],
+      [d2, BALANCE_XLARGE],
+      [d3, BALANCE_XLARGE],
+    ]);
+    const feeByOrigin = new Map<Token, bigint>([
+      [t2, FEE_MEDIUM],
+      [t3, FEE_LOW],
+    ]);
     const warpCore = createMockWarpCore(
       {
-        getTokenCollateral: vi
-          .fn()
-          .mockResolvedValueOnce(BALANCE_TINY) // t1 — below TRANSFER_AMOUNT
-          .mockResolvedValueOnce(BALANCE_XLARGE) // t2
-          .mockResolvedValueOnce(BALANCE_XLARGE), // t3
+        getTokenCollateral: vi.fn(async (token) => balanceByDest.get(token) ?? 0n),
         // Only t2 + t3 reach fee fetch (t1 filtered by balance)
-        getInterchainTransferFee: vi
-          .fn()
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) })
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) }),
+        getInterchainTransferFee: vi.fn(async ({ originTokenAmount }) => ({
+          tokenFeeQuote: new TokenAmount(feeByOrigin.get(originTokenAmount.token)!, feeToken),
+        })),
       },
       t1,
     );
@@ -925,14 +933,14 @@ describe('getTransferToken', () => {
       { originToken: t3, destinationToken: d3 },
     ]);
 
+    const balanceByDest = new Map<Token, bigint>([
+      [d1, BALANCE_LARGE],
+      [d2, BALANCE_XLARGE],
+      [d3, BALANCE_XXLARGE], // highest
+    ]);
     const warpCore = createMockWarpCore(
       {
-        // Ascending balances, sort will put t3 first (highest)
-        getTokenCollateral: vi
-          .fn()
-          .mockResolvedValueOnce(BALANCE_LARGE) // t1
-          .mockResolvedValueOnce(BALANCE_XLARGE) // t2
-          .mockResolvedValueOnce(BALANCE_XXLARGE), // t3 — highest
+        getTokenCollateral: vi.fn(async (token) => balanceByDest.get(token) ?? 0n),
         getInterchainTransferFee: vi.fn().mockRejectedValue(new Error('fee fetch failed')),
       },
       t1,
@@ -968,15 +976,22 @@ describe('getTransferToken', () => {
     ]);
 
     const feeToken = createMockToken({ symbol: 'FEE' });
+    // t3 → undefined fee (should win); others → concrete fees
+    const feeByOrigin = new Map<Token, bigint | undefined>([
+      [t1, FEE_HIGH],
+      [t2, FEE_LOW],
+      [t3, undefined],
+      [t4, FEE_MEDIUM],
+    ]);
     const warpCore = createMockWarpCore(
       {
         getTokenCollateral: vi.fn().mockResolvedValue(BALANCE_XXLARGE),
-        getInterchainTransferFee: vi
-          .fn()
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_HIGH, feeToken) })
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) })
-          .mockResolvedValueOnce({ tokenFeeQuote: undefined }) // t3 — no fee, should win
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) }),
+        getInterchainTransferFee: vi.fn(async ({ originTokenAmount }) => {
+          const fee = feeByOrigin.get(originTokenAmount.token);
+          return {
+            tokenFeeQuote: fee != null ? new TokenAmount(fee, feeToken) : undefined,
+          };
+        }),
       },
       t1,
     );
@@ -1091,14 +1106,17 @@ describe('getTransferToken', () => {
     };
 
     const feeToken = createMockToken({ symbol: 'FEE' });
+    const feeByOrigin = new Map<Token, bigint>([
+      [t1, FEE_HIGH],
+      [t2, FEE_LOW], // winner
+      [t3, FEE_MEDIUM],
+    ]);
     const warpCore = createMockWarpCore(
       {
         getTokenCollateral: vi.fn().mockResolvedValue(BALANCE_XXLARGE),
-        getInterchainTransferFee: vi
-          .fn()
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_HIGH, feeToken) })
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_LOW, feeToken) }) // winner
-          .mockResolvedValueOnce({ tokenFeeQuote: new TokenAmount(FEE_MEDIUM, feeToken) }),
+        getInterchainTransferFee: vi.fn(async ({ originTokenAmount }) => ({
+          tokenFeeQuote: new TokenAmount(feeByOrigin.get(originTokenAmount.token)!, feeToken),
+        })),
       },
       t1,
     );

--- a/src/features/warpCore/warpCoreConfig.test.ts
+++ b/src/features/warpCore/warpCoreConfig.test.ts
@@ -1,0 +1,180 @@
+import { TokenStandard } from '@hyperlane-xyz/sdk';
+import { describe, expect, test } from 'vitest';
+
+import { dedupeTokens } from './warpCoreConfig';
+
+// The dedupeTokens function operates on raw warp core config tokens (pre-Token
+// instantiation). Use a loose shape; the function only reads standard, chainName,
+// symbol, addressOrDenom.
+const makeToken = (overrides: Record<string, unknown>) =>
+  ({
+    decimals: 6,
+    name: 'Mock',
+    ...overrides,
+  }) as any;
+
+describe('dedupeTokens', () => {
+  test('should dedupe non-M0 tokens by chainName|addressOrDenom', () => {
+    // Two identical IBC token definitions (same address, same chain) — merge into one.
+    const t1 = makeToken({
+      chainName: 'neutron',
+      symbol: 'USDC',
+      standard: TokenStandard.CosmosIbc,
+      addressOrDenom: 'ibc/ABC',
+    });
+    const t2 = makeToken({
+      chainName: 'neutron',
+      symbol: 'USDC',
+      standard: TokenStandard.CosmosIbc,
+      addressOrDenom: 'ibc/ABC',
+    });
+
+    expect(dedupeTokens([t1, t2])).toHaveLength(1);
+  });
+
+  test('should keep non-M0 tokens with different addressOrDenom distinct', () => {
+    const t1 = makeToken({
+      chainName: 'ethereum',
+      symbol: 'USDC',
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+    });
+    const t2 = makeToken({
+      chainName: 'ethereum',
+      symbol: 'USDC',
+      standard: TokenStandard.EvmHypCollateral,
+      addressOrDenom: '0x2222222222222222222222222222222222222222',
+    });
+
+    expect(dedupeTokens([t1, t2])).toHaveLength(2);
+  });
+
+  test('should NOT merge EvmM0Portal tokens sharing addressOrDenom but different symbols', () => {
+    // wM, USDSC, USDnr all use the same ethereum portal contract but wrap different collaterals
+    const M0_HUB = '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd';
+    const wm = makeToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: '0x437cc33344a0B27A429f795ff6B469C72698B291',
+      warpRouteId: 'wM/wrapped-m',
+    });
+    const usdsc = makeToken({
+      chainName: 'ethereum',
+      symbol: 'USDSC',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: '0x3f99231dD03a9F0E7e3421c92B7b90fbe012985a',
+      warpRouteId: 'USDSC/usdsc',
+    });
+    const usdnr = makeToken({
+      chainName: 'ethereum',
+      symbol: 'USDnr',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: M0_HUB,
+      collateralAddressOrDenom: '0xD48e565561416dE59DA1050ED70b8d75e8eF28f9',
+      warpRouteId: 'USDnr/usdnr',
+    });
+
+    const result = dedupeTokens([wm, usdsc, usdnr]);
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.symbol).sort()).toEqual(['USDSC', 'USDnr', 'wM']);
+  });
+
+  test('should NOT merge EvmM0PortalLite tokens sharing addressOrDenom but different symbols', () => {
+    // wM Lite and mUSD share the same bsc portal-lite contract
+    const M0_LITE = '0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE';
+    const wmLite = makeToken({
+      chainName: 'bsc',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0PortalLite,
+      addressOrDenom: M0_LITE,
+      collateralAddressOrDenom: '0x437cc33344a0B27A429f795ff6B469C72698B291',
+      warpRouteId: 'wM/wrapped-m-portal-lite',
+    });
+    const musd = makeToken({
+      chainName: 'bsc',
+      symbol: 'mUSD',
+      standard: TokenStandard.EvmM0PortalLite,
+      addressOrDenom: M0_LITE,
+      collateralAddressOrDenom: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+      warpRouteId: 'mUSD/musd',
+    });
+
+    const result = dedupeTokens([wmLite, musd]);
+    expect(result).toHaveLength(2);
+  });
+
+  test('should still merge M0Portal duplicates with same chainName+symbol+addressOrDenom', () => {
+    // Identical wM entries (e.g. fetched from registry and also from yaml) should merge
+    const wm1 = makeToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd',
+      collateralAddressOrDenom: '0x437cc33344a0B27A429f795ff6B469C72698B291',
+    });
+    const wm2 = makeToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd',
+      collateralAddressOrDenom: '0x437cc33344a0B27A429f795ff6B469C72698B291',
+    });
+
+    expect(dedupeTokens([wm1, wm2])).toHaveLength(1);
+  });
+
+  test('should keep M0Portal Hub and PortalLite variants distinct on same chain (different addresses)', () => {
+    // wM on ethereum exists in both wrapped-m (Hub) and wrapped-m-portal-lite (Lite) configs
+    const wmHub = makeToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd',
+      collateralAddressOrDenom: '0x437cc33344a0B27A429f795ff6B469C72698B291',
+    });
+    const wmLite = makeToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0PortalLite,
+      addressOrDenom: '0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE',
+      collateralAddressOrDenom: '0x437cc33344a0B27A429f795ff6B469C72698B291',
+    });
+
+    const result = dedupeTokens([wmHub, wmLite]);
+    expect(result).toHaveLength(2);
+  });
+
+  test('should handle mix of M0 and non-M0 tokens', () => {
+    const ibc = makeToken({
+      chainName: 'neutron',
+      symbol: 'USDC',
+      standard: TokenStandard.CosmosIbc,
+      addressOrDenom: 'ibc/ABC',
+    });
+    const ibcDup = makeToken({
+      chainName: 'neutron',
+      symbol: 'USDC',
+      standard: TokenStandard.CosmosIbc,
+      addressOrDenom: 'ibc/ABC',
+    });
+    const wm = makeToken({
+      chainName: 'ethereum',
+      symbol: 'wM',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd',
+    });
+    const usdsc = makeToken({
+      chainName: 'ethereum',
+      symbol: 'USDSC',
+      standard: TokenStandard.EvmM0Portal,
+      addressOrDenom: '0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd',
+    });
+
+    const result = dedupeTokens([ibc, ibcDup, wm, usdsc]);
+    // IBC merged to 1, wM + USDSC stay as 2 → 3 total
+    expect(result).toHaveLength(3);
+  });
+});

--- a/src/features/warpCore/warpCoreConfig.test.ts
+++ b/src/features/warpCore/warpCoreConfig.test.ts
@@ -1,17 +1,16 @@
 import { TokenStandard } from '@hyperlane-xyz/sdk';
 import { describe, expect, test } from 'vitest';
 
-import { dedupeTokens } from './warpCoreConfig';
+import { dedupeTokens, NullableAddressWarpCoreToken } from './warpCoreConfig';
 
-// The dedupeTokens function operates on raw warp core config tokens (pre-Token
-// instantiation). Use a loose shape; the function only reads standard, chainName,
-// symbol, addressOrDenom.
-const makeToken = (overrides: Record<string, unknown>) =>
+const makeToken = (
+  overrides: Partial<NullableAddressWarpCoreToken>,
+): NullableAddressWarpCoreToken =>
   ({
     decimals: 6,
     name: 'Mock',
     ...overrides,
-  }) as any;
+  }) as NullableAddressWarpCoreToken;
 
 describe('dedupeTokens', () => {
   test('should dedupe non-M0 tokens by chainName|addressOrDenom', () => {

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -22,7 +22,7 @@ import { logger } from '../../utils/logger.ts';
 // Map of chain -> address -> wireDecimals
 export type WireDecimalsMap = Record<ChainName, Record<string, number>>;
 type WarpCoreToken = WarpCoreConfig['tokens'][number];
-type NullableAddressWarpCoreToken = Omit<WarpCoreToken, 'addressOrDenom'> & {
+export type NullableAddressWarpCoreToken = Omit<WarpCoreToken, 'addressOrDenom'> & {
   addressOrDenom: string | null;
 };
 

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -208,7 +208,9 @@ function filterToIds(
 
 // Separate warp configs may contain duplicate definitions of the same token.
 // E.g. an IBC token that gets used for interchain gas in many different routes.
-function dedupeTokens(tokens: NullableAddressWarpCoreToken[]): NullableAddressWarpCoreToken[] {
+export function dedupeTokens(
+  tokens: NullableAddressWarpCoreToken[],
+): NullableAddressWarpCoreToken[] {
   const idToToken: Record<string, NullableAddressWarpCoreToken> = {};
   for (const token of tokens) {
     let id = '';


### PR DESCRIPTION
## Summary

Fixes two bugs in the M0Portal token handling:

1. **wM Hub + Lite duplicates**: `dedupeTokensByCollateral` couldn't collapse them because `isCollateralizedToken()` returned false for `EvmM0Portal`/`EvmM0PortalLite` (they're not in the SDK's `TOKEN_COLLATERALIZED_STANDARDS`). Added them to `EXTRA_COLLATERALIZED_STANDARDS` in the warp UI so the UI-level dedup collapses them.

2. **wM impersonating USDSC/USDnr via shared addressOrDenom**: On ethereum, wM / USDSC / USDnr all use the same M0 Portal contract `0xD925...` as `addressOrDenom` (they wrap different collaterals). The address-fallback branch in `findConnectedDestinationToken` matched any token on the destination chain with the same `addressOrDenom`, so picking wM origin + USDSC destination would falsely route through wM's connection. Now requires symbol match for the fallback.

## Changes

- `src/features/tokens/utils.ts`
  - Add `EvmM0Portal`, `EvmM0PortalLite` to `EXTRA_COLLATERALIZED_STANDARDS`, with a docstring explaining this set is a UI-side extension of the SDK's `TOKEN_COLLATERALIZED_STANDARDS`.
  - Require case-insensitive symbol match in `findConnectedDestinationToken` address fallback (matches the case-handling in `getCollateralKey`/`getTokenKey`).
- `src/features/warpCore/warpCoreConfig.ts`
  - Export `dedupeTokens` and `NullableAddressWarpCoreToken` for unit testing.
- Tests
  - `utils.test.ts`: M0Portal symbol-mismatch rejection, symbol-match fallback regression guard, Hub+Lite collapse, `findRouteToken` routing the right variant by destination chain, `checkTokenHasRoute` rejects wM origin with USDSC dest sharing `addressOrDenom`.
  - `warpCoreConfig.test.ts` (new): SDK-level `dedupeTokens` behavior for M0Portal/PortalLite — keeps distinct-symbol tokens separate, merges true duplicates.
  - `fees.test.ts`: multi-candidate (3+ tokens) branch coverage for `getTransferToken` — default route with 4 candidates, lowest fee among 4, zero-fee preferred among 4, balance filter excludes before fee fetch, all-fee-fetches-fail returns highest balance, no-candidate-has-enough-balance returns origin. Mocks are keyed by token identity to stay resilient to production-side iteration order changes.