### PR TITLE
test: fix firefox e2e race, drop webkit from matrix

### DIFF
--- a/.github/workflows/e2e-wallet-full.yml
+++ b/.github/workflows/e2e-wallet-full.yml
@@ -15,7 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
+        # webkit disabled: prod build serves CSP `upgrade-insecure-requests`,
+        # which webkit strictly honors on localhost (chromium/firefox special-
+        # case it). All chunks get upgraded to https://localhost and fail SSL,
+        # so the app never hydrates. Re-enable once we have a build path that
+        # drops the upgrade directive for e2e without weakening prod CSP.
+        browser: [chromium, firefox]
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4

--- a/tests/e2e-wallet/destination-router/evm.spec.ts
+++ b/tests/e2e-wallet/destination-router/evm.spec.ts
@@ -2,13 +2,14 @@ import { expect, test, type Page } from '@playwright/test';
 import { MOCK_EVM_ADDRESS } from '../helpers/constants';
 import { installEvmRpcMock } from '../helpers/evmRpc';
 import { clickContinue, enterAmount, selectDestinationToken } from '../helpers/formFlow';
-import { openE2EApp } from '../helpers/page-setup';
+import { openE2EApp, waitForWarpRuntime } from '../helpers/page-setup';
 
 const USDC_ETHEREUM = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const REMOTE_ADDRESS_RE = /0x[0-9a-fA-F]{40}/;
 
 test.describe('EVM destination router selection', () => {
   async function captureRemoteAddress(page: Page, destPattern: RegExp) {
+    await waitForWarpRuntime(page);
     await selectDestinationToken(page, destPattern);
     await enterAmount(page, '1');
     await clickContinue(page);


### PR DESCRIPTION
## Summary

Two independent fixes to the wallet-connected e2e suite after the matrix started flaking post-merge:

### 1. Firefox fix: `destination-router/evm.spec.ts`

Added `waitForWarpRuntime(page)` inside `captureRemoteAddress` so the helper blocks until the async WarpCore runtime has finished replacing the synchronous `TokenMetadata` entries in the store.

Without the gate, opening the destination token picker races the token hydration. Chromium's JS engine happened to finish first; Firefox didn't, producing inconsistent symptoms across retries — sometimes the modal never opened, sometimes the click on the inner token button timed out, sometimes the modal stayed open after selection. Mirrors the pattern already used in `destination-router/solana.spec.ts`.

Verified locally: firefox `--repeat-each=3 --retries=0` passes 3/3 (previously 0/3). Chromium still passes, no regression.

### 2. Webkit dropped from the browser matrix

The entire webkit run was failing — every test timing out at 30s starting from the simplest autoconnect spec. Root cause traced via a Playwright debug script: the prod build serves

```
Content-Security-Policy: ...; upgrade-insecure-requests;
```

WebKit strictly honors this directive on `localhost`, so it rewrites every `http://localhost:3000/_next/static/chunks/*.js` request to `https://localhost:3000/...`. The prod server only listens on HTTP, every chunk fails with an SSL error, the page never hydrates, and `window.__WARP_E2E__` is never set — which is the thing the test harness waits on, hence the uniform 30s timeouts.

Chromium and Firefox special-case `localhost` as \"potentially trustworthy\" and skip the upgrade. WebKit doesn't.

A surgical fix (env-gated CSP directive) was attempted but Next.js 16 bakes `headers()` into `routes-manifest.json` at build time, so the env var would need to be set during `pnpm build` — and the wallet-full matrix currently restores the same build cache used by real production deploys. Disentangling that needs a separate e2e build path.

For now the webkit row is removed from the matrix with a comment explaining the blocker and how to re-enable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)