### PR TITLE
test: bump destination-router/evm timeout to 180s

### DIFF
--- a/tests/e2e-wallet/destination-router/evm.spec.ts
+++ b/tests/e2e-wallet/destination-router/evm.spec.ts
@@ -36,6 +36,7 @@ test.describe('EVM destination router selection', () => {
   test('Base and Arbitrum destinations resolve distinct non-empty remote-token addresses', async ({
     page,
   }) => {
+    test.setTimeout(180_000);
     await installEvmRpcMock(page, rpcConfig);
     await openE2EApp(page);
     await expect(page.getByText('0xe2e...e2ee').first()).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
## Summary

Fix flaky Firefox e2e: [run 24893767726](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/actions/runs/24893767726/job/72892996462).

The test `Base and Arbitrum destinations resolve distinct non-empty remote-token addresses` runs two full capture flows in sequence — each calls `waitForWarpRuntime` (20s budget) + token-picker modal waits (30s budget each) + review-panel wait (30s). Under Firefox on CI the whole sequence regularly blows the default 30s test timeout, producing cascading "modal not hidden / not visible / waitForWarpRuntime timeout" errors across the initial run and both retries.

Bump the per-test timeout to 180s to match the existing pattern used in `approval/evm.spec.ts` and `tx-payload/evm.spec.ts`, which also chain multi-step picker flows.

## Test plan
- [ ] e2e-wallet (firefox) CI job passes on this branch
- [ ] No regression in chromium e2e-wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)