### PR TITLE
fix(warp): use token decimals to format wire amounts

### DIFF
--- a/src/features/messages/useMergedTransferHistory.test.ts
+++ b/src/features/messages/useMergedTransferHistory.test.ts
@@ -1,11 +1,10 @@
 import { MultiProtocolProvider, WarpCore } from '@hyperlane-xyz/sdk';
 import type { ChainMetadata } from '@hyperlane-xyz/sdk/metadata/chainMetadataTypes';
 import type { ChainMap } from '@hyperlane-xyz/sdk/types';
-import { ProtocolType, normalizeAddress } from '@hyperlane-xyz/utils';
+import { ProtocolType } from '@hyperlane-xyz/utils';
 import { describe, expect, test } from 'vitest';
 
 import { createMockToken } from '../../utils/test';
-import type { RouterAddressInfo } from '../store';
 import { MessageStatus, type MessageStub } from './types';
 import { messageToTransferContext } from './useMergedTransferHistory';
 
@@ -66,29 +65,12 @@ describe('messageToTransferContext', () => {
         amount: '1000000',
       },
     };
-    // Key format must match production: messageToTransferContext uses
-    // `normalizeAddress(sender, protocol)` (EIP-55 checksummed for EVM), not
-    // `.toLowerCase()`. Use wireDecimals that DIFFERS from token.decimals so
-    // the test can distinguish the router-info path from the token fallback.
-    const normalizedRouter = normalizeAddress(matchingRouteToken.addressOrDenom);
-    const routerAddressesByChainMap: Record<string, Record<string, RouterAddressInfo>> = {
-      ethereum: {
-        [normalizedRouter]: { wireDecimals: 9 },
-      },
-    };
-
-    const result = messageToTransferContext(
-      msg,
-      multiProvider,
-      warpCore,
-      routerAddressesByChainMap,
-    );
+    const result = messageToTransferContext(msg, multiProvider, warpCore);
 
     expect(result.origin).toBe('ethereum');
     expect(result.destination).toBe('arbitrum');
-    // 1_000_000 wire units with wireDecimals=9 → "0.001". If the router-info
-    // lookup failed and we fell back to token.decimals=6, this would be "1".
-    expect(result.amount).toBe('0.001');
+    // 1_000_000 wire units formatted with token.decimals=6 → "1"
+    expect(result.amount).toBe('1');
     expect(result.originTokenAddressOrDenom).toBe(matchingRouteToken.addressOrDenom);
     expect(result.destTokenAddressOrDenom).toBe(msg.recipient);
   });

--- a/src/features/messages/useMergedTransferHistory.ts
+++ b/src/features/messages/useMergedTransferHistory.ts
@@ -1,8 +1,7 @@
-import type { ChainName, MultiProtocolProvider, WarpCore } from '@hyperlane-xyz/sdk';
+import type { MultiProtocolProvider, WarpCore } from '@hyperlane-xyz/sdk';
 import { useMemo } from 'react';
 
 import { logger } from '../../utils/logger';
-import { RouterAddressInfo } from '../store';
 import { tryFindToken } from '../tokens/hooks';
 import { formatMessageAmount } from '../transfer/scaleUtils';
 import { TransferContext, TransferStatus } from '../transfer/types';
@@ -24,7 +23,6 @@ export function messageToTransferContext(
   msg: MessageStub,
   multiProvider: MultiProtocolProvider,
   warpCore: WarpCore,
-  routerAddressesByChainMap: Record<ChainName, Record<string, RouterAddressInfo>>,
 ): TransferContext {
   const originChain = multiProvider.tryGetChainName(msg.originDomainId) || '';
   const destChain = multiProvider.tryGetChainName(msg.destinationDomainId) || '';
@@ -38,12 +36,7 @@ export function messageToTransferContext(
   const token = tryFindToken(warpCore, originChain, msg.sender);
   if (msg.warpTransfer?.amount && token) {
     try {
-      formattedAmount = formatMessageAmount(
-        msg.warpTransfer.amount,
-        { ...token, addressOrDenom: msg.sender },
-        routerAddressesByChainMap,
-        originChain,
-      );
+      formattedAmount = formatMessageAmount(msg.warpTransfer.amount, token);
     } catch (err) {
       logger.error('Failed to format warp transfer amount', err);
     }

--- a/src/features/routerAddresses.test.ts
+++ b/src/features/routerAddresses.test.ts
@@ -28,28 +28,12 @@ describe('getRouterAddressesByChain', () => {
       decimals: 6,
     });
 
-    const result = getRouterAddressesByChain([evmToken, sealevelToken, cosmosToken], {
-      ethereum: {
-        [VALID_EVM_ADDRESS]: 18,
-      },
-      solanamainnet: {
-        [sealevelToken.addressOrDenom]: 9,
-      },
-      cosmoshub: {
-        [cosmosToken.addressOrDenom]: 6,
-      },
-    });
+    const result = getRouterAddressesByChain([evmToken, sealevelToken, cosmosToken]);
     const normalizedEvmAddress = normalizeAddress(VALID_EVM_ADDRESS);
 
-    expect(result.ethereum?.[normalizedEvmAddress]).toEqual({
-      wireDecimals: 18,
-    });
-    expect(result.ethereum?.['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48']).toBeUndefined();
-    expect(result.solanamainnet?.[sealevelToken.addressOrDenom]).toEqual({
-      wireDecimals: 9,
-    });
-    expect(result.cosmoshub?.[cosmosToken.addressOrDenom]).toEqual({
-      wireDecimals: 6,
-    });
+    expect(result.ethereum?.has(normalizedEvmAddress)).toBe(true);
+    expect(result.ethereum?.has('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')).toBe(false);
+    expect(result.solanamainnet?.has(sealevelToken.addressOrDenom)).toBe(true);
+    expect(result.cosmoshub?.has(cosmosToken.addressOrDenom)).toBe(true);
   });
 });

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -40,12 +40,6 @@ import { assembleWarpCoreConfig } from './warpCore/warpCoreConfig';
 // Increment this when persist state has breaking changes
 const PERSIST_STATE_VERSION = 2;
 
-// Info stored per router address
-export interface RouterAddressInfo {
-  // Max decimals across all tokens in the warp route (for amount formatting)
-  wireDecimals: number;
-}
-
 interface WarpContext {
   registry: IRegistry;
   chainMetadata: ChainMap<ChainMetadata>;
@@ -57,8 +51,8 @@ interface WarpContext {
   collateralGroups: Map<string, Token[]>;
   /** Pre-computed token key to Token map for O(1) lookups */
   tokenByKeyMap: Map<string, Token>;
-  // Map of chain -> address -> router info
-  routerAddressesByChainMap: Record<ChainName, Record<string, RouterAddressInfo>>;
+  // Set of router addresses per chain
+  routerAddressesByChainMap: Record<ChainName, Set<string>>;
   // Deduplicated, sorted CoinGecko IDs for all tokens
   coinGeckoIds: string[];
 }
@@ -126,9 +120,9 @@ export interface AppState {
   collateralGroups: Map<string, Token[]>;
   /** Pre-computed token key to Token map for O(1) lookups */
   tokenByKeyMap: Map<string, Token>;
-  // Map of chain -> address -> router info
-  // Used to: 1) prevent sending to warp route addresses, 2) format amounts with correct decimals
-  routerAddressesByChainMap: Record<ChainName, Record<string, RouterAddressInfo>>;
+  // Set of router addresses per chain — used to prevent sending to warp route
+  // addresses and to filter message API results
+  routerAddressesByChainMap: Record<ChainName, Set<string>>;
   // Deduplicated, sorted CoinGecko IDs for all tokens (used by useTokenPrices)
   coinGeckoIds: string[];
 }
@@ -316,7 +310,7 @@ async function initWarpContext({
   }
 
   try {
-    const { config: coreConfig, wireDecimalsMap } = await assembleWarpCoreConfig(
+    const { config: coreConfig } = await assembleWarpCoreConfig(
       warpCoreConfigOverrides,
       currentRegistry,
     );
@@ -345,7 +339,7 @@ async function initWarpContext({
       tokenByKeyMap.set(getTokenKey(token), token);
     }
 
-    const routerAddressesByChainMap = getRouterAddressesByChain(warpCore.tokens, wireDecimalsMap);
+    const routerAddressesByChainMap = getRouterAddressesByChain(warpCore.tokens);
     const coinGeckoIds = Array.from(
       new Set(coreConfig.tokens.map((t) => t.coinGeckoId).filter(Boolean)),
     ).sort() as string[];
@@ -379,20 +373,14 @@ async function initWarpContext({
   }
 }
 
-// Build map of chain -> address -> router info using precomputed wireDecimals
+// Build map of chain -> set of router addresses
 export function getRouterAddressesByChain(
   tokens: WarpCore['tokens'],
-  wireDecimalsMap: Record<ChainName, Record<string, number>>,
-): Record<ChainName, Record<string, RouterAddressInfo>> {
-  return tokens.reduce<Record<ChainName, Record<string, RouterAddressInfo>>>((acc, token) => {
+): Record<ChainName, Set<string>> {
+  return tokens.reduce<Record<ChainName, Set<string>>>((acc, token) => {
     if (!token.addressOrDenom) return acc;
-    const normalizedAddr = normalizeAddress(token.addressOrDenom);
-
-    // Use precomputed wireDecimals from config, fallback to token decimals
-    const wireDecimals = wireDecimalsMap[token.chainName]?.[normalizedAddr] ?? token.decimals;
-
-    acc[token.chainName] ||= {};
-    acc[token.chainName][normalizedAddr] = { wireDecimals };
+    acc[token.chainName] ||= new Set<string>();
+    acc[token.chainName].add(normalizeAddress(token.addressOrDenom));
     return acc;
   }, {});
 }

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -46,7 +46,7 @@ import { ChainWalletWarning } from '../chains/ChainWalletWarning';
 import { useChainDisplayName, useMultiProvider } from '../chains/hooks';
 import { isMultiCollateralLimitExceeded } from '../limits/utils';
 import { useIsAccountSanctioned } from '../sanctions/hooks/useIsAccountSanctioned';
-import { RouterAddressInfo, useStore } from '../store';
+import { useStore } from '../store';
 import { useIsApproveRequired } from '../tokens/approval';
 import {
   getInitialTokenKeys,
@@ -873,7 +873,7 @@ async function validateForm(
   collateralGroups: Map<string, Token[]>,
   values: TransferFormValues,
   accounts: Record<KnownProtocolType, AccountInfo>,
-  routerAddressesByChainMap: Record<ChainName, Record<string, RouterAddressInfo>>,
+  routerAddressesByChainMap: Record<ChainName, Set<string>>,
 ): Promise<[Record<string, string> | null, Token | null]> {
   // returns a tuple, where first value is validation result
   // and second value is token override
@@ -905,7 +905,7 @@ async function validateForm(
 
     const destination = destinationToken.chainName;
 
-    if (routerAddressesByChainMap[destination]?.[normalizeAddress(recipient)]) {
+    if (routerAddressesByChainMap[destination]?.has(normalizeAddress(recipient))) {
       return [{ recipient: 'Warp Route address is not valid as recipient' }, null];
     }
 

--- a/src/features/transfer/scaleUtils.test.ts
+++ b/src/features/transfer/scaleUtils.test.ts
@@ -67,8 +67,6 @@ describe('computeDestAmount', () => {
 });
 
 describe('formatMessageAmount', () => {
-  const emptyRouterMap = {};
-
   test('uses localAmountFromMessage for tokens with scale', () => {
     // BSC USDT: 18 decimals, scale {1, 1e12}
     // Message amount 1000000 (1 USDT in 6-dec message space)
@@ -77,7 +75,7 @@ describe('formatMessageAmount', () => {
       decimals: 18,
       scale: { numerator: 1, denominator: 1_000_000_000_000 },
     };
-    expect(formatMessageAmount('1000000', token, emptyRouterMap, 'bsc')).toBe('1');
+    expect(formatMessageAmount('1000000', token)).toBe('1');
   });
 
   test('converts message amount using numeric scale (VRA-style)', () => {
@@ -85,18 +83,11 @@ describe('formatMessageAmount', () => {
     // Message amount 10e18 (10 VRA in message space with scale=10)
     // Local = 10e18 / 10 = 1e18 → "1" in 18 decimals
     const token = { decimals: 18, scale: 10 };
-    expect(formatMessageAmount('10000000000000000000', token, {}, 'bsc')).toBe('1');
+    expect(formatMessageAmount('10000000000000000000', token)).toBe('1');
   });
 
-  test('falls back to wireDecimals for tokens without scale', () => {
-    const token = { decimals: 6, addressOrDenom: '0xabc' };
-    const routerMap = { eth: { '0xabc': { wireDecimals: 6 } } };
-    // 1000000 in 6 decimals = 1
-    expect(formatMessageAmount('1000000', token, routerMap, 'eth')).toBe('1');
-  });
-
-  test('falls back to token.decimals when no routerInfo', () => {
-    const token = { decimals: 6, addressOrDenom: '0xabc' };
-    expect(formatMessageAmount('1000000', token, emptyRouterMap, 'eth')).toBe('1');
+  test('uses token.decimals when token has no scale', () => {
+    const token = { decimals: 6 };
+    expect(formatMessageAmount('1000000', token)).toBe('1');
   });
 });

--- a/src/features/transfer/scaleUtils.ts
+++ b/src/features/transfer/scaleUtils.ts
@@ -1,9 +1,8 @@
 import type { ScaleInput } from '@hyperlane-xyz/sdk';
 import { localAmountFromMessage, messageAmountFromLocal, scalesEqual } from '@hyperlane-xyz/sdk';
-import { fromWei, normalizeAddress, toWei } from '@hyperlane-xyz/utils';
+import { fromWei, toWei } from '@hyperlane-xyz/utils';
 
 import { logger } from '../../utils/logger';
-import type { RouterAddressInfo } from '../store';
 
 export interface ScaledToken {
   decimals: number;
@@ -39,21 +38,12 @@ export function computeDestAmount(
 /**
  * Formats a raw message-body amount into a human-readable local amount string.
  * For tokens with scale, converts from message-space to local units first.
- * Falls back to wireDecimals for tokens without scale.
  */
-export function formatMessageAmount(
-  rawAmount: string,
-  token: ScaledToken & { addressOrDenom?: string },
-  routerAddressesByChainMap: Record<string, Record<string, RouterAddressInfo>>,
-  chainName: string,
-): string {
+export function formatMessageAmount(rawAmount: string, token: ScaledToken): string {
   if (token.scale) {
     const messageAmount = BigInt(rawAmount);
     const localAmount = localAmountFromMessage(messageAmount, token.scale);
     return fromWei(localAmount.toString(), token.decimals);
   }
-  const normalizedAddr = token.addressOrDenom ? normalizeAddress(token.addressOrDenom) : '';
-  const routerInfo = routerAddressesByChainMap[chainName]?.[normalizedAddr];
-  const wireDecimals = routerInfo?.wireDecimals ?? token.decimals;
-  return fromWei(rawAmount, wireDecimals);
+  return fromWei(rawAmount, token.decimals);
 }

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -1,4 +1,3 @@
-import type { ChainName } from '@hyperlane-xyz/sdk';
 import { normalizeAddress } from '@hyperlane-xyz/utils';
 import { RefreshIcon, SpinnerIcon } from '@hyperlane-xyz/widgets';
 import { AccountList } from '@hyperlane-xyz/widgets/walletIntegrations/AccountList';
@@ -23,7 +22,7 @@ import {
   useMergedTransferHistory,
 } from '../messages/useMergedTransferHistory';
 import { useMessageHistory } from '../messages/useMessageHistory';
-import { RouterAddressInfo, useStore } from '../store';
+import { useStore } from '../store';
 import { tryFindToken, useWarpCore } from '../tokens/hooks';
 import { TokenChainIcon } from '../tokens/TokenChainIcon';
 import { computeDestAmount, formatMessageAmount } from '../transfer/scaleUtils';
@@ -75,12 +74,12 @@ export function SideBarMenu({
     return addresses;
   }, [accounts]);
 
-  // Get all warp route addresses from configured routes (normalized)
+  // Get all warp route addresses from configured routes (already normalized)
   const warpRouteAddresses = useMemo(() => {
     const addresses: string[] = [];
-    for (const addressMap of Object.values(routerAddressesByChainMap)) {
-      for (const addr of Object.keys(addressMap)) {
-        addresses.push(normalizeAddress(addr));
+    for (const addressSet of Object.values(routerAddressesByChainMap)) {
+      for (const addr of addressSet) {
+        addresses.push(addr);
       }
     }
     return addresses;
@@ -128,9 +127,7 @@ export function SideBarMenu({
     if (item.type === TransferItemType.Local) {
       setSelectedTransfer(item.data);
     } else {
-      setSelectedTransfer(
-        messageToTransferContext(item.data, multiProvider, warpCore, routerAddressesByChainMap),
-      );
+      setSelectedTransfer(messageToTransferContext(item.data, multiProvider, warpCore));
     }
     setIsModalOpen(true);
   };
@@ -236,7 +233,6 @@ export function SideBarMenu({
                       onClick={() => handleItemClick(item)}
                       multiProvider={multiProvider}
                       warpCore={warpCore}
-                      routerAddressesByChainMap={routerAddressesByChainMap}
                       nowMs={nowMs}
                     />
                   ))}
@@ -275,14 +271,12 @@ function TransferSummary({
   onClick,
   multiProvider,
   warpCore,
-  routerAddressesByChainMap,
   nowMs,
 }: {
   item: TransferItem;
   onClick: () => void;
   multiProvider: ReturnType<typeof useMultiProvider>;
   warpCore: ReturnType<typeof useWarpCore>;
-  routerAddressesByChainMap: Record<ChainName, Record<string, RouterAddressInfo>>;
   nowMs: number;
 }) {
   const { originChain, destChain, amount, destAmount, status, token, destToken, timestamp } =
@@ -310,12 +304,7 @@ function TransferSummary({
       let amount = '';
       if (msg.warpTransfer?.amount && token) {
         try {
-          amount = formatMessageAmount(
-            msg.warpTransfer.amount,
-            { ...token, addressOrDenom: msg.sender },
-            routerAddressesByChainMap,
-            originChain,
-          );
+          amount = formatMessageAmount(msg.warpTransfer.amount, token);
         } catch (err) {
           logger.error('Failed to format warp transfer amount', err);
         }
@@ -336,7 +325,7 @@ function TransferSummary({
         destToken,
         timestamp: msg.origin.timestamp,
       };
-    }, [item.type, item.data, multiProvider, warpCore, routerAddressesByChainMap]);
+    }, [item.type, item.data, multiProvider, warpCore]);
 
   return (
     <button onClick={onClick} className={`${styles.btn} justify-between py-3`}>

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -3,7 +3,6 @@ import {
   warpRouteConfigs as publishedRegistryWarpRoutes,
 } from '@hyperlane-xyz/registry';
 import {
-  ChainName,
   TOKEN_STANDARD_TO_PROTOCOL,
   TokenStandard,
   WarpCoreConfig,
@@ -11,7 +10,7 @@ import {
   getTokenConnectionId,
   validateZodResult,
 } from '@hyperlane-xyz/sdk';
-import { isObjEmpty, normalizeAddress, objFilter, objMerge } from '@hyperlane-xyz/utils';
+import { isObjEmpty, objFilter, objMerge } from '@hyperlane-xyz/utils';
 
 import { config } from '../../consts/config.ts';
 import { warpRouteConfigs as tsWarpRoutes } from '../../consts/warpRoutes.ts';
@@ -19,8 +18,6 @@ import yamlWarpRoutes from '../../consts/warpRoutes.yaml';
 import { getWarpRouteWhitelist, warpRouteWhitelist } from '../../consts/warpRouteWhitelist.ts';
 import { logger } from '../../utils/logger.ts';
 
-// Map of chain -> address -> wireDecimals
-export type WireDecimalsMap = Record<ChainName, Record<string, number>>;
 type WarpCoreToken = WarpCoreConfig['tokens'][number];
 export type NullableAddressWarpCoreToken = Omit<WarpCoreToken, 'addressOrDenom'> & {
   addressOrDenom: string | null;
@@ -29,7 +26,7 @@ export type NullableAddressWarpCoreToken = Omit<WarpCoreToken, 'addressOrDenom'>
 export async function assembleWarpCoreConfig(
   storeOverrides: WarpCoreConfig[],
   registry: IRegistry,
-): Promise<{ config: WarpCoreConfig; wireDecimalsMap: WireDecimalsMap }> {
+): Promise<{ config: WarpCoreConfig }> {
   const yamlResult = WarpCoreConfigSchema.safeParse(yamlWarpRoutes);
   const yamlConfig = validateZodResult(yamlResult, 'warp core yaml config');
   const tsResult = WarpCoreConfigSchema.safeParse(tsWarpRoutes);
@@ -119,9 +116,6 @@ export async function assembleWarpCoreConfig(
     : registryWarpRoutes;
   filteredRegistryConfigMap = fillMissingCoinGeckoIds(filteredRegistryConfigMap);
 
-  // Build wireDecimalsMap BEFORE flattening - this preserves route grouping
-  const wireDecimalsMap = buildWireDecimalsMap(filteredRegistryConfigMap);
-
   const filteredRegistryConfigValues = Object.values(filteredRegistryConfigMap);
   const filteredRegistryTokens = filteredRegistryConfigValues.map((c) => c.tokens).flat();
   const filteredRegistryOptions = filteredRegistryConfigValues.map((c) => c.options).flat();
@@ -152,22 +146,7 @@ export async function assembleWarpCoreConfig(
       'No warp route configs provided. Please check your registry, warp route whitelist, and custom route configs for issues.',
     );
 
-  return { config: { tokens, options }, wireDecimalsMap };
-}
-
-// Build map of chain -> address -> wireDecimals before tokens are flattened
-// wireDecimals = max decimals across all tokens in a warp route
-function buildWireDecimalsMap(routes: Record<string, WarpCoreConfig>): WireDecimalsMap {
-  const map: WireDecimalsMap = {};
-  for (const routeConfig of Object.values(routes)) {
-    const wireDecimals = Math.max(...routeConfig.tokens.map((t) => t.decimals ?? 18));
-    for (const token of routeConfig.tokens) {
-      if (!token.addressOrDenom) continue;
-      map[token.chainName] ||= {};
-      map[token.chainName][normalizeAddress(token.addressOrDenom)] = wireDecimals;
-    }
-  }
-  return map;
+  return { config: { tokens, options } };
 }
 
 // Fill missing coinGeckoIds within each warp route


### PR DESCRIPTION
## Summary

Same root cause + fix as [hyperlane-explorer#323](https://github.com/hyperlane-xyz/hyperlane-explorer/pull/323), applied to the display side of the warp-ui.

`formatMessageAmount` fell back to per-route `wireDecimals = max(decimals)` when a token had no `scale` field. On-chain routers (`TokenRouter` for EVM, `HyperlaneToken` for SVM) default to identity scale when unset, so the wire amount is always in the token's native-decimal space — no implicit max-decimals normalization to invert.

### The bug this fixes

USDT route: BSC has `decimals: 18, scale: {1, 1e12}` (compresses to 6-dec wire). The Eclipse and Solana entries have **no `scale`** in the registry, so `Math.max(decimals) = 18` was used to interpret a 6-dec wire amount → `fromWei(1_000_000, 18)` ≈ 0 → sidebar showed **"USDT 0"** for SVM → Tron transfers (and would for any other route where the origin chain isn't the max-decimal chain).

Tron → SVM works because Tron has `scale: {1, 1}` set, hitting the scaled branch.

The on-chain transfer itself is correct in both directions — only the display was off, masked by localStorage cache between page changes.

### What changes

- `src/features/transfer/scaleUtils.ts` — `formatMessageAmount` now uses `token.decimals` directly. Drops the `routerAddressesByChainMap` and `chainName` params.
- `src/features/messages/useMergedTransferHistory.ts` — `messageToTransferContext` no longer takes `routerAddressesByChainMap`.
- `src/features/wallet/SideBarMenu.tsx` — call sites updated; the `routerAddressesByChainMap` prop drilled into `TransferSummary` is removed (the sub-component no longer needs it).
- `src/features/transfer/TransferTokenForm.tsx` — recipient validation switches from `obj?.[addr]` to `set.has(addr)`.
- `src/features/store.ts`:
  - `RouterAddressInfo` interface deleted (was just `{ wireDecimals: number }`).
  - `routerAddressesByChainMap` collapses to `Record<ChainName, Set<string>>` — remaining consumers only need membership checks (recipient validation) and key iteration (warp-route filter for message history).
  - `getRouterAddressesByChain` drops the `wireDecimalsMap` param and returns the new shape.
- `src/features/warpCore/warpCoreConfig.ts` — `buildWireDecimalsMap` and `WireDecimalsMap` deleted; `assembleWarpCoreConfig` no longer returns a wireDecimalsMap.
- Tests updated.

### Why `wireDecimals` doesn't reflect on-chain reality (verified)

- **EVM `TokenRouter`** applies `messageAmount = localAmount * scaleNumerator / scaleDenominator`, with the constructor enforcing `scale > 0` — defaulting to `{1, 1}` (identity) when unset.
- **SVM `HyperlaneToken`** stores `decimals` and `remote_decimals` and applies `convert_decimals(amount, decimals, remote_decimals)` — identity when both are equal (the SVM equivalent of `scale: {1, 1}`).

There is no implicit "normalize to max(decimals) of route" anywhere in the contracts. `wireDecimals = Math.max(decimals)` was a heuristic that only ever produced the right number when the origin chain happened to be the max-decimal chain in the route. The SDK's transfer-side helper (`messageAmountFromLocal`) already defaults `scale: undefined → {1, 1}`, so this PR aligns the display path with the transfer path.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — 3 pre-existing warnings in untouched files, 0 errors
- [x] `pnpm run format`
- [x] `pnpm exec vitest run src/features/transfer/scaleUtils.test.ts src/features/messages/useMergedTransferHistory.test.ts src/features/routerAddresses.test.ts` — 15/15 pass
- [ ] Smoke-test in dev: SVM → Tron USDT message in the sidebar TransactionHistory should show the correct amount (after a fresh page load that bypasses localStorage cache)
- [ ] Recipient validation still rejects warp-route addresses (TransferTokenForm)
- [ ] Message history filtering still picks up local transfers (SideBarMenu warpRouteAddresses)