### PR TITLE
fix: show and log gas estimation error

### DIFF
--- a/src/features/transfer/FeeSectionButton.tsx
+++ b/src/features/transfer/FeeSectionButton.tsx
@@ -1,6 +1,6 @@
 import { WarpCoreFeeEstimate } from '@hyperlane-xyz/sdk';
 import { ChevronIcon, FuelPumpIcon, useModal } from '@hyperlane-xyz/widgets';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { getFeePercentage, getTotalFeesUsdRaw } from '../balances/feeUsdDisplay';
 import { FeePrices } from '../balances/useFeePrices';
@@ -41,16 +41,14 @@ export function FeeSectionButton({
   const { close, isOpen, open } = useModal();
   const loadingText = useLoadingDots(isLoading);
 
-  // Determine display text and whether button is clickable
   const hasFees = fees !== null;
   const isClickable = hasFees && !isLoading;
-  const feeText = isLoading
-    ? loadingText
-    : isError
-      ? 'Estimation failed'
-      : hasFees
-        ? fees.totalFees
-        : '-';
+  const feeText = useMemo(() => {
+    if (isLoading) return loadingText;
+    if (isError) return 'Estimation failed';
+    if (hasFees) return fees.totalFees;
+    return '-';
+  }, [isLoading, isError, hasFees, fees, loadingText]);
   const totalUsdRaw = hasFees ? getTotalFeesUsdRaw(fees, feePrices) : 0;
   const totalUsd = totalUsdRaw > 0 ? formatUsd(totalUsdRaw, true) : null;
   const pct = hasFees ? getFeePercentage(totalUsdRaw, transferUsd) : null;

--- a/src/features/transfer/FeeSectionButton.tsx
+++ b/src/features/transfer/FeeSectionButton.tsx
@@ -44,7 +44,13 @@ export function FeeSectionButton({
   // Determine display text and whether button is clickable
   const hasFees = fees !== null;
   const isClickable = hasFees && !isLoading;
-  const feeText = isLoading ? loadingText : isError ? 'Estimation failed' : hasFees ? fees.totalFees : '-';
+  const feeText = isLoading
+    ? loadingText
+    : isError
+      ? 'Estimation failed'
+      : hasFees
+        ? fees.totalFees
+        : '-';
   const totalUsdRaw = hasFees ? getTotalFeesUsdRaw(fees, feePrices) : 0;
   const totalUsd = totalUsdRaw > 0 ? formatUsd(totalUsdRaw, true) : null;
   const pct = hasFees ? getFeePercentage(totalUsdRaw, transferUsd) : null;

--- a/src/features/transfer/FeeSectionButton.tsx
+++ b/src/features/transfer/FeeSectionButton.tsx
@@ -27,11 +27,13 @@ function useLoadingDots(isLoading: boolean, intervalMs = 1000) {
 
 export function FeeSectionButton({
   isLoading,
+  isError,
   fees,
   feePrices,
   transferUsd,
 }: {
   isLoading: boolean;
+  isError: boolean;
   fees: (WarpCoreFeeEstimate & { totalFees: string }) | null;
   feePrices: FeePrices;
   transferUsd: number;
@@ -42,7 +44,7 @@ export function FeeSectionButton({
   // Determine display text and whether button is clickable
   const hasFees = fees !== null;
   const isClickable = hasFees && !isLoading;
-  const feeText = isLoading ? loadingText : hasFees ? fees.totalFees : '-';
+  const feeText = isLoading ? loadingText : isError ? 'Estimation failed' : hasFees ? fees.totalFees : '-';
   const totalUsdRaw = hasFees ? getTotalFeesUsdRaw(fees, feePrices) : 0;
   const totalUsd = totalUsdRaw > 0 ? formatUsd(totalUsdRaw, true) : null;
   const pct = hasFees ? getFeePercentage(totalUsdRaw, transferUsd) : null;

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -685,13 +685,11 @@ function ReviewDetails({
     isReview,
   );
   // Only fetch fees if route is supported
-  const { isLoading: isQuoteLoading, fees: feeQuotes } = useFeeQuotes(
-    values,
-    isRouteSupported,
-    originToken,
-    destinationToken,
-    !isReview,
-  );
+  const {
+    isLoading: isQuoteLoading,
+    isError: isFeeQuoteError,
+    fees: feeQuotes,
+  } = useFeeQuotes(values, isRouteSupported, originToken, destinationToken, !isReview);
 
   const { prices } = useTokenPrices();
   const feePrices = useFeePrices(feeQuotes ?? null, warpCore.tokens, prices);
@@ -727,6 +725,7 @@ function ReviewDetails({
         <FeeSectionButton
           fees={fees}
           isLoading={isLoading}
+          isError={isFeeQuoteError}
           feePrices={feePrices}
           transferUsd={transferUsd}
         />

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -751,7 +751,11 @@ function ReviewDetails({
   // Onchain fee quoting: used as fallback when offchain isn't available for this route
   const offchainSettled = !isOffchainQuoteLoading;
   const offchainUnavailable = !config.feeQuotingUrl || (offchainSettled && !offchainFeeQuotes);
-  const { isLoading: isOnchainQuoteLoading, isError: isFeeQuoteError, fees: onchainFeeQuotes } = useFeeQuotes(
+  const {
+    isLoading: isOnchainQuoteLoading,
+    isError: isFeeQuoteError,
+    fees: onchainFeeQuotes,
+  } = useFeeQuotes(
     values,
     isRouteSupported && offchainUnavailable,
     originToken,

--- a/src/features/transfer/useFeeQuotes.ts
+++ b/src/features/transfer/useFeeQuotes.ts
@@ -6,6 +6,7 @@ import {
   useAccounts,
 } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 import { defaultMultiCollateralRoutes } from '../../consts/defaultMultiCollateralRoutes';
 import { logger } from '../../utils/logger';
@@ -62,7 +63,7 @@ export function useFeeQuotes(
   );
   const shouldFetch = enabled && isFormValid;
 
-  const { isLoading, isError, data, isFetching } = useQuery({
+  const { isLoading, isError, data, isFetching, error } = useQuery({
     // The WarpCore class is not serializable, so we can't use it as a key
     // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: [
@@ -89,6 +90,10 @@ export function useFeeQuotes(
     enabled: shouldFetch,
     refetchInterval: FEE_QUOTE_REFRESH_INTERVAL,
   });
+
+  useEffect(() => {
+    if (isError) logger.error('Fee quote failed', error);
+  }, [isError, error]);
 
   return { isLoading: isLoading || isFetching, isError, fees: data };
 }


### PR DESCRIPTION
Before the gas estimation failed silently, now we log the error and show "Estimation failed" instead of "-" in the ui