### PR TITLE
feat: store-resolved chainAddresses with addresses.yaml/ts overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,35 @@
 {
   "name": "@hyperlane-xyz/warp-ui-template",
-  "description": "A web app template for building Hyperlane Warp Route UIs",
   "version": "13.0.0",
+  "private": true,
+  "description": "A web app template for building Hyperlane Warp Route UIs",
+  "homepage": "https://www.hyperlane.xyz",
+  "license": "Apache-2.0",
   "author": "J M Rossy",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hyperlane-xyz/hyperlane-warp-ui-template"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "clean": "rm -rf dist cache .next",
+    "predev": "node scripts/fetch-fonts.mjs",
+    "dev": "next dev",
+    "prebuild": "node scripts/fetch-fonts.mjs",
+    "fetch-fonts": "node --env-file-if-exists=.env.local scripts/fetch-fonts.mjs",
+    "build": "next build",
+    "typecheck": "tsc",
+    "lint": "oxlint ./src",
+    "start": "next start",
+    "test": "vitest --watch false",
+    "test:e2e": "playwright test --project=chromium",
+    "test:e2e:wallet": "playwright test tests/e2e-wallet --project=chromium",
+    "test:e2e:wallet:smoke": "playwright test tests/e2e-wallet/smoke/gate.spec.ts tests/e2e-wallet/autoconnect/evm.spec.ts tests/e2e-wallet/balance-display/evm.spec.ts tests/e2e-wallet/autoconnect/solana.spec.ts --project=chromium",
+    "format": "oxfmt ./src",
+    "link:monorepo": "node scripts/link-monorepo.js",
+    "unlink:monorepo": "node scripts/unlink-monorepo.js"
+  },
   "dependencies": {
     "@chakra-ui/next-js": "^2.4.2",
     "@chakra-ui/provider": "^2.4.2",
@@ -21,10 +48,10 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "24.3.0",
-    "@hyperlane-xyz/sdk": "33.0.2",
-    "@hyperlane-xyz/utils": "33.0.2",
-    "@hyperlane-xyz/widgets": "33.0.2",
+    "@hyperlane-xyz/registry": "25.0.0",
+    "@hyperlane-xyz/sdk": "33.1.0",
+    "@hyperlane-xyz/utils": "33.1.0",
+    "@hyperlane-xyz/widgets": "33.1.0",
     "@interchain-ui/react": "^1.23.28",
     "@intercom/messenger-js-sdk": "^0.0.18",
     "@metamask/post-message-stream": "6.1.2",
@@ -99,34 +126,7 @@
   "engines": {
     "node": ">=24"
   },
-  "homepage": "https://www.hyperlane.xyz",
-  "license": "Apache-2.0",
-  "main": "dist/src/index.js",
   "packageManager": "pnpm@10.25.0",
-  "private": true,
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/hyperlane-xyz/hyperlane-warp-ui-template"
-  },
-  "scripts": {
-    "clean": "rm -rf dist cache .next",
-    "predev": "node scripts/fetch-fonts.mjs",
-    "dev": "next dev",
-    "prebuild": "node scripts/fetch-fonts.mjs",
-    "fetch-fonts": "node --env-file-if-exists=.env.local scripts/fetch-fonts.mjs",
-    "build": "next build",
-    "typecheck": "tsc",
-    "lint": "oxlint ./src",
-    "start": "next start",
-    "test": "vitest --watch false",
-    "test:e2e": "playwright test --project=chromium",
-    "test:e2e:wallet": "playwright test tests/e2e-wallet --project=chromium",
-    "test:e2e:wallet:smoke": "playwright test tests/e2e-wallet/smoke/gate.spec.ts tests/e2e-wallet/autoconnect/evm.spec.ts tests/e2e-wallet/balance-display/evm.spec.ts tests/e2e-wallet/autoconnect/solana.spec.ts --project=chromium",
-    "format": "oxfmt ./src",
-    "link:monorepo": "node scripts/link-monorepo.js",
-    "unlink:monorepo": "node scripts/unlink-monorepo.js"
-  },
-  "types": "dist/src/index.d.ts",
   "pnpm": {
     "overrides": {
       "tronweb>ethers": "^6.13.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@headlessui/react": "^2.2.0",
-    "@hyperlane-xyz/registry": "25.0.0",
+    "@hyperlane-xyz/registry": "24.3.0",
     "@hyperlane-xyz/sdk": "33.1.0",
     "@hyperlane-xyz/utils": "33.1.0",
     "@hyperlane-xyz/widgets": "33.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hyperlane-xyz/registry':
-        specifier: 25.0.0
-        version: 25.0.0
+        specifier: 24.3.0
+        version: 24.3.0
       '@hyperlane-xyz/sdk':
         specifier: 33.1.0
         version: 33.1.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
@@ -1427,10 +1427,6 @@ packages:
 
   '@hyperlane-xyz/registry@24.3.0':
     resolution: {integrity: sha512-nd0ndJf7HmakuFCwm0gKOZoVXQukEaVponXecjCuIGM8apGA0M9AhhBbsRD2f+JjKmOcZ2vehQaQfd270tGBXQ==}
-    engines: {node: '>=24'}
-
-  '@hyperlane-xyz/registry@25.0.0':
-    resolution: {integrity: sha512-V39zhKQkCF0UcbFoJu+KR7a28G+8JVdpp61XrlvG6taZyxuMVksJthPCmRJUlojZCZLPhrzX2fK9NIDHie59cw==}
     engines: {node: '>=24'}
 
   '@hyperlane-xyz/sdk@33.1.0':
@@ -12265,12 +12261,6 @@ snapshots:
       - utf-8-validate
 
   '@hyperlane-xyz/registry@24.3.0':
-    dependencies:
-      jszip: 3.10.1
-      yaml: 2.4.5
-      zod: 3.21.4
-
-  '@hyperlane-xyz/registry@25.0.0':
     dependencies:
       jszip: 3.10.1
       yaml: 2.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,17 +91,17 @@ importers:
         specifier: ^2.2.0
         version: 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hyperlane-xyz/registry':
-        specifier: 24.3.0
-        version: 24.3.0
+        specifier: 25.0.0
+        version: 25.0.0
       '@hyperlane-xyz/sdk':
-        specifier: 33.0.2
-        version: 33.0.2(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
+        specifier: 33.1.0
+        version: 33.1.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@hyperlane-xyz/utils':
-        specifier: 33.0.2
-        version: 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+        specifier: 33.1.0
+        version: 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@hyperlane-xyz/widgets':
-        specifier: 33.0.2
-        version: 33.0.2(@cosmjs/amino@0.36.2)(@cosmjs/proto-signing@0.32.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.91.0)(@tanstack/react-query@5.91.0(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(babel-plugin-macros@3.1.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(get-starknet-core@4.0.0)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@6.0.2)(utf-8-validate@6.0.6)(zod@3.21.4)
+        specifier: 33.1.0
+        version: 33.1.0(@cosmjs/amino@0.36.2)(@cosmjs/proto-signing@0.32.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.91.0)(@tanstack/react-query@5.91.0(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(babel-plugin-macros@3.1.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(get-starknet-core@4.0.0)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@6.0.2)(utf-8-validate@6.0.6)(zod@3.21.4)
       '@interchain-ui/react':
         specifier: ^1.23.28
         version: 1.26.3(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1394,8 +1394,8 @@ packages:
     resolution: {integrity: sha512-mFfnZfgp4OKkUIS/FKikfUgdnDKRy25ytCKBQiV+N+HbYy3I4v4ZCPBQ69QL+TYmKmCZJeUEnYeS5K+OBRP+Eg==}
     engines: {node: '>=16.0.0'}
 
-  '@hyperlane-xyz/aleo-sdk@33.0.2':
-    resolution: {integrity: sha512-/ZmLLFAxqShy0wq+4neVRKqCF+PGjMpQXOyisGHmiKszHOz+UyFmyTEqgGGXdOQKoJ/oCMaQGQXT5YJ77fCucw==}
+  '@hyperlane-xyz/aleo-sdk@33.1.0':
+    resolution: {integrity: sha512-vIImfDbGW9y65oNJoCvas6JuoYnYIXG0pBfPTLG3eKvE7sPn6+fHp8F+0AjnXW/Cf9MBTF0l5pQHTwueZ41ySg==}
     peerDependencies:
       testcontainers: 11.12.0
     peerDependenciesMeta:
@@ -1410,45 +1410,49 @@ packages:
       '@ethersproject/providers': '*'
       '@types/sinon-chai': '*'
 
-  '@hyperlane-xyz/cosmos-sdk@33.0.2':
-    resolution: {integrity: sha512-SctjeM5uDxgNy8iDg3ONAUTlIuKfzkYrpkf7YOFxvSPAZoBYXTs+D++atGMbToH/brTFg7XGiKD4qwwPDfMIyA==}
+  '@hyperlane-xyz/cosmos-sdk@33.1.0':
+    resolution: {integrity: sha512-t9+aiG9FO2n98buLukPssXMtE0jIlUm4p5yb4v9xBIka3DPasPbFkeEGdVj7k58cAzE6hnJBEJCWF2SSA5wUMA==}
 
-  '@hyperlane-xyz/cosmos-types@33.0.2':
-    resolution: {integrity: sha512-/QjSW1Zy5BlPVxBgd3qCf7Ma5yL8lPwzG9KfHrBwAaQMEwCD0Ad+UAlGCFRMgAqo3yzx5qgeKmh7/lUkSJ3RuA==}
+  '@hyperlane-xyz/cosmos-types@33.1.0':
+    resolution: {integrity: sha512-NWEp1NLV3FEEnimcDT2RP8mG1keavIVMu/hNc33NLKM9yNYFCtYnxQ5xOoayDh2OiYsiBK9fEP+zw1Ehcx/seA==}
 
-  '@hyperlane-xyz/deploy-sdk@5.1.0':
-    resolution: {integrity: sha512-TO7tMvQ81LnywwVMiH6E5H2XF57WZVvc4Oa0sRyaVlSI5V3sfUjTOr9iRnXd1AJrHSndmazLJYCpqyotAjs0ow==}
+  '@hyperlane-xyz/deploy-sdk@6.0.0':
+    resolution: {integrity: sha512-mogwe0939dLoQ8aLKbC3zJEHND14lhV4h9pZIEV/waTJPCSe1vDDBSitIZSUHDbiQeCrjPEPN1grZKNrpigAhA==}
 
-  '@hyperlane-xyz/provider-sdk@5.1.0':
-    resolution: {integrity: sha512-8Ujf5IuQr1SGWOau6wiugpngc37YJPuO8UcsOmJolr3PbssZcP2jZ+z/jYFvK5JQfl8rOH4D7srp0RfdNAheXA==}
+  '@hyperlane-xyz/provider-sdk@6.0.0':
+    resolution: {integrity: sha512-2D59mLyt8O4GFFL3WJ6uzEQqAGPV6UL2tGlVi0hwA4CyIsnwtzxylvk5NtmkCdHuRAxobcd59IH9peWUwDBrhg==}
 
-  '@hyperlane-xyz/radix-sdk@33.0.2':
-    resolution: {integrity: sha512-pORFMwUTNv4T/RtbWwi3n2aPq3EamGhj8+FIcAOl9xEjZdAqQc3S9StQuOJxG6oTAiW6iKL5e0vKIPLXo5tx1w==}
+  '@hyperlane-xyz/radix-sdk@33.1.0':
+    resolution: {integrity: sha512-YLE+aQmOxZJEFiaFg2oUDgkOaS7Ow2MPI5towXvnxovDde1X7bDElIlW2hK5kL5hQIl8J5w85x09Dc3ECw6luQ==}
 
   '@hyperlane-xyz/registry@24.3.0':
     resolution: {integrity: sha512-nd0ndJf7HmakuFCwm0gKOZoVXQukEaVponXecjCuIGM8apGA0M9AhhBbsRD2f+JjKmOcZ2vehQaQfd270tGBXQ==}
     engines: {node: '>=24'}
 
-  '@hyperlane-xyz/sdk@33.0.2':
-    resolution: {integrity: sha512-gAIIbbClfkKgRh7BZwLd5EfFDrf6iMKVLwwIiXk4Ap/QFeQe8IT89VE5EhuhQOQ/8eJUzB6ubgQh1QarXSUdiA==}
+  '@hyperlane-xyz/registry@25.0.0':
+    resolution: {integrity: sha512-V39zhKQkCF0UcbFoJu+KR7a28G+8JVdpp61XrlvG6taZyxuMVksJthPCmRJUlojZCZLPhrzX2fK9NIDHie59cw==}
+    engines: {node: '>=24'}
+
+  '@hyperlane-xyz/sdk@33.1.0':
+    resolution: {integrity: sha512-vTto7GiuGH32R1qMp92Q5btcDn37pyVHpWhweSXt19dLeNMiOKlRaAuYmBC8df7ANhTOS8ZkpTJ4+0jDkYkQkw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@ethersproject/abi': '*'
 
-  '@hyperlane-xyz/sealevel-sdk@33.0.2':
-    resolution: {integrity: sha512-xe7oY/buhAuej/6Np8iDidQBjWQbTw9zKBAGm35byKQGld895IOLed1mn0YR651d+jqi+6UDY4m+RxcZFPCQ1g==}
+  '@hyperlane-xyz/sealevel-sdk@33.1.0':
+    resolution: {integrity: sha512-9OPq8B5adIQCB+mzLrb9QToxaj6Jvu4HrY7q0E45tMViMsFeQkFo8oyoTH2r7hAcGpnK/qEal+OR5aBNykO0DQ==}
 
-  '@hyperlane-xyz/starknet-core@33.0.2':
-    resolution: {integrity: sha512-CSX1RKdb3nYV1O59N5ZlrvxSBCVnT9wEvh8Xfvns3cLqMCxhoUe3SAPpON3l/Zh7M3bZZskoV/4N4D0nsraeYQ==}
+  '@hyperlane-xyz/starknet-core@33.1.0':
+    resolution: {integrity: sha512-LJmrBycdSnVaPXXW43/DLIF3O2bWZNR5EbnmjdM4pNOo9nLKKixfiU8IwmuX/CHAK4phpAJ2yZnpc7xVfcXUKg==}
 
-  '@hyperlane-xyz/starknet-sdk@28.0.4':
-    resolution: {integrity: sha512-u0vwQRw0CY1OKebC4QYkxHLZxXOZeUUG9L+QJSTW0nFeM9ZBhRwkdCiZpzrK0unB4yT7sDb+dSd5L1VP8978Uw==}
+  '@hyperlane-xyz/starknet-sdk@28.0.5':
+    resolution: {integrity: sha512-RZfDKiNj/ZKBQLYWsLJJzRy8knJUBdZ1PgOCnDoa7cttpGyVS4I/wwQXUpvaO+yh/24N0ENBEPn9jiXP8vX46w==}
 
-  '@hyperlane-xyz/tron-sdk@23.0.4':
-    resolution: {integrity: sha512-Shs2JrsasjDQwilxpaPhkokjS5LB+W5rlK7mAcF1XepWcbG4sO591+cBmaE0BEGeJ3Y0LJ0RO8zFEx33EuIXWA==}
+  '@hyperlane-xyz/tron-sdk@23.0.5':
+    resolution: {integrity: sha512-u5wABKQYbTwaAxQnxm2KeY5bUgw9MOTK/7m6ymXpc6e3mVgstoB2/EqwAfMd1/vWrtviY9iMLg2jKApmyFlE7w==}
 
-  '@hyperlane-xyz/utils@33.0.2':
-    resolution: {integrity: sha512-c7mZroyqc6V7YibVXstwEETmsXAYbgPB2pz9B6N5HqlH5DFPIJASln20GB260Nvso4vWNg38JgGoTQkrKATfRg==}
+  '@hyperlane-xyz/utils@33.1.0':
+    resolution: {integrity: sha512-iPcL1lOQ0TtvgMljdBN9SEWRHwZ65zLLeEcA0WMQQQLORSaCXGaJoYkFKr8hXGNTS7SaNIhIKEEjY+24ZTR0Gw==}
     engines: {node: '>=16'}
     peerDependencies:
       '@google-cloud/pino-logging-gcp-config': ^1.3.0
@@ -1459,8 +1463,8 @@ packages:
       pino-pretty:
         optional: true
 
-  '@hyperlane-xyz/widgets@33.0.2':
-    resolution: {integrity: sha512-FJdwWOiMyuWFWinKx/mamP7XrfiSazPDyLLUWgkeNPRdg5kSHlEdujH9XTM/OcRREiIKuqHoA30Tz5+zSIDyww==}
+  '@hyperlane-xyz/widgets@33.1.0':
+    resolution: {integrity: sha512-deOhMp0FgfIU8V9VNvNmOFEfkUxIsKXx10Gsw56RIQnN5NofU61P4b1S7fxwDpuI0cnTTkdrutiyVpuFeHzoNw==}
     peerDependencies:
       react: ^18
       react-dom: ^18
@@ -12161,10 +12165,10 @@ snapshots:
     dependencies:
       '@hpke/common': 1.10.1
 
-  '@hyperlane-xyz/aleo-sdk@33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/aleo-sdk@33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@provablehq/sdk': 0.9.15(patch_hash=c3b67b6e17970e4e71124b375f996bb58f69b19e6deba7d2dd82a7809373358b)
       bignumber.js: 9.3.1
       unzipper: 0.12.3
@@ -12182,16 +12186,16 @@ snapshots:
       '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@types/sinon-chai': 4.0.0
 
-  '@hyperlane-xyz/cosmos-sdk@33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/cosmos-sdk@33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
       '@cosmjs/amino': 0.32.4
       '@cosmjs/math': 0.32.4
       '@cosmjs/proto-signing': 0.32.4
       '@cosmjs/stargate': 0.32.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@cosmjs/tendermint-rpc': 0.32.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/cosmos-types': 33.0.2
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/cosmos-types': 33.1.0
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
       - bufferutil
@@ -12201,21 +12205,21 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/cosmos-types@33.0.2':
+  '@hyperlane-xyz/cosmos-types@33.1.0':
     dependencies:
       long: 5.3.2
       protobufjs: 7.5.4
 
-  '@hyperlane-xyz/deploy-sdk@5.1.0(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/deploy-sdk@6.0.0(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@hyperlane-xyz/aleo-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/cosmos-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/radix-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/sealevel-sdk': 33.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/starknet-sdk': 28.0.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/tron-sdk': 23.0.4(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/aleo-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/cosmos-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/radix-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/sealevel-sdk': 33.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/starknet-sdk': 28.0.5(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/tron-sdk': 23.0.5(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       zod: 3.21.4
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
@@ -12229,9 +12233,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/provider-sdk@5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/provider-sdk@6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       pino: 8.21.0
       zod: 3.21.4
     transitivePeerDependencies:
@@ -12242,10 +12246,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/radix-sdk@33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/radix-sdk@33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@radixdlt/babylon-core-api-sdk': 1.3.0
       '@radixdlt/babylon-gateway-api-sdk': 1.10.1
       '@radixdlt/radix-engine-toolkit': 1.0.6
@@ -12266,7 +12270,13 @@ snapshots:
       yaml: 2.4.5
       zod: 3.21.4
 
-  '@hyperlane-xyz/sdk@33.0.2(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/registry@25.0.0':
+    dependencies:
+      jszip: 3.10.1
+      yaml: 2.4.5
+      zod: 3.21.4
+
+  '@hyperlane-xyz/sdk@33.1.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
       '@arbitrum/sdk': 4.0.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@aws-sdk/client-s3': 3.1011.0
@@ -12280,15 +12290,15 @@ snapshots:
       '@cosmjs/stargate': 0.32.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@cosmjs/tendermint-rpc': 0.32.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@ethersproject/abi': 5.8.0
-      '@hyperlane-xyz/aleo-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/aleo-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@hyperlane-xyz/core': 11.3.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/sinon-chai@4.0.0)
-      '@hyperlane-xyz/cosmos-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/deploy-sdk': 5.1.0(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/radix-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/starknet-core': 33.0.2
-      '@hyperlane-xyz/tron-sdk': 23.0.4(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/cosmos-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/deploy-sdk': 6.0.0(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/radix-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/starknet-core': 33.1.0
+      '@hyperlane-xyz/tron-sdk': 23.0.5(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@safe-global/api-kit': 4.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)(zod@3.21.4)
       '@safe-global/protocol-kit': 6.1.1(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)(zod@3.21.4)
       '@safe-global/safe-core-sdk-types': 5.1.0(typescript@6.0.2)(zod@3.21.4)
@@ -12345,10 +12355,10 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@hyperlane-xyz/sealevel-sdk@33.0.2(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/sealevel-sdk@33.1.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@noble/hashes': 1.8.0
       '@solana-program/loader-v3': 0.3.0(@solana/kit@6.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6))
       '@solana-program/system': 0.12.0(@solana/kit@6.4.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6))
@@ -12363,15 +12373,15 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/starknet-core@33.0.2':
+  '@hyperlane-xyz/starknet-core@33.1.0':
     dependencies:
       starknet: 7.6.4
 
-  '@hyperlane-xyz/starknet-sdk@28.0.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/starknet-sdk@28.0.5(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/starknet-core': 33.0.2
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/starknet-core': 33.1.0
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       starknet: 7.6.4
     transitivePeerDependencies:
       - '@google-cloud/pino-logging-gcp-config'
@@ -12381,14 +12391,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/tron-sdk@23.0.4(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/tron-sdk@23.0.5(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
       '@ethersproject/abi': 5.8.0
       '@ethersproject/providers': 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@hyperlane-xyz/core': 11.3.1(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/sinon-chai@4.0.0)
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@hyperlane-xyz/registry': 24.3.0
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       bignumber.js: 9.3.1
       ethers: 5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       tronweb: 6.2.2(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -12402,7 +12412,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/utils@33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
+  '@hyperlane-xyz/utils@33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)':
     dependencies:
       '@cosmjs/encoding': 0.32.4
       '@ethersproject/bytes': 5.8.0
@@ -12422,19 +12432,19 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@hyperlane-xyz/widgets@33.0.2(@cosmjs/amino@0.36.2)(@cosmjs/proto-signing@0.32.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.91.0)(@tanstack/react-query@5.91.0(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(babel-plugin-macros@3.1.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(get-starknet-core@4.0.0)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@6.0.2)(utf-8-validate@6.0.6)(zod@3.21.4)':
+  '@hyperlane-xyz/widgets@33.1.0(@cosmjs/amino@0.36.2)(@cosmjs/proto-signing@0.32.4)(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@tanstack/query-core@5.91.0)(@tanstack/react-query@5.91.0(react@19.2.4))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(babel-plugin-macros@3.1.0)(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(get-starknet-core@4.0.0)(immer@10.2.0)(react-dom@19.2.4(react@19.2.4))(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6))(react@19.2.4)(typescript@6.0.2)(utf-8-validate@6.0.6)(zod@3.21.4)':
     dependencies:
       '@chain-registry/types': 0.50.322
       '@cosmjs/stargate': 0.32.4(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@cosmos-kit/react': 2.18.0(@cosmjs/amino@0.36.2)(@cosmjs/proto-signing@0.32.4)(@interchain-ui/react@1.26.3(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(utf-8-validate@6.0.6)
       '@headlessui/react': 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@hyperlane-xyz/aleo-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/cosmos-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/provider-sdk': 5.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/radix-sdk': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/sdk': 33.0.2(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/tron-sdk': 23.0.4(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
-      '@hyperlane-xyz/utils': 33.0.2(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/aleo-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/cosmos-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/provider-sdk': 6.0.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/radix-sdk': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/sdk': 33.1.0(@ethersproject/abi@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@react-native-async-storage/async-storage@1.24.0(react-native@0.84.1(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(utf-8-validate@6.0.6)))(@types/sinon-chai@4.0.0)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.20))(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/tron-sdk': 23.0.5(@types/sinon-chai@4.0.0)(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
+      '@hyperlane-xyz/utils': 33.1.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@6.0.6)
       '@interchain-ui/react': 1.26.3(@types/react@19.2.14)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@provablehq/aleo-types': 0.3.0-alpha.1
       '@provablehq/aleo-wallet-adaptor-react': 0.3.0-alpha.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/consts/chainAddresses.ts
+++ b/src/consts/chainAddresses.ts
@@ -6,7 +6,7 @@ import { ChainMap } from '@hyperlane-xyz/sdk';
 // you need TypeScript-side imports (e.g. importing pre-built `*Addresses`
 // constants from `@hyperlane-xyz/registry`).
 //
-// For YAML-friendly definitions, use `addresses.yaml` instead.
+// For YAML-friendly definitions, use `chainAddresses.yaml` instead.
 // Schema: any contract addresses you'd find in a registry chain's addresses.yaml
 // (e.g. mailbox, quotedCalls, validatorAnnounce, ...)
 export const addresses: ChainMap<ChainAddresses> = {

--- a/src/consts/chainAddresses.ts
+++ b/src/consts/chainAddresses.ts
@@ -1,0 +1,17 @@
+import { ChainAddresses } from '@hyperlane-xyz/registry';
+import { ChainMap } from '@hyperlane-xyz/sdk';
+
+// Per-chain contract addresses to merge with the configured registry's
+// addresses. Entries here override registry entries per key. Useful when
+// you need TypeScript-side imports (e.g. importing pre-built `*Addresses`
+// constants from `@hyperlane-xyz/registry`).
+//
+// For YAML-friendly definitions, use `addresses.yaml` instead.
+// Schema: any contract addresses you'd find in a registry chain's addresses.yaml
+// (e.g. mailbox, quotedCalls, validatorAnnounce, ...)
+export const addresses: ChainMap<ChainAddresses> = {
+  // mychain: {
+  //   mailbox: '0x...',
+  //   quotedCalls: '0x...',
+  // },
+};

--- a/src/consts/chainAddresses.yaml
+++ b/src/consts/chainAddresses.yaml
@@ -3,6 +3,11 @@
 # override registry entries per key, mirroring how chains.yaml extends chains.
 # Schema: any contract addresses you'd find in a registry chain's addresses.yaml
 # (e.g. mailbox, quotedCalls, validatorAnnounce, ...)
+# Full set of valid keys: https://github.com/hyperlane-xyz/hyperlane-registry/blob/main/chains/ethereum/addresses.yaml
+# (or the ChainAddresses type from @hyperlane-xyz/registry)
+#
+# Note: schema validation runs at app init — a typo here will throw and
+# block the whole warp context init, not just balance fetching.
 ---
 # Example using local anvil chain:
 # anvil1:

--- a/src/consts/chainAddresses.yaml
+++ b/src/consts/chainAddresses.yaml
@@ -1,0 +1,13 @@
+# A map of chain name -> contract addresses
+# Merges with addresses from the configured registry. Filesystem entries
+# override registry entries per key, mirroring how chains.yaml extends chains.
+# Schema: any contract addresses you'd find in a registry chain's addresses.yaml
+# (e.g. mailbox, quotedCalls, validatorAnnounce, ...)
+---
+# Example using local anvil chain:
+# anvil1:
+#   mailbox: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788'
+#   quotedCalls: '0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE'
+# anvil2:
+#   mailbox: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788'
+#   quotedCalls: '0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE'

--- a/src/features/balances/evm.ts
+++ b/src/features/balances/evm.ts
@@ -1,5 +1,5 @@
-import { chainAddresses } from '@hyperlane-xyz/registry';
-import { MultiProtocolProvider, Token } from '@hyperlane-xyz/sdk';
+import { ChainAddresses } from '@hyperlane-xyz/registry';
+import { ChainMap, MultiProtocolProvider, Token } from '@hyperlane-xyz/sdk';
 import { ProtocolType, normalizeAddress } from '@hyperlane-xyz/utils';
 import {
   Hex,
@@ -62,8 +62,8 @@ function classifyToken(token: Token): { type: TokenClassification; erc20Address?
  * Prefer the registry's batchContractAddress when available — some chains
  * (e.g. ancient8, viction) have the standard multicall3 address compromised.
  */
-function getBatchAddress(chainName: string): Hex {
-  const addresses = (chainAddresses as Record<string, Record<string, string>>)[chainName];
+function getBatchAddress(chainName: string, chainAddresses: ChainMap<ChainAddresses>): Hex {
+  const addresses = chainAddresses[chainName];
   if (addresses?.batchContractAddress) {
     return addresses.batchContractAddress.toLowerCase() as Hex;
   }
@@ -224,6 +224,7 @@ export async function fetchChainBalances(
   group: ChainGroup,
   multiProvider: MultiProtocolProvider,
   evmAddress: Hex,
+  chainAddresses: ChainMap<ChainAddresses>,
 ): Promise<Record<string, bigint>> {
   const rpcUrl = multiProvider.tryGetChainMetadata(group.chainName)?.rpcUrls?.[0]?.http;
   if (!rpcUrl) {
@@ -232,7 +233,7 @@ export async function fetchChainBalances(
   }
 
   const client = createPublicClient({ transport: http(rpcUrl) });
-  const batchAddress = getBatchAddress(group.chainName);
+  const batchAddress = getBatchAddress(group.chainName, chainAddresses);
   const balanceOfCallData = encodeFunctionData({
     abi: erc20Abi,
     functionName: 'balanceOf',

--- a/src/features/balances/hooks.ts
+++ b/src/features/balances/hooks.ts
@@ -149,11 +149,29 @@ export function useTokenBalances(tokens: Token[], scope: string, addressOverride
     [cosmosAddresses],
   );
 
+  // fetchChainBalances only reads batchContractAddress per chain. If that
+  // expands, widen this digest accordingly.
+  const chainAddressesKey = useMemo(
+    () =>
+      Object.entries(chainAddresses)
+        .map(([chain, addrs]) => `${chain}:${addrs.batchContractAddress ?? ''}`)
+        .sort()
+        .join('|'),
+    [chainAddresses],
+  );
+
   const hasAnyAddress = effectiveAddresses.size > 0 || cosmosAddresses.length > 0;
 
   const { data: balances = {}, isLoading } = useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps -- effectiveAddresses derived from addressEntries; tokens covered by tokenKeys; multiProvider is not serializable
-    queryKey: ['tokenBalances', addressEntries, cosmosAddressKey, scope, tokenKeys],
+    queryKey: [
+      'tokenBalances',
+      addressEntries,
+      cosmosAddressKey,
+      scope,
+      tokenKeys,
+      chainAddressesKey,
+    ],
     queryFn: async (): Promise<Record<string, bigint>> => {
       const promises: Promise<Record<string, bigint>>[] = [];
 

--- a/src/features/balances/hooks.ts
+++ b/src/features/balances/hooks.ts
@@ -14,6 +14,7 @@ import { useToastError } from '../../components/toast/useToastError';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { getChainDisplayName } from '../chains/utils';
+import { useStore } from '../store';
 import { getTokenKey } from '../tokens/utils';
 import { fetchCosmosChainBalances, groupCosmosTokensByChain } from './cosmos';
 import { fetchChainBalances, groupEvmTokensByChain } from './evm';
@@ -122,6 +123,7 @@ function useWalletAddresses(multiProvider: MultiProtocolProvider): Map<ProtocolT
  */
 export function useTokenBalances(tokens: Token[], scope: string, addressOverride?: string) {
   const multiProvider = useMultiProvider();
+  const chainAddresses = useStore((s) => s.chainAddresses);
   const walletAddresses = useWalletAddresses(multiProvider);
   const cosmosAddresses = useCosmosAccount(multiProvider).addresses;
   const tokenKeys = useMemo(() => tokens.map((t) => getTokenKey(t)), [tokens]);
@@ -160,7 +162,9 @@ export function useTokenBalances(tokens: Token[], scope: string, addressOverride
       if (evmAddr) {
         const { chainGroups, fallbackTokens } = groupEvmTokensByChain(tokens, multiProvider);
         for (const [chainId, group] of chainGroups) {
-          promises.push(fetchChainBalances(chainId, group, multiProvider, evmAddr as Hex));
+          promises.push(
+            fetchChainBalances(chainId, group, multiProvider, evmAddr as Hex, chainAddresses),
+          );
         }
         for (const { token, key } of fallbackTokens) {
           promises.push(fetchSdkBalance(token, multiProvider, evmAddr, key));

--- a/src/features/chains/addresses.ts
+++ b/src/features/chains/addresses.ts
@@ -22,7 +22,7 @@ export async function assembleChainAddresses(
   }
   const filesystemAddresses = result.data;
 
-  let registryChainAddresses: ChainMap<ChainAddresses>;
+  let registryChainAddresses: ChainMap<ChainAddresses> | undefined;
   if (config.registryUrl) {
     try {
       logger.debug('Using custom registry chain addresses from:', config.registryUrl);
@@ -32,10 +32,11 @@ export async function assembleChainAddresses(
         'Failed fetching chain addresses from GH registry, using published addresses',
         config.registryUrl,
       );
-      registryChainAddresses = (await import('@hyperlane-xyz/registry')).chainAddresses;
     }
   } else {
     logger.debug('Using default published registry for chain addresses');
+  }
+  if (!registryChainAddresses) {
     registryChainAddresses = (await import('@hyperlane-xyz/registry')).chainAddresses;
   }
 

--- a/src/features/chains/addresses.ts
+++ b/src/features/chains/addresses.ts
@@ -27,10 +27,11 @@ export async function assembleChainAddresses(
     try {
       logger.debug('Using custom registry chain addresses from:', config.registryUrl);
       registryChainAddresses = await registry.getAddresses();
-    } catch {
-      logger.debug(
+    } catch (error) {
+      logger.warn(
         'Failed fetching chain addresses from GH registry, using published addresses',
         config.registryUrl,
+        error,
       );
     }
   } else {

--- a/src/features/chains/addresses.ts
+++ b/src/features/chains/addresses.ts
@@ -1,0 +1,49 @@
+import { ChainAddresses, ChainAddressesSchema, IRegistry } from '@hyperlane-xyz/registry';
+import { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
+import { objFilter, objMerge } from '@hyperlane-xyz/utils';
+import { z } from 'zod';
+
+import { addresses as ChainAddressesTS } from '../../consts/chainAddresses.ts';
+import ChainAddressesYaml from '../../consts/chainAddresses.yaml';
+import { config } from '../../consts/config';
+import { logger } from '../../utils/logger';
+
+export async function assembleChainAddresses(
+  chainsInTokens: ChainName[],
+  registry: IRegistry,
+): Promise<ChainMap<ChainAddresses>> {
+  const result = z.record(ChainAddressesSchema).safeParse({
+    ...ChainAddressesYaml,
+    ...ChainAddressesTS,
+  });
+  if (!result.success) {
+    logger.warn('Invalid chain addresses', result.error);
+    throw new Error(`Invalid chain addresses: ${result.error.toString()}`);
+  }
+  const filesystemAddresses = result.data;
+
+  let registryChainAddresses: ChainMap<ChainAddresses>;
+  if (config.registryUrl) {
+    try {
+      logger.debug('Using custom registry chain addresses from:', config.registryUrl);
+      registryChainAddresses = await registry.getAddresses();
+    } catch {
+      logger.debug(
+        'Failed fetching chain addresses from GH registry, using published addresses',
+        config.registryUrl,
+      );
+      registryChainAddresses = (await import('@hyperlane-xyz/registry')).chainAddresses;
+    }
+  } else {
+    logger.debug('Using default published registry for chain addresses');
+    registryChainAddresses = (await import('@hyperlane-xyz/registry')).chainAddresses;
+  }
+
+  // Filter to only chains referenced by the configured warp routes
+  registryChainAddresses = objFilter(registryChainAddresses, (c, _a): _a is ChainAddresses =>
+    chainsInTokens.includes(c),
+  );
+
+  // Filesystem entries override registry entries per key
+  return objMerge<ChainMap<ChainAddresses>>(registryChainAddresses, filesystemAddresses);
+}

--- a/src/features/chains/metadata.ts
+++ b/src/features/chains/metadata.ts
@@ -37,7 +37,7 @@ export async function assembleChainMetadata(
   }
   const filesystemMetadata = result.data as ChainMap<ChainMetadata>;
 
-  let registryChainMetadata: ChainMap<ChainMetadata>;
+  let registryChainMetadata: ChainMap<ChainMetadata> | undefined;
   if (config.registryUrl) {
     try {
       logger.debug('Using custom registry chain metadata from:', config.registryUrl);
@@ -47,10 +47,11 @@ export async function assembleChainMetadata(
         'Failed fetching chain metadata from GH registry, using published registry',
         config.registryUrl,
       );
-      registryChainMetadata = (await import('@hyperlane-xyz/registry')).chainMetadata;
     }
   } else {
     logger.debug('Using default published registry for chain metadata');
+  }
+  if (!registryChainMetadata) {
     registryChainMetadata = (await import('@hyperlane-xyz/registry')).chainMetadata;
   }
 

--- a/src/features/chains/metadata.ts
+++ b/src/features/chains/metadata.ts
@@ -42,10 +42,11 @@ export async function assembleChainMetadata(
     try {
       logger.debug('Using custom registry chain metadata from:', config.registryUrl);
       registryChainMetadata = await registry.getMetadata();
-    } catch {
-      logger.debug(
+    } catch (error) {
+      logger.warn(
         'Failed fetching chain metadata from GH registry, using published registry',
         config.registryUrl,
+        error,
       );
     }
   } else {

--- a/src/features/chains/metadata.ts
+++ b/src/features/chains/metadata.ts
@@ -1,4 +1,4 @@
-import { IRegistry, chainMetadata as publishedChainMetadata } from '@hyperlane-xyz/registry';
+import { IRegistry } from '@hyperlane-xyz/registry';
 import {
   ChainMap,
   ChainMetadata,
@@ -47,11 +47,11 @@ export async function assembleChainMetadata(
         'Failed fetching chain metadata from GH registry, using published registry',
         config.registryUrl,
       );
-      registryChainMetadata = publishedChainMetadata;
+      registryChainMetadata = (await import('@hyperlane-xyz/registry')).chainMetadata;
     }
   } else {
     logger.debug('Using default published registry for chain metadata');
-    registryChainMetadata = publishedChainMetadata;
+    registryChainMetadata = (await import('@hyperlane-xyz/registry')).chainMetadata;
   }
 
   // Filter out chains that are not in the tokens config

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -1,6 +1,5 @@
 import {
   ChainAddresses,
-  chainMetadata,
   GithubRegistry,
   IRegistry,
   PartialRegistry,
@@ -304,8 +303,8 @@ async function initWarpContext({
     // Pre-load registry content to avoid repeated requests
     await currentRegistry.listRegistryContent();
   } catch (error) {
-    // Lazy-load the published chainAddresses constant so it stays out of the initial bundle
-    const { chainAddresses } = await import('@hyperlane-xyz/registry');
+    // Lazy-load the published constants so they stay out of the initial bundle
+    const { chainAddresses, chainMetadata } = await import('@hyperlane-xyz/registry');
     currentRegistry = new PartialRegistry({
       chainAddresses,
       chainMetadata,

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -144,6 +144,8 @@ export const useStore = create<AppState>()(
         logger.debug('Setting chain overrides in store');
         const filtered = objFilter(overrides, (_, metadata) => !!metadata);
         const {
+          chainMetadata,
+          chainAddresses,
           multiProvider,
           warpCore,
           routerAddressesByChainMap,
@@ -157,6 +159,8 @@ export const useStore = create<AppState>()(
         });
         set({
           chainMetadataOverrides: filtered,
+          chainMetadata,
+          chainAddresses,
           multiProvider,
           warpCore,
           routerAddressesByChainMap,
@@ -170,6 +174,8 @@ export const useStore = create<AppState>()(
       setWarpCoreConfigOverrides: async (overrides: WarpCoreConfig[] | undefined = []) => {
         logger.debug('Setting warp core config overrides in store');
         const {
+          chainMetadata,
+          chainAddresses,
           multiProvider,
           warpCore,
           routerAddressesByChainMap,
@@ -183,6 +189,8 @@ export const useStore = create<AppState>()(
         });
         set({
           warpCoreConfigOverrides: overrides,
+          chainMetadata,
+          chainAddresses,
           multiProvider,
           warpCore,
           routerAddressesByChainMap,

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -144,6 +144,7 @@ export const useStore = create<AppState>()(
         logger.debug('Setting chain overrides in store');
         const filtered = objFilter(overrides, (_, metadata) => !!metadata);
         const {
+          registry,
           chainMetadata,
           chainAddresses,
           multiProvider,
@@ -159,6 +160,7 @@ export const useStore = create<AppState>()(
         });
         set({
           chainMetadataOverrides: filtered,
+          registry,
           chainMetadata,
           chainAddresses,
           multiProvider,
@@ -174,6 +176,7 @@ export const useStore = create<AppState>()(
       setWarpCoreConfigOverrides: async (overrides: WarpCoreConfig[] | undefined = []) => {
         logger.debug('Setting warp core config overrides in store');
         const {
+          registry,
           chainMetadata,
           chainAddresses,
           multiProvider,
@@ -189,6 +192,7 @@ export const useStore = create<AppState>()(
         });
         set({
           warpCoreConfigOverrides: overrides,
+          registry,
           chainMetadata,
           chainAddresses,
           multiProvider,

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -1,5 +1,5 @@
 import {
-  chainAddresses,
+  ChainAddresses,
   chainMetadata,
   GithubRegistry,
   IRegistry,
@@ -21,6 +21,7 @@ import { persist } from 'zustand/middleware';
 
 import { config } from '../consts/config';
 import { logger } from '../utils/logger';
+import { assembleChainAddresses } from './chains/addresses';
 import { assembleChainMetadata } from './chains/metadata';
 import {
   buildTokensArray,
@@ -43,6 +44,7 @@ const PERSIST_STATE_VERSION = 2;
 interface WarpContext {
   registry: IRegistry;
   chainMetadata: ChainMap<ChainMetadata>;
+  chainAddresses: ChainMap<ChainAddresses>;
   multiProvider: MultiProtocolProvider;
   warpCore: WarpCore;
   /** Unified tokens array (deduplicated, can be origin or destination) */
@@ -74,6 +76,8 @@ function buildE2ETokenSnapshot(tokens: Token[] | undefined): E2ETokenSnapshot[] 
 export interface AppState {
   // Chains and providers
   chainMetadata: ChainMap<ChainMetadata>;
+  // Per-chain contract addresses, merged from registry + filesystem (addresses.yaml)
+  chainAddresses: ChainMap<ChainAddresses>;
   // Overrides to chain metadata set by user via the chain picker
   chainMetadataOverrides: ChainMap<Partial<ChainMetadata>>;
   setChainMetadataOverrides: (overrides?: ChainMap<Partial<ChainMetadata> | undefined>) => void;
@@ -133,6 +137,7 @@ export const useStore = create<AppState>()(
     (set, get) => ({
       // Chains and providers
       chainMetadata: {},
+      chainAddresses: {},
       chainMetadataOverrides: {},
       setChainMetadataOverrides: async (
         overrides: ChainMap<Partial<ChainMetadata> | undefined> = {},
@@ -299,9 +304,11 @@ async function initWarpContext({
     // Pre-load registry content to avoid repeated requests
     await currentRegistry.listRegistryContent();
   } catch (error) {
+    // Lazy-load the published chainAddresses constant so it stays out of the initial bundle
+    const { chainAddresses } = await import('@hyperlane-xyz/registry');
     currentRegistry = new PartialRegistry({
-      chainAddresses: chainAddresses,
-      chainMetadata: chainMetadata,
+      chainAddresses,
+      chainMetadata,
     });
     logger.warn(
       'Failed to list registry content using GithubRegistry, will continue with PartialRegistry.',
@@ -316,11 +323,10 @@ async function initWarpContext({
     );
 
     const chainsInTokens = Array.from(new Set(coreConfig.tokens.map((t) => t.chainName)));
-    const { chainMetadata, chainMetadataWithOverrides } = await assembleChainMetadata(
-      chainsInTokens,
-      currentRegistry,
-      chainMetadataOverrides,
-    );
+    const [{ chainMetadata, chainMetadataWithOverrides }, chainAddresses] = await Promise.all([
+      assembleChainMetadata(chainsInTokens, currentRegistry, chainMetadataOverrides),
+      assembleChainAddresses(chainsInTokens, currentRegistry),
+    ]);
     const multiProvider = new MultiProtocolProvider(chainMetadataWithOverrides);
     const warpCore = WarpCore.FromConfig(multiProvider, coreConfig);
 
@@ -348,6 +354,7 @@ async function initWarpContext({
     return {
       registry: currentRegistry,
       chainMetadata,
+      chainAddresses,
       multiProvider,
       warpCore,
       routerAddressesByChainMap,
@@ -362,6 +369,7 @@ async function initWarpContext({
     return {
       registry,
       chainMetadata: {},
+      chainAddresses: {},
       multiProvider: new MultiProtocolProvider({}),
       warpCore: new WarpCore(new MultiProtocolProvider({}), []),
       routerAddressesByChainMap: {},


### PR DESCRIPTION
## Summary

Mirrors the existing `chainMetadata` flow for chain contract addresses, with two related upsides:

1. **Single source of truth** — `chainAddresses` is loaded once at warp context init and exposed via the Zustand store. Consumers read it synchronously instead of awaiting `registry.getAddresses()`.
2. **Filesystem override pattern** — adds `src/consts/chainAddresses.yaml` and `chainAddresses.ts` parallel to `chains.yaml` / `chains.ts`. Useful for local dev / forks that want to extend the registry without patching the store.

While restructuring, also lazy-loads the published `chainAddresses` and `chainMetadata` constants from `@hyperlane-xyz/registry` so they're shed from the initial bundle.

## Changes

### Address resolution mirrors metadata
- `src/features/chains/addresses.ts` — new helper `assembleChainAddresses(chainsInTokens, registry)`. Spreads `{...chainAddressesYaml, ...chainAddressesTS}`, validates with `ChainAddressesSchema`, fetches from registry (or falls back to the published constant), filters to chains referenced by warp routes, and merges filesystem on top of registry per key.
- `src/features/store.ts` — adds `chainAddresses: ChainMap<ChainAddresses>` to `WarpContext` / `AppState`, populated alongside `chainMetadata` via `Promise.all` in `initWarpContext`.
- `src/consts/chainAddresses.yaml` + `src/consts/chainAddresses.ts` — empty templates (commented examples).

### Existing consumers migrated to the store
- `src/features/balances/evm.ts` — `fetchChainBalances` and `getBatchAddress` now accept `ChainMap<ChainAddresses>` as a parameter.
- `src/features/balances/hooks.ts` — reads `chainAddresses` from the store and passes to `fetchChainBalances`.

### Bundle: lazy-load the published registry constants
- The published `chainAddresses` (~420 KB raw / ~80 KB gz) and `chainMetadata` (~384 KB raw / ~80 KB gz) constants from `@hyperlane-xyz/registry` are no longer statically imported. They're resolved via dynamic `import('@hyperlane-xyz/registry')` only on:
  - registry fetch failure in `assembleChainMetadata` / `assembleChainAddresses`
  - `listRegistryContent` failure in `initWarpContext` (PartialRegistry fallback path)
  - the no-`NEXT_PUBLIC_REGISTRY_URL` branch in `assembleChainMetadata` (rare path used when no custom registry is configured)
- Webpack/Turbopack emits one shared async chunk for the registry package; both lazy imports dedupe.

## Side effects worth flagging

- **Cold-start regression for deployments without `NEXT_PUBLIC_REGISTRY_URL`**: bounded by one chunk fetch on first load (~100–300ms), then cached. Production deployments that set the env var only hit the lazy paths on registry-failure (already an error path).
- API of `assembleChainMetadata` / `getBatchAddress` / `fetchChainBalances` changed (additive param). Internal only.

## Verification

- `pnpm format`, `pnpm lint`, `pnpm typecheck` clean.
- `pnpm test` — 22 files, 231 tests pass.