### PR TITLE
feat: add USDe/igra and TIBBIR/igra to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -51,6 +51,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // USDS routes
   'USDS/ethereum-igra',
 
+  // USDe routes
+  'USDe/igra',
+
   // USDT routes
   'USDT/ethereum-hyperevm',
   'USDT/ethereum-inevm',
@@ -68,6 +71,9 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // IKAS routes
   'IKAS/igra',
+
+  // TIBBIR routes
+  'TIBBIR/igra',
 
   // INJ routes
   'INJ/inevm-injective',


### PR DESCRIPTION
Adds the following warp routes to the Nexus UI whitelist:

| Field | Value |
| ----- | ----- |
| **Linear** | [AW-627](https://linear.app/hyperlane-xyz/issue/AW-627/igra-usde-yield-route-ethereum-igra) · [AW-624](https://linear.app/hyperlane-xyz/issue/AW-624/igra-tibbir-base-igra) |

- `USDe/igra`
- `TIBBIR/igra`