### PR TITLE
feat: relayer api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_WALLET_CONNECT_ID=12345678901234567890123456789012
 NEXT_PUBLIC_RPC_OVERRIDES='{"chain1":{"http":"https://..."}}'
+NEXT_PUBLIC_RELAY_API_URL=http://localhost:8900
 
 # Predicate Attestation Support (server-side only, optional)
 # Required for routes with PredicateRouterWrapper

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 NEXT_PUBLIC_WALLET_CONNECT_ID=12345678901234567890123456789012
 NEXT_PUBLIC_RPC_OVERRIDES='{"chain1":{"http":"https://..."}}'
+
+# Localhost only; production deployments must use https://
 NEXT_PUBLIC_RELAY_API_URL=http://localhost:8900
 
 # Predicate Attestation Support (server-side only, optional)

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -14,6 +14,7 @@ const chainWalletWhitelists = JSON.parse(process.env.NEXT_PUBLIC_CHAIN_WALLET_WH
 const rpcOverrides = process.env.NEXT_PUBLIC_RPC_OVERRIDES || '';
 const explorerApiUrl =
   process.env.NEXT_PUBLIC_EXPLORER_API_URL || 'https://explorer4.hasura.app/v1/graphql';
+const relayApiUrl = process.env.NEXT_PUBLIC_RELAY_API_URL || undefined;
 
 interface Config {
   addressBlacklist: string[]; // A list of addresses that are blacklisted and cannot be used in the app
@@ -22,6 +23,7 @@ interface Config {
   defaultDestinationToken: string | undefined; // The initial destination token to show when app first loads (format: chainName-symbol, e.g. "bsc-hyper")
   enableExplorerLink: boolean; // Include a link to the hyperlane explorer in the transfer modal
   explorerApiUrl: string; // URL for the Hyperlane Explorer GraphQL API
+  relayApiUrl: string | undefined; // Optional URL for the Hyperlane Relayer API
   isDevMode: boolean; // Enables some debug features in the app
   registryUrl: string | undefined; // Optional URL to use a custom registry instead of the published canonical version
   registryBranch?: string | undefined; // Optional customization of the registry branch instead of main
@@ -42,6 +44,7 @@ export const config: Config = Object.freeze({
   chainWalletWhitelists,
   enableExplorerLink: false,
   explorerApiUrl,
+  relayApiUrl,
   defaultOriginToken: 'ethereum-USDC',
   defaultDestinationToken: 'base-USDC',
   isDevMode,

--- a/src/features/transfer/relayApi.ts
+++ b/src/features/transfer/relayApi.ts
@@ -1,5 +1,20 @@
+import { ProviderType, TypedTransactionReceipt } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
+
+// keccak256("MessageSent(bytes)") — emitted by MessageTransmitter V2 for both native USDC
+// transfers (depositForBurn) and GMP-only messages. Covers CCTP V2 GMP that lacks DepositForBurn.
+const MESSAGE_SENT_TOPIC = '0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036';
+
+// Circle's MessageTransmitter V2 addresses (lowercase for comparison).
+// Source: https://developers.circle.com/cctp/references/contract-addresses#messagetransmitterv2
+const MESSAGE_TRANSMITTER_V2_ADDRESSES = new Set([
+  '0x81d40f21f12a8f0e3252bccb954d722d4c464b64', // mainnet (all chains except EDGE)
+  '0x5b61381fc9e58e70efc13a4a97516997019198ee', // mainnet EDGE
+  '0xe737e5cebeeba77efe34d4aa090756590b1ce275', // testnet (all chains)
+]);
 
 interface RelayResponse {
   messages: Array<{
@@ -11,11 +26,27 @@ interface RelayResponse {
 }
 
 /**
- * Submits an origin transaction hash to the relayer API for fast processing.
+ * Submits an origin transaction hash to the relayer API for fast CCTP processing.
  * Fire-and-forget: errors are logged but never surfaced to the user.
  */
-export async function submitToRelayApi(originChain: string, txHash: string): Promise<void> {
+export async function submitToRelayApi(
+  originChain: string,
+  txHash: string,
+  originProtocol: ProtocolType,
+  txReceipt: TypedTransactionReceipt | null | undefined,
+): Promise<void> {
   if (!config.relayApiUrl) return;
+
+  const isCctp =
+    originProtocol === ProtocolType.Ethereum &&
+    txReceipt != null &&
+    (txReceipt.type === ProviderType.EthersV5 || txReceipt.type === ProviderType.Viem) &&
+    txReceipt.receipt.logs.some(
+      (log) =>
+        log.topics[0] === MESSAGE_SENT_TOPIC &&
+        MESSAGE_TRANSMITTER_V2_ADDRESSES.has(log.address.toLowerCase()),
+    );
+  if (!isCctp) return;
 
   try {
     const payload = { origin_chain: originChain, tx_hash: txHash };

--- a/src/features/transfer/relayApi.ts
+++ b/src/features/transfer/relayApi.ts
@@ -1,5 +1,5 @@
 import { ProviderType, TypedTransactionReceipt } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
+import { ProtocolType, isNullish } from '@hyperlane-xyz/utils';
 
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
@@ -37,21 +37,22 @@ export async function submitToRelayApi(
 ): Promise<void> {
   if (!config.relayApiUrl) return;
 
-  const isCctp =
-    originProtocol === ProtocolType.Ethereum &&
-    txReceipt != null &&
-    (txReceipt.type === ProviderType.EthersV5 || txReceipt.type === ProviderType.Viem) &&
-    txReceipt.receipt.logs.some(
-      (log) =>
-        log.topics[0] === MESSAGE_SENT_TOPIC &&
-        MESSAGE_TRANSMITTER_V2_ADDRESSES.has(log.address.toLowerCase()),
-    );
-  if (!isCctp) return;
-
   try {
+    const isCctp =
+      originProtocol === ProtocolType.Ethereum &&
+      !isNullish(txReceipt) &&
+      (txReceipt.type === ProviderType.EthersV5 || txReceipt.type === ProviderType.Viem) &&
+      txReceipt.receipt.logs.some(
+        (log) =>
+          log.topics[0] === MESSAGE_SENT_TOPIC &&
+          MESSAGE_TRANSMITTER_V2_ADDRESSES.has(log.address.toLowerCase()),
+      );
+    if (!isCctp) return;
+
+    const baseUrl = config.relayApiUrl.replace(/\/$/, '');
     const payload = { origin_chain: originChain, tx_hash: txHash };
-    logger.debug('[RelayAPI] Requesting relay', { url: `${config.relayApiUrl}/relay`, payload });
-    const response = await fetch(`${config.relayApiUrl}/relay`, {
+    logger.debug('[RelayAPI] Requesting relay', { url: `${baseUrl}/relay`, payload });
+    const response = await fetch(`${baseUrl}/relay`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/src/features/transfer/relayApi.ts
+++ b/src/features/transfer/relayApi.ts
@@ -1,0 +1,43 @@
+import { config } from '../../consts/config';
+import { logger } from '../../utils/logger';
+
+interface RelayResponse {
+  messages: Array<{
+    message_id: string;
+    origin: number;
+    destination: number;
+    nonce: number;
+  }>;
+}
+
+/**
+ * Submits an origin transaction hash to the relayer API for fast processing.
+ * Fire-and-forget: errors are logged but never surfaced to the user.
+ */
+export async function submitToRelayApi(originChain: string, txHash: string): Promise<void> {
+  if (!config.relayApiUrl) return;
+
+  try {
+    const payload = { origin_chain: originChain, tx_hash: txHash };
+    logger.debug('[RelayAPI] Requesting relay', { url: `${config.relayApiUrl}/relay`, payload });
+    const response = await fetch(`${config.relayApiUrl}/relay`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      logger.warn(`[RelayAPI] ${response.status} for ${txHash} on ${originChain}: ${text}`);
+      return;
+    }
+
+    const data: RelayResponse = await response.json();
+    logger.debug(
+      `[RelayAPI] Accepted ${data.messages.length} message(s) from ${txHash} on ${originChain}`,
+      data.messages.map((m) => m.message_id),
+    );
+  } catch (error) {
+    logger.warn(`[RelayAPI] Failed to submit ${txHash} on ${originChain}`, error);
+  }
+}

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -30,7 +30,6 @@ import { submitToRelayApi } from './relayApi';
 import { TransferContext, TransferFormValues, TransferStatus } from './types';
 import { tryGetMsgIdFromTransferReceipt } from './utils';
 
-
 const CHAIN_MISMATCH_ERROR = 'ChainMismatchError';
 const TRANSFER_TIMEOUT_ERROR1 = 'block height exceeded';
 const TRANSFER_TIMEOUT_ERROR2 = 'timeout';

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -5,7 +5,7 @@ import {
   WarpCore,
   WarpTxCategory,
 } from '@hyperlane-xyz/sdk';
-import { toTitleCase, toWei } from '@hyperlane-xyz/utils';
+import { ProtocolType, toTitleCase, toWei } from '@hyperlane-xyz/utils';
 import {
   getAccountAddressForChain,
   useAccounts,
@@ -26,8 +26,21 @@ import { AppState, useStore } from '../store';
 import { getTokenByKey, useWarpCore } from '../tokens/hooks';
 import { findConnectedDestinationToken } from '../tokens/utils';
 import { fetchPredicateAttestation, PredicateAttestationResult } from './predicate';
+import { submitToRelayApi } from './relayApi';
 import { TransferContext, TransferFormValues, TransferStatus } from './types';
 import { tryGetMsgIdFromTransferReceipt } from './utils';
+
+// keccak256("MessageSent(bytes)") — emitted by MessageTransmitter V2 for both native USDC
+// transfers (depositForBurn) and GMP-only messages. Covers CCTP V2 GMP that lacks DepositForBurn.
+const MESSAGE_SENT_TOPIC = '0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036';
+
+// Circle's MessageTransmitter V2 addresses (lowercase for comparison).
+// Source: https://developers.circle.com/cctp/references/contract-addresses#messagetransmitterv2
+const MESSAGE_TRANSMITTER_V2_ADDRESSES = new Set([
+  '0x81d40f21f12a8f0e3252bccb954d722d4c464b64', // mainnet (all chains except EDGE)
+  '0x5b61381fc9e58e70efc13a4a97516997019198ee', // mainnet EDGE
+  '0xe737e5cebeeba77efe34d4aa090756590b1ce275', // testnet (all chains)
+]);
 
 const CHAIN_MISMATCH_ERROR = 'ChainMismatchError';
 const TRANSFER_TIMEOUT_ERROR1 = 'block height exceeded';
@@ -268,6 +281,18 @@ async function executeTransfer({
       originBlockNumber,
       msgId,
     });
+
+    // Submit to relay API for fast CCTP processing. Fire-and-forget: never blocks or fails the transfer.
+    const isCctp =
+      originProtocol === ProtocolType.Ethereum &&
+      txReceipt != null &&
+      (txReceipt.type === ProviderType.EthersV5 || txReceipt.type === ProviderType.Viem) &&
+      txReceipt.receipt.logs.some(
+        (log) =>
+          log.topics[0] === MESSAGE_SENT_TOPIC &&
+          MESSAGE_TRANSMITTER_V2_ADDRESSES.has(log.address.toLowerCase()),
+      );
+    if (originTxHash && isCctp) submitToRelayApi(origin, originTxHash);
 
     // track event after tx submission
     const originChainId = warpCore.multiProvider.getChainId(origin);

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -5,7 +5,7 @@ import {
   WarpCore,
   WarpTxCategory,
 } from '@hyperlane-xyz/sdk';
-import { ProtocolType, toTitleCase, toWei } from '@hyperlane-xyz/utils';
+import { toTitleCase, toWei } from '@hyperlane-xyz/utils';
 import {
   getAccountAddressForChain,
   useAccounts,
@@ -30,17 +30,6 @@ import { submitToRelayApi } from './relayApi';
 import { TransferContext, TransferFormValues, TransferStatus } from './types';
 import { tryGetMsgIdFromTransferReceipt } from './utils';
 
-// keccak256("MessageSent(bytes)") — emitted by MessageTransmitter V2 for both native USDC
-// transfers (depositForBurn) and GMP-only messages. Covers CCTP V2 GMP that lacks DepositForBurn.
-const MESSAGE_SENT_TOPIC = '0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036';
-
-// Circle's MessageTransmitter V2 addresses (lowercase for comparison).
-// Source: https://developers.circle.com/cctp/references/contract-addresses#messagetransmitterv2
-const MESSAGE_TRANSMITTER_V2_ADDRESSES = new Set([
-  '0x81d40f21f12a8f0e3252bccb954d722d4c464b64', // mainnet (all chains except EDGE)
-  '0x5b61381fc9e58e70efc13a4a97516997019198ee', // mainnet EDGE
-  '0xe737e5cebeeba77efe34d4aa090756590b1ce275', // testnet (all chains)
-]);
 
 const CHAIN_MISMATCH_ERROR = 'ChainMismatchError';
 const TRANSFER_TIMEOUT_ERROR1 = 'block height exceeded';
@@ -282,17 +271,7 @@ async function executeTransfer({
       msgId,
     });
 
-    // Submit to relay API for fast CCTP processing. Fire-and-forget: never blocks or fails the transfer.
-    const isCctp =
-      originProtocol === ProtocolType.Ethereum &&
-      txReceipt != null &&
-      (txReceipt.type === ProviderType.EthersV5 || txReceipt.type === ProviderType.Viem) &&
-      txReceipt.receipt.logs.some(
-        (log) =>
-          log.topics[0] === MESSAGE_SENT_TOPIC &&
-          MESSAGE_TRANSMITTER_V2_ADDRESSES.has(log.address.toLowerCase()),
-      );
-    if (originTxHash && isCctp) submitToRelayApi(origin, originTxHash);
+    if (originTxHash) submitToRelayApi(origin, originTxHash, originProtocol, txReceipt);
 
     // track event after tx submission
     const originChainId = warpCore.multiProvider.getChainId(origin);


### PR DESCRIPTION
Implements the relay api and calls it only if the message originates from a cctp v2 route. The new env variable NEXT_PUBLIC_RELAY_API_URL has been already added to vercel