### PR TITLE
fix: correct token picker route availability

### DIFF
--- a/src/features/tokens/TokenList.tsx
+++ b/src/features/tokens/TokenList.tsx
@@ -66,9 +66,7 @@ export function TokenList({
 
   // Deferred state for route map - allows UI to render immediately
   const [tokenRouteMap, setTokenRouteMap] = useState<Map<string, boolean> | null>(null);
-  const [tokenPickerRouteMap, setTokenPickerRouteMap] = useState<Map<string, boolean> | null>(
-    null,
-  );
+  const [tokenPickerRouteMap, setTokenPickerRouteMap] = useState<Map<string, boolean> | null>(null);
   const [, startTransition] = useTransition();
 
   // Default token set: featured+routable when featured defined, all tokens otherwise
@@ -288,9 +286,7 @@ export function TokenList({
         <div className="py-2 md:px-3">
           {tokens.map((token) => {
             const key = getTokenKey(token);
-            const hasRoute = tokenPickerRouteMap
-              ? (tokenPickerRouteMap.get(key) ?? true)
-              : true;
+            const hasRoute = tokenPickerRouteMap ? (tokenPickerRouteMap.get(key) ?? true) : true;
             const balance = balanceMap.get(key);
             const usdValue = usdMap.get(key) ?? null;
 
@@ -371,44 +367,50 @@ const TokenButton = React.memo(function TokenButton({
     >
       <TokenChainIcon token={token} size={36} />
 
-      <div className="ml-3 min-w-0 flex-1 text-left">
-        <div className="flex items-center gap-2">
-          <span className={`token-picker-symbol ${styles.base} text-base text-black`}>
-            {token.symbol || 'Unknown'}
-          </span>
-          <span className="token-picker-chain-name text-xs text-gray-500">{chainDisplayName}</span>
-        </div>
-        <div className={`token-picker-name ${styles.base} mt-0.5 truncate text-xs text-gray-500`}>
-          {token.name || 'Unknown Token'}
-        </div>
-      </div>
-
-      <div className="ml-2 shrink-0 text-right">
-        {isBalanceLoading && !primaryValue ? (
-          <div className="token-picker-shimmer mb-1 ml-auto h-4 w-14 animate-pulse rounded bg-gray-100" />
-        ) : primaryValue ? (
-          <>
-            <div className={`token-picker-usd ${styles.base} text-sm font-medium text-black`}>
-              {primaryValue}
-            </div>
-            {secondaryValue && (
-              <div className={`token-picker-meta ${styles.base} text-xs text-gray-400`}>
-                {secondaryValue}
-              </div>
-            )}
-          </>
-        ) : null}
-        {showRouteUnavailable && (
-          <div className="flex items-center justify-end gap-1 whitespace-nowrap text-[10px] text-gray-400">
-            <span>Route unavailable</span>
-            <Tooltip
-              content={routeTooltipMessage}
-              id={`route-tooltip-${getTokenKey(token)}`}
-              tooltipClassName="token-picker-info-icon max-w-[280px]"
-              onClick={(e) => e.stopPropagation()}
-            />
+      <div className="ml-3 grid min-w-0 flex-1 grid-cols-[minmax(0,1fr)_minmax(6.75rem,max-content)] items-center gap-3">
+        <div className="min-w-0 text-left">
+          <div className="flex min-w-0 items-center gap-2">
+            <span
+              className={`token-picker-symbol ${styles.base} max-w-[8rem] shrink-0 truncate text-base text-black`}
+            >
+              {token.symbol || 'Unknown'}
+            </span>
+            <span className="token-picker-chain-name min-w-0 truncate text-xs text-gray-500">
+              {chainDisplayName}
+            </span>
           </div>
-        )}
+          <div className={`token-picker-name ${styles.base} mt-0.5 truncate text-xs text-gray-500`}>
+            {token.name || 'Unknown Token'}
+          </div>
+        </div>
+
+        <div className="min-w-[6.75rem] justify-self-end text-right tabular-nums">
+          {isBalanceLoading && !primaryValue ? (
+            <div className="token-picker-shimmer mb-1 ml-auto h-4 w-14 animate-pulse rounded bg-gray-100" />
+          ) : primaryValue ? (
+            <>
+              <div className={`token-picker-usd ${styles.base} text-sm font-medium text-black`}>
+                {primaryValue}
+              </div>
+              {secondaryValue && (
+                <div className={`token-picker-meta ${styles.base} text-xs text-gray-400`}>
+                  {secondaryValue}
+                </div>
+              )}
+            </>
+          ) : null}
+          {showRouteUnavailable && (
+            <div className="flex items-center justify-end gap-1 whitespace-nowrap text-[10px] text-gray-400">
+              <span>Route unavailable</span>
+              <Tooltip
+                content={routeTooltipMessage}
+                id={`route-tooltip-${getTokenKey(token)}`}
+                tooltipClassName="token-picker-info-icon max-w-[280px]"
+                onClick={(e) => e.stopPropagation()}
+              />
+            </div>
+          )}
+        </div>
       </div>
     </button>
   );

--- a/src/features/tokens/TokenList.tsx
+++ b/src/features/tokens/TokenList.tsx
@@ -206,15 +206,15 @@ export function TokenList({
     balanceMap,
   ]);
 
-  // In origin mode the result is counterpart-independent, so exclude
-  // counterpartToken from the effect deps to avoid recomputing the whole
-  // route map when only the destination changes.
+  // In origin mode the result is counterpart-independent, so gate the
+  // effect on a masked counterpart to avoid rebuilding the route map when
+  // only the destination changes.
   const counterpartDep = selectionMode === 'destination' ? counterpartToken : null;
 
   // Compute route map in a transition (non-blocking)
   useEffect(() => {
     startTransition(() => {
-      if (selectionMode === 'destination' && !counterpartDep) {
+      if (selectionMode === 'destination' && !counterpartToken) {
         setTokenRouteMap(null);
         return;
       }
@@ -225,7 +225,7 @@ export function TokenList({
         const key = getTokenKey(token);
         const hasRoute = checkTokenPickerHasRoute(
           token,
-          counterpartDep,
+          counterpartToken,
           selectionMode,
           allTokens,
           collateralGroups,
@@ -235,6 +235,8 @@ export function TokenList({
 
       setTokenRouteMap(routeMap);
     });
+    // counterpartToken intentionally omitted: counterpartDep gates this effect.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allTokens, counterpartDep, selectionMode, collateralGroups]);
 
   // Reset scroll when user changes search or chain filter

--- a/src/features/tokens/TokenList.tsx
+++ b/src/features/tokens/TokenList.tsx
@@ -206,10 +206,15 @@ export function TokenList({
     balanceMap,
   ]);
 
+  // In origin mode the result is counterpart-independent, so exclude
+  // counterpartToken from the effect deps to avoid recomputing the whole
+  // route map when only the destination changes.
+  const counterpartDep = selectionMode === 'destination' ? counterpartToken : null;
+
   // Compute route map in a transition (non-blocking)
   useEffect(() => {
     startTransition(() => {
-      if (!counterpartToken) {
+      if (selectionMode === 'destination' && !counterpartDep) {
         setTokenRouteMap(null);
         return;
       }
@@ -220,7 +225,7 @@ export function TokenList({
         const key = getTokenKey(token);
         const hasRoute = checkTokenPickerHasRoute(
           token,
-          counterpartToken,
+          counterpartDep,
           selectionMode,
           allTokens,
           collateralGroups,
@@ -230,7 +235,7 @@ export function TokenList({
 
       setTokenRouteMap(routeMap);
     });
-  }, [allTokens, counterpartToken, selectionMode, collateralGroups]);
+  }, [allTokens, counterpartDep, selectionMode, collateralGroups]);
 
   // Reset scroll when user changes search or chain filter
   useEffect(() => {

--- a/src/features/tokens/TokenList.tsx
+++ b/src/features/tokens/TokenList.tsx
@@ -11,7 +11,7 @@ import { useCollateralGroups, useTokens } from './hooks';
 import { TokenChainIcon } from './TokenChainIcon';
 import { TokenSelectionMode } from './types';
 import { useTokenPrices } from './useTokenPrice';
-import { checkTokenHasRoute, getTokenKey } from './utils';
+import { checkTokenPickerHasRoute, getTokenKey } from './utils';
 
 const featuredSet = new Set(config.featuredTokens.map((t) => t.toLowerCase()));
 
@@ -218,9 +218,13 @@ export function TokenList({
 
       for (const token of allTokens) {
         const key = getTokenKey(token);
-        const originToken = selectionMode === 'origin' ? token : counterpartToken;
-        const destToken = selectionMode === 'origin' ? counterpartToken : token;
-        const hasRoute = checkTokenHasRoute(originToken, destToken, collateralGroups);
+        const hasRoute = checkTokenPickerHasRoute(
+          token,
+          counterpartToken,
+          selectionMode,
+          allTokens,
+          collateralGroups,
+        );
         routeMap.set(key, hasRoute);
       }
 
@@ -310,9 +314,10 @@ const TokenButton = React.memo(function TokenButton({
     ? getChainDisplayName(multiProvider, counterpartToken.chainName)
     : '';
 
-  const routeDirection = selectionMode === 'destination' ? 'from' : 'to';
   const routeTooltipMessage = counterpartToken
-    ? `No route ${routeDirection} ${counterpartToken.symbol} on ${counterpartChainName}`
+    ? selectionMode === 'destination'
+      ? `No route from ${counterpartToken.symbol} on ${counterpartChainName}`
+      : `No available destination from ${token.symbol} on ${chainDisplayName}`
     : '';
 
   const formattedBalance = balance != null ? formatBalance(balance, token.decimals) : null;

--- a/src/features/tokens/TokenList.tsx
+++ b/src/features/tokens/TokenList.tsx
@@ -11,13 +11,12 @@ import { useCollateralGroups, useTokens } from './hooks';
 import { TokenChainIcon } from './TokenChainIcon';
 import { TokenSelectionMode } from './types';
 import { useTokenPrices } from './useTokenPrice';
-import { checkTokenPairHasRoute, checkTokenPickerHasRoute, getTokenKey } from './utils';
-
-const featuredSet = new Set(config.featuredTokens.map((t) => t.toLowerCase()));
-
-function isFeaturedToken(token: Token): boolean {
-  return featuredSet.has(`${token.chainName}-${token.symbol}`.toLowerCase());
-}
+import {
+  checkTokenPairHasRoute,
+  checkTokenPickerHasRoute,
+  getDefaultTokens,
+  getTokenKey,
+} from './utils';
 
 function matchesSearch(
   token: Token,
@@ -74,12 +73,7 @@ export function TokenList({
 
   // Default token set: featured+routable when featured defined, all tokens otherwise
   const defaultTokens = useMemo(() => {
-    if (featuredSet.size === 0) return allTokens;
-    return allTokens.filter((t) => {
-      if (isFeaturedToken(t)) return true;
-      if (tokenRouteMap) return tokenRouteMap.get(getTokenKey(t)) ?? false;
-      return false;
-    });
+    return getDefaultTokens(allTokens, config.featuredTokens, tokenRouteMap);
   }, [allTokens, tokenRouteMap]);
 
   // Tokens to fetch balances for:
@@ -105,7 +99,7 @@ export function TokenList({
       (hasRoute ? routable : rest).push(t);
     }
 
-    if (featuredSet.size > 0) return [...routable, ...rest];
+    if (config.featuredTokens.length > 0) return [...routable, ...rest];
 
     const maxDefault = 50;
     const combined = [...routable, ...rest];
@@ -193,7 +187,7 @@ export function TokenList({
 
     // No filter: cap display at 50 only when no featured tokens
     const maxDisplay = 50;
-    const shouldCap = !hasFilter && featuredSet.size === 0;
+    const shouldCap = !hasFilter && config.featuredTokens.length === 0;
     const isLimited = shouldCap && sorted.length > maxDisplay;
     const displayTokens = isLimited ? sorted.slice(0, maxDisplay) : sorted;
 

--- a/src/features/tokens/TokenList.tsx
+++ b/src/features/tokens/TokenList.tsx
@@ -11,7 +11,7 @@ import { useCollateralGroups, useTokens } from './hooks';
 import { TokenChainIcon } from './TokenChainIcon';
 import { TokenSelectionMode } from './types';
 import { useTokenPrices } from './useTokenPrice';
-import { checkTokenPickerHasRoute, getTokenKey } from './utils';
+import { checkTokenPairHasRoute, checkTokenPickerHasRoute, getTokenKey } from './utils';
 
 const featuredSet = new Set(config.featuredTokens.map((t) => t.toLowerCase()));
 
@@ -67,6 +67,9 @@ export function TokenList({
 
   // Deferred state for route map - allows UI to render immediately
   const [tokenRouteMap, setTokenRouteMap] = useState<Map<string, boolean> | null>(null);
+  const [tokenPickerRouteMap, setTokenPickerRouteMap] = useState<Map<string, boolean> | null>(
+    null,
+  );
   const [, startTransition] = useTransition();
 
   // Default token set: featured+routable when featured defined, all tokens otherwise
@@ -206,16 +209,41 @@ export function TokenList({
     balanceMap,
   ]);
 
-  // In origin mode the result is counterpart-independent, so gate the
-  // effect on a masked counterpart to avoid rebuilding the route map when
-  // only the destination changes.
+  // Compute strict current-pair route map for default list gating and sorting.
+  useEffect(() => {
+    startTransition(() => {
+      if (!counterpartToken) {
+        setTokenRouteMap(null);
+        return;
+      }
+
+      const routeMap = new Map<string, boolean>();
+
+      for (const token of allTokens) {
+        const key = getTokenKey(token);
+        const hasRoute = checkTokenPairHasRoute(
+          token,
+          counterpartToken,
+          selectionMode,
+          collateralGroups,
+        );
+        routeMap.set(key, hasRoute);
+      }
+
+      setTokenRouteMap(routeMap);
+    });
+  }, [allTokens, counterpartToken, selectionMode, collateralGroups]);
+
+  // In origin mode the picker warning is counterpart-independent, so gate
+  // this effect on a masked counterpart to avoid rebuilding the display map
+  // when only the destination changes.
   const counterpartDep = selectionMode === 'destination' ? counterpartToken : null;
 
-  // Compute route map in a transition (non-blocking)
+  // Compute picker display route map in a transition (non-blocking)
   useEffect(() => {
     startTransition(() => {
       if (selectionMode === 'destination' && !counterpartToken) {
-        setTokenRouteMap(null);
+        setTokenPickerRouteMap(null);
         return;
       }
 
@@ -233,7 +261,7 @@ export function TokenList({
         routeMap.set(key, hasRoute);
       }
 
-      setTokenRouteMap(routeMap);
+      setTokenPickerRouteMap(routeMap);
     });
     // counterpartToken intentionally omitted: counterpartDep gates this effect.
     // INVARIANT: checkTokenPickerHasRoute MUST stay counterpart-independent in
@@ -266,7 +294,9 @@ export function TokenList({
         <div className="py-2 md:px-3">
           {tokens.map((token) => {
             const key = getTokenKey(token);
-            const hasRoute = tokenRouteMap ? (tokenRouteMap.get(key) ?? true) : true;
+            const hasRoute = tokenPickerRouteMap
+              ? (tokenPickerRouteMap.get(key) ?? true)
+              : true;
             const balance = balanceMap.get(key);
             const usdValue = usdMap.get(key) ?? null;
 

--- a/src/features/tokens/TokenList.tsx
+++ b/src/features/tokens/TokenList.tsx
@@ -236,6 +236,10 @@ export function TokenList({
       setTokenRouteMap(routeMap);
     });
     // counterpartToken intentionally omitted: counterpartDep gates this effect.
+    // INVARIANT: checkTokenPickerHasRoute MUST stay counterpart-independent in
+    // origin mode. If that ever changes (e.g. ranking biases on destination),
+    // drop the mask and put counterpartToken back in the deps array — otherwise
+    // tokenRouteMap will silently go stale.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allTokens, counterpartDep, selectionMode, collateralGroups]);
 

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -892,6 +892,28 @@ describe('checkTokenPickerHasRoute', () => {
     ).toBe(false);
   });
 
+  test('origin mode skips same-chain peers when checking routability', () => {
+    // Two tokens on the same chain, both with no cross-chain connections.
+    // The picker-level same-chain filter should reject the peer outright,
+    // not rely on checkTokenHasRoute for the rejection.
+    const origin = createMockToken({
+      chainName: TestChainName.test1,
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+      collateralAddressOrDenom: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    });
+    const sameChainPeer = createMockToken({
+      chainName: TestChainName.test1,
+      symbol: 'PEER',
+      addressOrDenom: '0x2222222222222222222222222222222222222222',
+      collateralAddressOrDenom: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    });
+    const groups = groupTokensByCollateral([origin, sameChainPeer]);
+
+    expect(checkTokenPickerHasRoute(origin, null, 'origin', [origin, sameChainPeer], groups)).toBe(
+      false,
+    );
+  });
+
   test('destination mode with a null counterpart returns false', () => {
     const token = createMockToken({
       chainName: TestChainName.test1,

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -853,9 +853,7 @@ describe('checkTokenPickerHasRoute', () => {
       currentDefaultDestination,
     ]);
 
-    expect(checkTokenPairHasRoute(origin, currentDefaultDestination, 'origin', groups)).toBe(
-      false,
-    );
+    expect(checkTokenPairHasRoute(origin, currentDefaultDestination, 'origin', groups)).toBe(false);
 
     expect(
       checkTokenPickerHasRoute(

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createMockToken, createTokenConnectionMock } from '../../utils/test';
 import {
   buildTokensArray,
+  checkTokenPickerHasRoute,
   checkTokenHasRoute,
   dedupeTokensByCollateral,
   findConnectedDestinationToken,
@@ -822,6 +823,69 @@ describe('checkTokenHasRoute', () => {
 
     const groups = groupTokensByCollateral([originDeduped, originWithRoute, dest]);
     expect(checkTokenHasRoute(originDeduped, dest, groups)).toBe(true);
+  });
+});
+
+describe('checkTokenPickerHasRoute', () => {
+  test('should not mark origin unavailable when another destination is routable', () => {
+    const routableDestination = createMockToken({
+      chainName: TestChainName.test2,
+      addressOrDenom: '0x2222222222222222222222222222222222222222',
+      collateralAddressOrDenom: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    });
+    const origin = createMockToken({
+      chainName: TestChainName.test1,
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+      collateralAddressOrDenom: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      connections: [createTokenConnectionMock(undefined, routableDestination)],
+    });
+    const currentDefaultDestination = createMockToken({
+      chainName: 'base',
+      symbol: 'USDC',
+      addressOrDenom: '0x3333333333333333333333333333333333333333',
+      collateralAddressOrDenom: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+    });
+    const groups = groupTokensByCollateral([origin, routableDestination, currentDefaultDestination]);
+
+    expect(
+      checkTokenPickerHasRoute(
+        origin,
+        currentDefaultDestination,
+        'origin',
+        [origin, routableDestination, currentDefaultDestination],
+        groups,
+      ),
+    ).toBe(true);
+  });
+
+  test('should keep destination selection strict to current origin', () => {
+    const origin = createMockToken({
+      chainName: TestChainName.test1,
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+      connections: [
+        createTokenConnectionMock(undefined, {
+          chainName: TestChainName.test2,
+          addressOrDenom: '0x2222222222222222222222222222222222222222',
+        }),
+      ],
+    });
+    const unsupportedDestination = createMockToken({
+      chainName: 'base',
+      symbol: 'USDC',
+      addressOrDenom: '0x3333333333333333333333333333333333333333',
+      collateralAddressOrDenom: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+    });
+    const groups = groupTokensByCollateral([origin, unsupportedDestination]);
+
+    expect(
+      checkTokenPickerHasRoute(
+        unsupportedDestination,
+        origin,
+        'destination',
+        [origin, unsupportedDestination],
+        groups,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -845,7 +845,11 @@ describe('checkTokenPickerHasRoute', () => {
       addressOrDenom: '0x3333333333333333333333333333333333333333',
       collateralAddressOrDenom: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
     });
-    const groups = groupTokensByCollateral([origin, routableDestination, currentDefaultDestination]);
+    const groups = groupTokensByCollateral([
+      origin,
+      routableDestination,
+      currentDefaultDestination,
+    ]);
 
     expect(
       checkTokenPickerHasRoute(
@@ -856,6 +860,36 @@ describe('checkTokenPickerHasRoute', () => {
         groups,
       ),
     ).toBe(true);
+  });
+
+  test('should mark origin unavailable when it has no routes to any listed destination', () => {
+    const isolatedOrigin = createMockToken({
+      chainName: TestChainName.test1,
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+      collateralAddressOrDenom: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    });
+    const otherListed = createMockToken({
+      chainName: TestChainName.test2,
+      addressOrDenom: '0x2222222222222222222222222222222222222222',
+      collateralAddressOrDenom: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    });
+    const counterpart = createMockToken({
+      chainName: 'base',
+      symbol: 'USDC',
+      addressOrDenom: '0x3333333333333333333333333333333333333333',
+      collateralAddressOrDenom: '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC',
+    });
+    const groups = groupTokensByCollateral([isolatedOrigin, otherListed, counterpart]);
+
+    expect(
+      checkTokenPickerHasRoute(
+        isolatedOrigin,
+        counterpart,
+        'origin',
+        [isolatedOrigin, otherListed, counterpart],
+        groups,
+      ),
+    ).toBe(false);
   });
 
   test('should keep destination selection strict to current origin', () => {

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -4,8 +4,8 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createMockToken, createTokenConnectionMock } from '../../utils/test';
 import {
   buildTokensArray,
-  checkTokenPickerHasRoute,
   checkTokenHasRoute,
+  checkTokenPickerHasRoute,
   dedupeTokensByCollateral,
   findConnectedDestinationToken,
   findRouteToken,
@@ -890,6 +890,39 @@ describe('checkTokenPickerHasRoute', () => {
         groups,
       ),
     ).toBe(false);
+  });
+
+  test('destination mode with a null counterpart returns false', () => {
+    const token = createMockToken({
+      chainName: TestChainName.test1,
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+    });
+    const groups = groupTokensByCollateral([token]);
+
+    expect(checkTokenPickerHasRoute(token, null, 'destination', [token], groups)).toBe(false);
+    expect(checkTokenPickerHasRoute(token, undefined, 'destination', [token], groups)).toBe(false);
+  });
+
+  test('origin mode resolves based on allTokens when counterpart is null', () => {
+    const routableDestination = createMockToken({
+      chainName: TestChainName.test2,
+      addressOrDenom: '0x2222222222222222222222222222222222222222',
+      collateralAddressOrDenom: '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    });
+    const origin = createMockToken({
+      chainName: TestChainName.test1,
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+      collateralAddressOrDenom: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      connections: [createTokenConnectionMock(undefined, routableDestination)],
+    });
+    const groups = groupTokensByCollateral([origin, routableDestination]);
+
+    expect(
+      checkTokenPickerHasRoute(origin, null, 'origin', [origin, routableDestination], groups),
+    ).toBe(true);
+    expect(
+      checkTokenPickerHasRoute(origin, undefined, 'origin', [origin, routableDestination], groups),
+    ).toBe(true);
   });
 
   test('should keep destination selection strict to current origin', () => {

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -10,6 +10,7 @@ import {
   dedupeTokensByCollateral,
   findConnectedDestinationToken,
   findRouteToken,
+  getDefaultTokens,
   getTokenKey,
   groupTokensByCollateral,
   isValidMultiCollateralToken,
@@ -980,6 +981,38 @@ describe('checkTokenPickerHasRoute', () => {
         groups,
       ),
     ).toBe(false);
+  });
+});
+
+describe('getDefaultTokens', () => {
+  test('should keep default list gated by featured tokens and strict current-pair routes', () => {
+    const featured = createMockToken({
+      chainName: 'ethereum',
+      symbol: 'USDC',
+      addressOrDenom: '0x1111111111111111111111111111111111111111',
+    });
+    const strictRoutable = createMockToken({
+      chainName: 'base',
+      symbol: 'USDC',
+      addressOrDenom: '0x2222222222222222222222222222222222222222',
+    });
+    const pickerOnlyRoutable = createMockToken({
+      chainName: 'fluent',
+      symbol: 'BLEND',
+      addressOrDenom: '0x3333333333333333333333333333333333333333',
+    });
+    const strictRouteMap = new Map([
+      [getTokenKey(strictRoutable), true],
+      [getTokenKey(pickerOnlyRoutable), false],
+    ]);
+
+    expect(
+      getDefaultTokens(
+        [featured, strictRoutable, pickerOnlyRoutable],
+        ['ethereum-USDC'],
+        strictRouteMap,
+      ),
+    ).toEqual([featured, strictRoutable]);
   });
 });
 

--- a/src/features/tokens/utils.test.ts
+++ b/src/features/tokens/utils.test.ts
@@ -5,6 +5,7 @@ import { createMockToken, createTokenConnectionMock } from '../../utils/test';
 import {
   buildTokensArray,
   checkTokenHasRoute,
+  checkTokenPairHasRoute,
   checkTokenPickerHasRoute,
   dedupeTokensByCollateral,
   findConnectedDestinationToken,
@@ -850,6 +851,10 @@ describe('checkTokenPickerHasRoute', () => {
       routableDestination,
       currentDefaultDestination,
     ]);
+
+    expect(checkTokenPairHasRoute(origin, currentDefaultDestination, 'origin', groups)).toBe(
+      false,
+    );
 
     expect(
       checkTokenPickerHasRoute(

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -316,6 +316,17 @@ export function checkTokenHasRoute(
   return originGroup.some((token) => Boolean(findConnectedDestinationToken(token, destToken)));
 }
 
+export function checkTokenPairHasRoute(
+  token: Token,
+  counterpartToken: Token,
+  selectionMode: TokenSelectionMode,
+  collateralGroups: Map<string, Token[]>,
+): boolean {
+  const originToken = selectionMode === 'origin' ? token : counterpartToken;
+  const destToken = selectionMode === 'origin' ? counterpartToken : token;
+  return checkTokenHasRoute(originToken, destToken, collateralGroups);
+}
+
 /**
  * Route availability as used by the token picker.
  *

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -321,21 +321,23 @@ export function checkTokenHasRoute(
  *
  * Destination selection is strict against the current origin. Origin selection can
  * auto-switch destination, so only mark an origin unavailable when it has no
- * route to any other listed token.
+ * route to any other listed token. In origin mode counterpartToken is unused and
+ * the result depends only on token + allTokens + collateralGroups.
  */
 export function checkTokenPickerHasRoute(
   token: Token,
-  counterpartToken: Token,
+  counterpartToken: Token | null | undefined,
   selectionMode: TokenSelectionMode,
   allTokens: Token[],
   collateralGroups: Map<string, Token[]>,
 ): boolean {
   if (selectionMode === 'destination') {
+    if (!counterpartToken) return false;
     return checkTokenHasRoute(counterpartToken, token, collateralGroups);
   }
 
-  if (checkTokenHasRoute(token, counterpartToken, collateralGroups)) return true;
-
+  // Only consider listed (non-disabled) destinations so a disabled counterpart
+  // can't surface a token as routable.
   return allTokens.some(
     (destinationToken) =>
       destinationToken.chainName !== token.chainName &&

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -178,6 +178,21 @@ export function getTokenKey(token: IToken): string {
   return key;
 }
 
+export function getDefaultTokens(
+  allTokens: Token[],
+  featuredTokens: string[],
+  tokenRouteMap: Map<string, boolean> | null,
+): Token[] {
+  if (featuredTokens.length === 0) return allTokens;
+
+  const featuredSet = new Set(featuredTokens.map((token) => token.toLowerCase()));
+  return allTokens.filter((token) => {
+    if (featuredSet.has(`${token.chainName}-${token.symbol}`.toLowerCase())) return true;
+    if (tokenRouteMap) return tokenRouteMap.get(getTokenKey(token)) ?? false;
+    return false;
+  });
+}
+
 /**
  * De-duplicate tokens by collateral address on the same chain
  * Returns only one token per unique collateral address per chain

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -323,6 +323,10 @@ export function checkTokenHasRoute(
  * auto-switch destination, so only mark an origin unavailable when it has no
  * route to any other listed token. In origin mode counterpartToken is unused and
  * the result depends only on token + allTokens + collateralGroups.
+ *
+ * Caller contract: `allTokens` is expected to already be filtered to listed
+ * (non-disabled) tokens. We iterate it as-is, so a disabled counterpart that
+ * isn't in this set can't surface a token as routable.
  */
 export function checkTokenPickerHasRoute(
   token: Token,
@@ -336,8 +340,6 @@ export function checkTokenPickerHasRoute(
     return checkTokenHasRoute(counterpartToken, token, collateralGroups);
   }
 
-  // Only consider listed (non-disabled) destinations so a disabled counterpart
-  // can't surface a token as routable.
   return allTokens.some(
     (destinationToken) =>
       destinationToken.chainName !== token.chainName &&

--- a/src/features/tokens/utils.ts
+++ b/src/features/tokens/utils.ts
@@ -7,7 +7,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 import { eqAddress, isNullish, normalizeAddress, objKeys } from '@hyperlane-xyz/utils';
 
-import { DefaultMultiCollateralRoutes } from './types';
+import { DefaultMultiCollateralRoutes, TokenSelectionMode } from './types';
 
 // Module-level caches for expensive key computations
 // WeakMap allows automatic garbage collection when token objects are no longer referenced
@@ -314,6 +314,33 @@ export function checkTokenHasRoute(
   // to the specific destination token. Uses findConnectedDestinationToken to stay
   // consistent with the transfer flow's matching logic (collateral key + address fallback).
   return originGroup.some((token) => Boolean(findConnectedDestinationToken(token, destToken)));
+}
+
+/**
+ * Route availability as used by the token picker.
+ *
+ * Destination selection is strict against the current origin. Origin selection can
+ * auto-switch destination, so only mark an origin unavailable when it has no
+ * route to any other listed token.
+ */
+export function checkTokenPickerHasRoute(
+  token: Token,
+  counterpartToken: Token,
+  selectionMode: TokenSelectionMode,
+  allTokens: Token[],
+  collateralGroups: Map<string, Token[]>,
+): boolean {
+  if (selectionMode === 'destination') {
+    return checkTokenHasRoute(counterpartToken, token, collateralGroups);
+  }
+
+  if (checkTokenHasRoute(token, counterpartToken, collateralGroups)) return true;
+
+  return allTokens.some(
+    (destinationToken) =>
+      destinationToken.chainName !== token.chainName &&
+      checkTokenHasRoute(token, destinationToken, collateralGroups),
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes route availability labeling in the token picker.

When selecting an origin token, the picker now treats a token as available if it can route to any listed destination, because origin selection can auto-switch the destination. Destination selection remains strict against the current origin.

## Root Cause

The picker reused strict current-pair route checking for both selection modes. That made routable tokens like Fluent BLEND/USDnr appear as "Route unavailable" when the current default destination was Base USDC, even though selecting those origin tokens can move the user onto a valid route.

## Validation

- `pnpm vitest src/features/tokens/utils.test.ts --run`
- `pnpm typecheck`
- `pnpm lint` (passes with existing no-console warnings outside this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the token picker's route-availability computation and React effect dependencies, which can affect which tokens appear selectable/disabled and how lists are sorted; main risk is UI logic regressions or stale route state.
> 
> **Overview**
> Fixes token picker route availability so **origin selection** marks a token routable if it can reach *any* listed destination (since the destination may auto-switch), while **destination selection** remains strict to the current origin.
> 
> This introduces `checkTokenPickerHasRoute`, `checkTokenPairHasRoute`, and `getDefaultTokens` in `utils.ts`, updates `TokenList` to maintain separate strict-vs-picker route maps (with a masked dependency to avoid unnecessary recomputation in origin mode), and adjusts the route-unavailable tooltip copy/layout. Adds targeted unit tests covering the new routability semantics and default-token gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c01e2a82f12f2c7bb57d8af7c04f5a1f4fb3fef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->