### PR TITLE
feat: add NEX/bsc to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -419,6 +419,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // paradex
   'DIME/paradex',
 
+  // NEX routes
+  'NEX/bsc',
+
   // rise
   'RISE/bsc-ethereum',
 


### PR DESCRIPTION
Adds \`NEX/bsc\` to the Nexus UI warp route whitelist.

| Field | Value |
| ----- | ----- |
| **Linear** | [AW-638](https://linear.app/hyperlane-xyz/issue/AW-638/nex-eth-collateral-bsc-synthetic) |
| **Warp route** | \`NEX/bsc\` |