### PR TITLE
feat(chains): add featured chain sort

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -37,6 +37,7 @@ interface Config {
   walletProtocols: ProtocolType[] | undefined; // Wallet Protocols to show in the wallet connect modal. Leave undefined to include all of them
   rpcOverrides: string; // JSON string containing a map of chain names to an object with an URL for RPC overrides (For an example check the .env.example file)
   enableTrackingEvents: boolean; // Allow tracking events to happen on some actions;
+  featuredChains: string[]; // Chains to pin at the top of the default chain picker sort
   featuredTokens: string[]; // List of featured tokens to prioritize in token picker (format: "chainName-symbol")
   feeQuotingUrl: string | undefined; // Offchain fee quoting service base URL
 }
@@ -70,6 +71,23 @@ export const config: Config = Object.freeze({
   rpcOverrides,
   enableTrackingEvents: false,
   feeQuotingUrl,
+  featuredChains: [
+    'ethereum',
+    'base',
+    'arbitrum',
+    'solanamainnet',
+    'optimism',
+    'bsc',
+    'polygon',
+    'avalanche',
+    'unichain',
+    'hyperevm',
+    'linea',
+    'worldchain',
+    'eclipsemainnet',
+    'ink',
+    'monad',
+  ],
   featuredTokens: [
     // USDC
     'arbitrum-USDC',

--- a/src/features/chains/chainFilterSort.test.ts
+++ b/src/features/chains/chainFilterSort.test.ts
@@ -110,8 +110,23 @@ describe('chainSearch', () => {
   });
 
   describe('sort', () => {
-    it('sorts by name ascending (default)', () => {
+    it('sorts featured chains first by default', () => {
       const result = search({});
+      const names = result.filter((c) => !c.disabled).map((c) => c.name);
+      expect(names).toEqual([
+        'ethereum',
+        'arbitrum',
+        'solanamainnet',
+        'polygon',
+        'cosmoshub',
+        'sepolia',
+      ]);
+    });
+
+    it('sorts by name ascending', () => {
+      const result = search({
+        sort: { sortBy: ChainSortBy.Name, sortOrder: SortOrder.Asc },
+      });
       const names = result.filter((c) => !c.disabled).map((c) => c.name);
       expect(names).toEqual([
         'arbitrum',

--- a/src/features/chains/chainFilterSort.ts
+++ b/src/features/chains/chainFilterSort.ts
@@ -1,9 +1,11 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
-import { ChainInfo } from './hooks';
+import { config } from '../../consts/config';
+import type { ChainInfo } from './hooks';
 
 // ── Sort ────────────────────────────────────────────────────────────
 export enum ChainSortBy {
+  Featured = 'featured',
   Name = 'name',
   ChainId = 'chain id',
   Protocol = 'protocol',
@@ -20,7 +22,7 @@ export interface SortState {
 }
 
 export const defaultSortState: SortState = {
-  sortBy: ChainSortBy.Name,
+  sortBy: ChainSortBy.Featured,
   sortOrder: SortOrder.Asc,
 };
 
@@ -44,7 +46,14 @@ export function isFilterActive(filter: ChainFilterState): boolean {
   return filter.type !== undefined || filter.protocol !== undefined;
 }
 
-export const sortOptions = [ChainSortBy.Name, ChainSortBy.ChainId, ChainSortBy.Protocol];
+export const sortOptions = [
+  ChainSortBy.Featured,
+  ChainSortBy.Name,
+  ChainSortBy.ChainId,
+  ChainSortBy.Protocol,
+];
+
+const featuredChainRank = new Map(config.featuredChains.map((chainName, i) => [chainName, i]));
 
 // ── Combined search + filter + sort (mirrors widgets' chainSearch) ──
 export function chainSearch({
@@ -85,6 +94,19 @@ export function chainSearch({
         // Disabled chains always at the bottom
         if (c1.disabled && !c2.disabled) return 1;
         if (!c1.disabled && c2.disabled) return -1;
+
+        if (sort.sortBy === ChainSortBy.Featured) {
+          const c1Rank = featuredChainRank.get(c1.name);
+          const c2Rank = featuredChainRank.get(c2.name);
+          const c1Featured = c1Rank !== undefined;
+          const c2Featured = c2Rank !== undefined;
+
+          if (c1Featured && c2Featured && c1Rank !== c2Rank) {
+            return sort.sortOrder === SortOrder.Asc ? c1Rank - c2Rank : c2Rank - c1Rank;
+          }
+          if (c1Featured && !c2Featured) return -1;
+          if (!c1Featured && c2Featured) return 1;
+        }
 
         if (sort.sortBy === ChainSortBy.ChainId) {
           const result = c1.chainId

--- a/src/features/chains/chainFilterSort.ts
+++ b/src/features/chains/chainFilterSort.ts
@@ -53,7 +53,16 @@ export const sortOptions = [
   ChainSortBy.Protocol,
 ];
 
-const featuredChainRank = new Map(config.featuredChains.map((chainName, i) => [chainName, i]));
+const featuredChainRank = new Map<string, number>();
+for (const [i, chainName] of config.featuredChains.entries()) {
+  const existingRank = featuredChainRank.get(chainName);
+  if (existingRank !== undefined) {
+    throw new Error(
+      `Duplicate featured chain in config.featuredChains: ${chainName} at indices ${existingRank} and ${i}`,
+    );
+  }
+  featuredChainRank.set(chainName, i);
+}
 
 // ── Combined search + filter + sort (mirrors widgets' chainSearch) ──
 export function chainSearch({

--- a/src/features/chains/chainFilterSort.ts
+++ b/src/features/chains/chainFilterSort.ts
@@ -101,7 +101,7 @@ export function chainSearch({
           const c1Featured = c1Rank !== undefined;
           const c2Featured = c2Rank !== undefined;
 
-          if (c1Featured && c2Featured && c1Rank !== c2Rank) {
+          if (c1Featured && c2Featured) {
             return sort.sortOrder === SortOrder.Asc ? c1Rank - c2Rank : c2Rank - c1Rank;
           }
           if (c1Featured && !c2Featured) return -1;


### PR DESCRIPTION
## Summary
- Add a hard-coded `featuredChains` config list.
- Make the chain picker default sort show featured chains first, then alphabetical.
- Keep explicit name/chain id/protocol sort options available.

## Validation
- `pnpm vitest --watch false src/features/chains/chainFilterSort.test.ts`
- `pnpm typecheck`
- `pnpm lint` (3 existing no-console warnings)