### PR TITLE
feat: featured-chain default sort in chain picker

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -38,6 +38,7 @@ interface Config {
   rpcOverrides: string; // JSON string containing a map of chain names to an object with an URL for RPC overrides (For an example check the .env.example file)
   enableTrackingEvents: boolean; // Allow tracking events to happen on some actions;
   featuredTokens: string[]; // List of featured tokens to prioritize in token picker (format: "chainName-symbol")
+  featuredChains: string[]; // List of featured chain names shown first (in this order) when sorting by "featured"
   feeQuotingUrl: string | undefined; // Offchain fee quoting service base URL
 }
 
@@ -129,5 +130,27 @@ export const config: Config = Object.freeze({
     // stHYPER
     'bsc-stHYPER',
     'ethereum-stHYPER',
+  ],
+  featuredChains: [
+    'ethereum',
+    'solanamainnet',
+    'base',
+    'arbitrum',
+    'optimism',
+    'hyperevm',
+    'bsc',
+    'polygon',
+    'avalanche',
+    'eclipsemainnet',
+    'unichain',
+    'linea',
+    'monad',
+    'ink',
+    'worldchain',
+    'starknet',
+    'radix',
+    'aleo',
+    'sonicsvm',
+    'matchain',
   ],
 });

--- a/src/features/chains/chainFilterSort.test.ts
+++ b/src/features/chains/chainFilterSort.test.ts
@@ -110,8 +110,10 @@ describe('chainSearch', () => {
   });
 
   describe('sort', () => {
-    it('sorts by name ascending (default)', () => {
-      const result = search({});
+    it('sorts by name ascending', () => {
+      const result = search({
+        sort: { sortBy: ChainSortBy.Name, sortOrder: SortOrder.Asc },
+      });
       const names = result.filter((c) => !c.disabled).map((c) => c.name);
       expect(names).toEqual([
         'arbitrum',
@@ -121,6 +123,57 @@ describe('chainSearch', () => {
         'sepolia',
         'solanamainnet',
       ]);
+    });
+
+    describe('sort featured', () => {
+      it('sorts featured chains first in config order by default', () => {
+        const result = search({});
+        const names = result.filter((c) => !c.disabled).map((c) => c.name);
+
+        expect(names).toEqual([
+          'ethereum',
+          'solanamainnet',
+          'arbitrum',
+          'polygon',
+          'cosmoshub',
+          'sepolia',
+        ]);
+      });
+
+      it('sorts non-featured chains alphabetically after featured chains', () => {
+        const result = search({
+          sort: { sortBy: ChainSortBy.Featured, sortOrder: SortOrder.Asc },
+        });
+        const names = result.filter((c) => !c.disabled).map((c) => c.name);
+
+        expect(names.slice(4)).toEqual(['cosmoshub', 'sepolia']);
+      });
+
+      it('sorts disabled chains to the bottom when sorting featured', () => {
+        const result = search({
+          sort: { sortBy: ChainSortBy.Featured, sortOrder: SortOrder.Asc },
+        });
+        const lastChain = result[result.length - 1];
+
+        expect(lastChain.disabled).toBe(true);
+        expect(lastChain.name).toBe('disabled-chain');
+      });
+
+      it('reverses featured sorting for descending order', () => {
+        const result = search({
+          sort: { sortBy: ChainSortBy.Featured, sortOrder: SortOrder.Desc },
+        });
+        const names = result.filter((c) => !c.disabled).map((c) => c.name);
+
+        expect(names).toEqual([
+          'sepolia',
+          'cosmoshub',
+          'polygon',
+          'arbitrum',
+          'solanamainnet',
+          'ethereum',
+        ]);
+      });
     });
 
     it('sorts by name descending', () => {

--- a/src/features/chains/chainFilterSort.ts
+++ b/src/features/chains/chainFilterSort.ts
@@ -1,9 +1,11 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 
+import { config } from '../../consts/config';
 import { ChainInfo } from './hooks';
 
 // ── Sort ────────────────────────────────────────────────────────────
 export enum ChainSortBy {
+  Featured = 'featured',
   Name = 'name',
   ChainId = 'chain id',
   Protocol = 'protocol',
@@ -19,8 +21,10 @@ export interface SortState {
   sortOrder: SortOrder;
 }
 
+const featuredChainOrder = new Map(config.featuredChains.map((name, i) => [name, i]));
+
 export const defaultSortState: SortState = {
-  sortBy: ChainSortBy.Name,
+  sortBy: ChainSortBy.Featured,
   sortOrder: SortOrder.Asc,
 };
 
@@ -44,7 +48,12 @@ export function isFilterActive(filter: ChainFilterState): boolean {
   return filter.type !== undefined || filter.protocol !== undefined;
 }
 
-export const sortOptions = [ChainSortBy.Name, ChainSortBy.ChainId, ChainSortBy.Protocol];
+export const sortOptions = [
+  ChainSortBy.Featured,
+  ChainSortBy.Name,
+  ChainSortBy.ChainId,
+  ChainSortBy.Protocol,
+];
 
 // ── Combined search + filter + sort (mirrors widgets' chainSearch) ──
 export function chainSearch({
@@ -85,6 +94,24 @@ export function chainSearch({
         // Disabled chains always at the bottom
         if (c1.disabled && !c2.disabled) return 1;
         if (!c1.disabled && c2.disabled) return -1;
+
+        if (sort.sortBy === ChainSortBy.Featured) {
+          const featuredIndex1 = featuredChainOrder.get(c1.name);
+          const featuredIndex2 = featuredChainOrder.get(c2.name);
+
+          let result = 0;
+          if (featuredIndex1 !== undefined && featuredIndex2 !== undefined) {
+            result = featuredIndex1 - featuredIndex2;
+          } else if (featuredIndex1 !== undefined) {
+            result = -1;
+          } else if (featuredIndex2 !== undefined) {
+            result = 1;
+          } else {
+            result = c1.name.localeCompare(c2.name);
+          }
+
+          return sort.sortOrder === SortOrder.Asc ? result : -result;
+        }
 
         if (sort.sortBy === ChainSortBy.ChainId) {
           const result = c1.chainId


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch the chain picker default sort from alphabetical to featured-first ordering
- add a simple hardcoded `featuredChains` config list, mirroring the existing featured tokens pattern
- keep existing sort modes while adding a new `Featured` option

## Motivation
Nam Chu Hoai noted that alphabetical ordering ranks chains like `ancient8` too high in the picker. This change promotes a curated set of mainstream chains first, then leaves the remaining chains alphabetical.

## Notes
- the featured chain list is intentionally simple and hardcoded for now
- the ordering can be tweaked later without changing the sorting logic

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d89b920-e0c1-4d00-8896-fff1991483b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d89b920-e0c1-4d00-8896-fff1991483b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

