### PR TITLE
chore: resume Krown routes

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -381,12 +381,12 @@ export const warpRouteWhitelist: Array<string> | null = [
   'WETH/carrchain',
 
   // Krown routes
-  // 'ETH/krown',
-  // 'USDC/krown',
-  // 'USDT/krown',
-  // 'BNB/krown',
-  // 'WBTC/krown',
-  // 'KROWN/krown',
+  'ETH/krown',
+  'USDC/krown',
+  'USDT/krown',
+  'BNB/krown',
+  'WBTC/krown',
+  'KROWN/krown',
 
   // ENI routes
   'ETH/eni',


### PR DESCRIPTION
## Summary
- Re-enabled Krown routes in the warp route whitelist.

## Testing
- pnpm vitest src/consts/warpRouteWhitelist.test.ts
- Local test message: https://explorer.hyperlane.xyz/message/0x19b35776c8cbd1b78e6d4623332dc9f65d7ee4cbf3f4f8e68e9c69b3b2e82ed0