### PR TITLE
feat: add CROSS/moonpay to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -428,6 +428,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // fluent
   'BLEND/fluent',
   'USDnr/usdnr',
+
+  // CROSS routes
+  'CROSS/moonpay',
 ];
 
 /**


### PR DESCRIPTION
Adds `CROSS/moonpay` to the Nexus UI warp route whitelist.

| Field | Value |
| ----- | ----- |
| **Warp route** | `CROSS/moonpay` |