### PR TITLE
chore: migrate to pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: |
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -72,9 +72,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -100,9 +100,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -134,9 +134,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -162,9 +162,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -100,7 +100,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -162,7 +162,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.github/workflows/e2e-wallet-full.yml
+++ b/.github/workflows/e2e-wallet-full.yml
@@ -37,9 +37,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.github/workflows/e2e-wallet-full.yml
+++ b/.github/workflows/e2e-wallet-full.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,9 +26,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -72,9 +72,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-pnpm-11-store-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,7 +47,7 @@ jobs:
           NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_ID }}
 
   e2e:
-    timeout-minutes: 10
+    timeout-minutes: 20
     needs: [build]
     if: ${{ !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('package.json', '**/pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-11-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-11-store-
 
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'package.json', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.github/workflows/update-hyperlane-deps.yml
+++ b/.github/workflows/update-hyperlane-deps.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
 
       - name: Get latest SDK, Utils, Registry, and Widgets versions
         id: get-versions

--- a/package.json
+++ b/package.json
@@ -126,33 +126,5 @@
   "engines": {
     "node": ">=24"
   },
-  "packageManager": "pnpm@10.25.0",
-  "pnpm": {
-    "overrides": {
-      "tronweb>ethers": "^6.13.5",
-      "@solana/web3.js": "^1.95.4",
-      "axios": "^1.7.9",
-      "bignumber": "9.1.2",
-      "bn.js": "^5.2",
-      "cosmjs-types": "0.9",
-      "ethers": "^5.8.0",
-      "globals": "^14.0.0",
-      "lit-html": "2.8.0",
-      "react-fast-compare": "^3.2",
-      "viem": "^2.21.41",
-      "zustand": "^4.4",
-      "sha.js": "2.4.12",
-      "cipher-base": "1.0.5",
-      "elliptic": "6.6.1",
-      "pbkdf2": "3.1.3",
-      "form-data": "4.0.4",
-      "@ledgerhq/errors": "6.31.0"
-    },
-    "patchedDependencies": {
-      "starknetkit@2.6.1": "patches/starknetkit@2.6.1.patch",
-      "@provablehq/wasm@0.9.18": "patches/@provablehq__wasm@0.9.18.patch",
-      "@provablehq/sdk@0.9.15": "patches/@provablehq__sdk@0.9.15.patch"
-    },
-    "onlyBuiltDependencies": []
-  }
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,15 +25,9 @@ overrides:
   '@ledgerhq/errors': 6.31.0
 
 patchedDependencies:
-  '@provablehq/sdk@0.9.15':
-    hash: c3b67b6e17970e4e71124b375f996bb58f69b19e6deba7d2dd82a7809373358b
-    path: patches/@provablehq__sdk@0.9.15.patch
-  '@provablehq/wasm@0.9.18':
-    hash: 9af61d89e033cd3d4a4659b1412e680fe485647bc975037fd7ac764298eb5ca8
-    path: patches/@provablehq__wasm@0.9.18.patch
-  starknetkit@2.6.1:
-    hash: d8d81d77fa623989f021747f735ecef191f7ef8744e03c5f475cc1e9314d79d7
-    path: patches/starknetkit@2.6.1.patch
+  '@provablehq/sdk@0.9.15': c3b67b6e17970e4e71124b375f996bb58f69b19e6deba7d2dd82a7809373358b
+  '@provablehq/wasm@0.9.18': 9af61d89e033cd3d4a4659b1412e680fe485647bc975037fd7ac764298eb5ca8
+  starknetkit@2.6.1: d8d81d77fa623989f021747f735ecef191f7ef8744e03c5f475cc1e9314d79d7
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,15 @@ patchedDependencies:
   starknetkit@2.6.1: patches/starknetkit@2.6.1.patch
   '@provablehq/wasm@0.9.18': patches/@provablehq__wasm@0.9.18.patch
   '@provablehq/sdk@0.9.15': patches/@provablehq__sdk@0.9.15.patch
+allowBuilds:
+  '@sentry/cli': false
+  bigint-buffer: false
+  bufferutil: false
+  core-js: false
+  esbuild: false
+  keccak: false
+  protobufjs: false
+  secp256k1: false
+  sharp: false
+  tiny-secp256k1: false
+  utf-8-validate: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,26 @@
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@hyperlane-xyz/*'
+overrides:
+  tronweb>ethers: ^6.13.5
+  '@solana/web3.js': ^1.95.4
+  axios: ^1.7.9
+  bignumber: 9.1.2
+  bn.js: ^5.2
+  cosmjs-types: '0.9'
+  ethers: ^5.8.0
+  globals: ^14.0.0
+  lit-html: 2.8.0
+  react-fast-compare: ^3.2
+  viem: ^2.21.41
+  zustand: ^4.4
+  sha.js: 2.4.12
+  cipher-base: 1.0.5
+  elliptic: 6.6.1
+  pbkdf2: 3.1.3
+  form-data: 4.0.4
+  '@ledgerhq/errors': 6.31.0
+patchedDependencies:
+  starknetkit@2.6.1: patches/starknetkit@2.6.1.patch
+  '@provablehq/wasm@0.9.18': patches/@provablehq__wasm@0.9.18.patch
+  '@provablehq/sdk@0.9.15': patches/@provablehq__sdk@0.9.15.patch

--- a/tests/chain-selection/sort-chains.spec.ts
+++ b/tests/chain-selection/sort-chains.spec.ts
@@ -10,10 +10,11 @@ test.describe('Chain Selection - Sort Chains', () => {
     await expect(page.getByText('Select Token')).toBeVisible();
 
     // Open sort dropdown
-    await page.getByRole('button', { name: 'Sort: Name (asc)' }).click();
+    await page.getByRole('button', { name: 'Sort: Featured (asc)' }).click();
 
     // Should show sort options
     await expect(page.getByText('Sort by')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Featured', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Name', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Chain Id', exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Protocol', exact: true })).toBeVisible();
@@ -26,12 +27,12 @@ test.describe('Chain Selection - Sort Chains', () => {
 
     await getOriginTokenButton(page).click();
 
-    // Get first chain in default (Name asc) sort
+    // Get first chain in default (Featured asc) sort
     const chainButtons = page.locator('button[class*="border-l-2"]');
     const firstChainDefault = await chainButtons.nth(1).textContent();
 
     // Switch to Chain Id sort
-    await page.getByRole('button', { name: 'Sort: Name (asc)' }).click();
+    await page.getByRole('button', { name: 'Sort: Featured (asc)' }).click();
     await page.getByRole('button', { name: 'Chain Id', exact: true }).click();
 
     // First chain should be different after sorting by Chain Id
@@ -45,10 +46,14 @@ test.describe('Chain Selection - Sort Chains', () => {
 
     await getOriginTokenButton(page).click();
 
-    // Default sort is Name (asc) - first chain should start with 'A'
     const chainButtons = page.locator('button[class*="border-l-2"]');
-    const firstChainBefore = chainButtons.nth(1); // nth(0) is "All Chains"
-    await expect(firstChainBefore).toContainText(/^[A-B]/);
+
+    // Switch from default Featured sort to Name asc.
+    await page.getByRole('button', { name: 'Sort: Featured (asc)' }).click();
+    await page.getByRole('button', { name: 'Name', exact: true }).click();
+
+    // Name asc first chain should start with 'A' or 'B'.
+    await expect(chainButtons.nth(1)).toContainText(/^[A-B]/);
 
     // Open sort and toggle order to desc
     await page.getByRole('button', { name: 'Sort: Name (asc)' }).click();


### PR DESCRIPTION
## Summary
- Bumped the repo package manager pin to pnpm 11.1.3.
- Moved pnpm overrides and patched dependency config from `package.json#pnpm` into `pnpm-workspace.yaml` for pnpm 11.
- Refreshed lockfile metadata with pnpm 11.1.3.

## Validation
- `pnpm@11.1.3 install --lockfile-only --ignore-scripts`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm install --frozen-lockfile`
- `git diff --check`