### PR TITLE
chore: remove ctUSD/citrea from Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -413,9 +413,6 @@ export const warpRouteWhitelist: Array<string> | null = [
   'SOL/aleo',
   'WBTC/aleo',
 
-  // citrea
-  'ctUSD/citrea',
-
   // paradex
   'DIME/paradex',
 


### PR DESCRIPTION
## Summary
- Removes `ctUSD/citrea` from the Nexus warp route whitelist (`src/consts/warpRouteWhitelist.ts`).
- Rationale: Moonpay is migrating liquidity from the ctUSD/Citrea route to the new CROSS/moonpay route (added in #1102), so the ctUSD/Citrea route is being wound down in the Nexus UI.
- Requested by @nambrot.

## Test plan
- [ ] Verify ctUSD/citrea no longer appears in the Nexus UI route list after deploy.