### PR TITLE
fix: fixed logic merging warp core config assuming eveything is an array

### DIFF
--- a/src/features/warpCore/warpCoreConfig.test.ts
+++ b/src/features/warpCore/warpCoreConfig.test.ts
@@ -1,7 +1,13 @@
-import { TokenStandard } from '@hyperlane-xyz/sdk';
+import { TokenStandard, WarpCoreConfig } from '@hyperlane-xyz/sdk';
 import { describe, expect, test } from 'vitest';
 
-import { dedupeTokens, NullableAddressWarpCoreToken } from './warpCoreConfig';
+import { dedupeTokens, NullableAddressWarpCoreToken, reduceOptions } from './warpCoreConfig';
+
+// The WarpCoreConfig['options'] schema currently only declares array-valued fields,
+// but reduceOptions handles arbitrary keys (registry/yaml/store configs may add their own).
+// Cast the looser test shapes through unknown to exercise all three branches.
+type Options = WarpCoreConfig['options'];
+const opts = (o: Record<string, unknown>): Options => o as unknown as Options;
 
 const makeToken = (
   overrides: Partial<NullableAddressWarpCoreToken>,
@@ -175,5 +181,69 @@ describe('dedupeTokens', () => {
     const result = dedupeTokens([ibc, ibcDup, wm, usdsc]);
     // IBC merged to 1, wM + USDSC stay as 2 → 3 total
     expect(result).toHaveLength(3);
+  });
+});
+
+describe('reduceOptions', () => {
+  test('concatenates array-valued options across configs', () => {
+    const a = opts({
+      interchainFeeConstants: [{ origin: 'ethereum', destination: 'arbitrum', amount: 1n }],
+    });
+    const b = opts({
+      interchainFeeConstants: [{ origin: 'arbitrum', destination: 'ethereum', amount: 2n }],
+    });
+
+    const result = reduceOptions([a, b]) as any;
+    expect(result.interchainFeeConstants).toHaveLength(2);
+    expect(result.interchainFeeConstants[0].origin).toBe('ethereum');
+    expect(result.interchainFeeConstants[1].origin).toBe('arbitrum');
+  });
+
+  test('deep-merges object-valued options last-wins (does not clobber nested keys)', () => {
+    const a = opts({ sealevel: { altAddresses: { eclipsemainnet: '0xAAA' } } });
+    const b = opts({ sealevel: { altAddresses: { solanamainnet: '0xBBB' } } });
+
+    const result = reduceOptions([a, b]) as any;
+    expect(result.sealevel.altAddresses).toEqual({
+      eclipsemainnet: '0xAAA',
+      solanamainnet: '0xBBB',
+    });
+  });
+
+  test('last-write wins for scalar option values', () => {
+    const a = opts({ relayerUrl: 'https://first.example' });
+    const b = opts({ relayerUrl: 'https://second.example' });
+
+    const result = reduceOptions([a, b]) as any;
+    expect(result.relayerUrl).toBe('https://second.example');
+  });
+
+  test('handles inconsistent shapes across configs without throwing', () => {
+    // First config writes an array; second writes an object at the same key.
+    // The object branch should not spread the array as {0: ..., 1: ...}.
+    const a = opts({ feature: [1, 2] });
+    const b = opts({ feature: { enabled: true } });
+
+    const result = reduceOptions([a, b]) as any;
+    expect(result.feature).toEqual({ enabled: true });
+  });
+
+  test('ignores nullish incoming scalars instead of overwriting prior value', () => {
+    const a = opts({ relayerUrl: 'https://first.example' });
+    const b = opts({ relayerUrl: null });
+
+    const result = reduceOptions([a, b]) as any;
+    expect(result.relayerUrl).toBe('https://first.example');
+  });
+
+  test('returns empty options object when given empty list', () => {
+    expect(reduceOptions([])).toEqual({});
+  });
+
+  test('skips undefined entries in the options list', () => {
+    const a = opts({ interchainFeeConstants: [{ origin: 'a', destination: 'b', amount: 1n }] });
+
+    const result = reduceOptions([a, undefined]) as any;
+    expect(result.interchainFeeConstants).toHaveLength(1);
   });
 });

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -10,7 +10,7 @@ import {
   getTokenConnectionId,
   validateZodResult,
 } from '@hyperlane-xyz/sdk';
-import { isObjEmpty, objFilter, objMerge } from '@hyperlane-xyz/utils';
+import { isNullish, isObjEmpty, objFilter, objMerge } from '@hyperlane-xyz/utils';
 
 import { config } from '../../consts/config.ts';
 import { warpRouteConfigs as tsWarpRoutes } from '../../consts/warpRoutes.ts';
@@ -208,7 +208,9 @@ export function dedupeTokens(
 }
 
 // Combine a list of WarpCore option objects into one single options object
-function reduceOptions(optionsList: Array<WarpCoreConfig['options']>): WarpCoreConfig['options'] {
+export function reduceOptions(
+  optionsList: Array<WarpCoreConfig['options']>,
+): WarpCoreConfig['options'] {
   return optionsList.reduce<WarpCoreConfig['options']>((acc, o) => {
     if (!o || !acc) return acc;
     for (const key of Object.keys(o)) {
@@ -219,8 +221,11 @@ function reduceOptions(optionsList: Array<WarpCoreConfig['options']>): WarpCoreC
       if (Array.isArray(incoming)) {
         acc[key] = (Array.isArray(current) ? current : []).concat(incoming);
       } else if (incoming && typeof incoming === 'object') {
-        acc[key] = { ...(current && typeof current === 'object' ? current : {}), ...incoming };
-      } else if (incoming !== undefined) {
+        acc[key] = objMerge(
+          current && typeof current === 'object' && !Array.isArray(current) ? current : {},
+          incoming,
+        );
+      } else if (!isNullish(incoming)) {
         acc[key] = incoming;
       }
     }

--- a/src/features/warpCore/warpCoreConfig.ts
+++ b/src/features/warpCore/warpCoreConfig.ts
@@ -212,7 +212,17 @@ function reduceOptions(optionsList: Array<WarpCoreConfig['options']>): WarpCoreC
   return optionsList.reduce<WarpCoreConfig['options']>((acc, o) => {
     if (!o || !acc) return acc;
     for (const key of Object.keys(o)) {
-      acc[key] = (acc[key] || []).concat(o[key] || []);
+      const incoming = o[key];
+      const current = acc[key];
+      // Array-valued options (e.g., interchainFeeConstants) concatenate;
+      // object-valued options (e.g., sealevel.altAddresses) deep-merge last-wins.
+      if (Array.isArray(incoming)) {
+        acc[key] = (Array.isArray(current) ? current : []).concat(incoming);
+      } else if (incoming && typeof incoming === 'object') {
+        acc[key] = { ...(current && typeof current === 'object' ? current : {}), ...incoming };
+      } else if (incoming !== undefined) {
+        acc[key] = incoming;
+      }
     }
     return acc;
   }, {});


### PR DESCRIPTION
## Summary

  Fixes a bug in `reduceOptions` (`src/features/warpCore/warpCoreConfig.ts`) where every
  non-primitive value in `WarpCoreConfig.options` was assumed to be an array and merged via
  `.concat()`. If a config supplied an object-valued option (e.g. a forward-looking
  `sealevel.altAddresses`), `(acc[key] || []).concat(o[key])` produced an array wrapping the
  object instead of merging it, breaking downstream consumers.

  ## What changed

  Type-aware merge across the three value shapes that can appear under an options key:

  - **Array** → concatenate (preserves prior behavior for `interchainFeeConstants`,
  `localFeeConstants`, `routeBlacklist`)
  - **Object** → deep-merge last-wins via `objMerge` from `@hyperlane-xyz/utils` (already
  used elsewhere in the file)
  - **Scalar** → last-write-wins, skipping nullish incoming values via `isNullish` so a later
   `null` doesn't clobber an earlier real value

  Also guards `!Array.isArray(current)` on the object branch so a prior array isn't spread as
   `{0: ..., 1: ...}` if a later config writes an object under the same key.

  ## Tests

  Added table-style tests for `reduceOptions` covering:
  - array concat across configs
  - object deep-merge (nested keys preserved last-wins)
  - scalar overwrite
  - inconsistent-shape across configs (array then object)
  - nullish incoming scalar ignored
  - empty list and undefined entries