### PR TITLE
fix: await ICoreAdapter.extractMessageIds in preparation for async SDK change

### DIFF
--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -267,7 +267,7 @@ async function executeTransfer({
     }
 
     const msgId = txReceipt
-      ? tryGetMsgIdFromTransferReceipt(multiProvider, origin, txReceipt)
+      ? await tryGetMsgIdFromTransferReceipt(multiProvider, origin, txReceipt)
       : undefined;
 
     const originTxHash = hashes.at(-1);

--- a/src/features/transfer/utils.ts
+++ b/src/features/transfer/utils.ts
@@ -83,7 +83,7 @@ export function getIconByTransferStatus(status: TransferStatus) {
   }
 }
 
-export function tryGetMsgIdFromTransferReceipt(
+export async function tryGetMsgIdFromTransferReceipt(
   multiProvider: MultiProvider,
   origin: ChainName,
   receipt: TypedTransactionReceipt,
@@ -121,7 +121,7 @@ export function tryGetMsgIdFromTransferReceipt(
         return acc;
       }, {});
     const core = new MultiProtocolCore(multiProvider, addressStubs);
-    const messages = core.extractMessageIds(origin, receipt);
+    const messages = await core.extractMessageIds(origin, receipt);
     if (messages.length) {
       const msgId = messages[0].messageId;
       logger.debug('Message id found in logs', msgId);


### PR DESCRIPTION
## Summary

Precautionary change to `await` `ICoreAdapter.extractMessageIds` before it becomes async in the SDK.

- `tryGetMsgIdFromTransferReceipt` made `async`
- `core.extractMessageIds(...)` call awaited
- Caller in `executeTransfer` updated to `await tryGetMsgIdFromTransferReceipt`

`await` on a non-Promise is a no-op, so this is safe today and won't break once hyperlane-xyz/hyperlane-monorepo#8767 is released.

## Test plan
- [ ] Existing transfer flow works as expected
- [ ] Message ID is still correctly extracted from transfer receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)