### PR TITLE
fix: prevent stale transfer data flash in details modal

### DIFF
--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -40,7 +40,6 @@ export function SideBarMenu({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const prevTransfersLengthRef = useRef(transfers.length);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -54,6 +53,8 @@ export function SideBarMenu({
     originChainName: s.originChainName,
     routerAddressesByChainMap: s.routerAddressesByChainMap,
   }));
+
+  const prevTransfersLengthRef = useRef(transfers.length);
 
   // Get all connected wallet addresses (normalized for consistent matching)
   const { accounts } = useAccounts(multiProvider, config.addressBlacklist);

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -41,6 +41,7 @@ export function SideBarMenu({
   onClose: () => void;
 }) {
   const didMountRef = useRef(false);
+  const prevTransfersLengthRef = useRef(0);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -49,14 +50,11 @@ export function SideBarMenu({
 
   const multiProvider = useMultiProvider();
 
-  const { transfers, transferLoading, originChainName, routerAddressesByChainMap } = useStore(
-    (s) => ({
-      transfers: s.transfers,
-      transferLoading: s.transferLoading,
-      originChainName: s.originChainName,
-      routerAddressesByChainMap: s.routerAddressesByChainMap,
-    }),
-  );
+  const { transfers, originChainName, routerAddressesByChainMap } = useStore((s) => ({
+    transfers: s.transfers,
+    originChainName: s.originChainName,
+    routerAddressesByChainMap: s.routerAddressesByChainMap,
+  }));
 
   // Get all connected wallet addresses (normalized for consistent matching)
   const { accounts } = useAccounts(multiProvider, config.addressBlacklist);
@@ -132,15 +130,22 @@ export function SideBarMenu({
     setIsModalOpen(true);
   };
 
-  // Open modal for new transfer
+  // Open modal when a new transfer is added (avoids showing stale data from the
+  // previous transfer, which would happen if we triggered on transferLoading
+  // because addTransfer is called after setTransferLoading(true)).
   useEffect(() => {
     if (!didMountRef.current) {
       didMountRef.current = true;
-    } else if (transferLoading) {
+      prevTransfersLengthRef.current = transfers.length;
+      return;
+    }
+    const prev = prevTransfersLengthRef.current;
+    prevTransfersLengthRef.current = transfers.length;
+    if (transfers.length > prev) {
       setSelectedTransfer(transfers[transfers.length - 1]);
       setIsModalOpen(true);
     }
-  }, [transfers, transferLoading]);
+  }, [transfers]);
 
   useEffect(() => {
     setIsMenuOpen(isOpen);

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -40,8 +40,7 @@ export function SideBarMenu({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const didMountRef = useRef(false);
-  const prevTransfersLengthRef = useRef(0);
+  const prevTransfersLengthRef = useRef(transfers.length);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -134,18 +133,14 @@ export function SideBarMenu({
   // previous transfer, which would happen if we triggered on transferLoading
   // because addTransfer is called after setTransferLoading(true)).
   useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true;
-      prevTransfersLengthRef.current = transfers.length;
-      return;
-    }
     const prev = prevTransfersLengthRef.current;
     prevTransfersLengthRef.current = transfers.length;
     if (transfers.length > prev) {
       setSelectedTransfer(transfers[transfers.length - 1]);
       setIsModalOpen(true);
     }
-  }, [transfers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- transfers.length increasing guarantees a new transfers ref; listing transfers would re-run on status updates
+  }, [transfers.length]);
 
   useEffect(() => {
     setIsMenuOpen(isOpen);

--- a/src/pages/embed.tsx
+++ b/src/pages/embed.tsx
@@ -58,13 +58,14 @@ function useAutoTransferModal() {
     if (transfers.length > prev) {
       const latestTransfer = transfers[transfers.length - 1];
       if (!latestTransfer) {
-        logger.error('Expected latest transfer on new transfer', transfers);
+        logger.error('Expected latest transfer to exist after transfers.length increased', transfers);
         return;
       }
       setSelectedTransfer(latestTransfer);
       setIsOpen(true);
     }
-  }, [transfers]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- transfers.length increasing guarantees a new transfers ref; listing transfers would re-run on status updates
+  }, [transfers.length]);
 
   const close = () => {
     setIsOpen(false);

--- a/src/pages/embed.tsx
+++ b/src/pages/embed.tsx
@@ -58,13 +58,16 @@ function useAutoTransferModal() {
     if (transfers.length > prev) {
       const latestTransfer = transfers[transfers.length - 1];
       if (!latestTransfer) {
-        logger.error('Expected latest transfer to exist after transfers.length increased', transfers);
+        logger.error(
+          'Expected latest transfer to exist after transfers.length increased',
+          transfers,
+        );
         return;
       }
       setSelectedTransfer(latestTransfer);
       setIsOpen(true);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- transfers.length increasing guarantees a new transfers ref; listing transfers would re-run on status updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- transfers.length increasing guarantees a new transfers ref; listing transfers would re-run on status updates
   }, [transfers.length]);
 
   const close = () => {

--- a/src/pages/embed.tsx
+++ b/src/pages/embed.tsx
@@ -48,26 +48,23 @@ function usePostMessageBridge() {
 /** Auto-opens TransfersDetailsModal when a new transfer starts. */
 function useAutoTransferModal() {
   const transfers = useStore((s) => s.transfers);
-  const transferLoading = useStore((s) => s.transferLoading);
   const [selectedTransfer, setSelectedTransfer] = useState<TransferContext | null>(null);
   const [isOpen, setIsOpen] = useState(false);
-  const didMountRef = useRef(false);
+  const prevTransfersLengthRef = useRef(transfers.length);
 
   useEffect(() => {
-    if (!didMountRef.current) {
-      didMountRef.current = true;
-      return;
-    } else if (transferLoading) {
+    const prev = prevTransfersLengthRef.current;
+    prevTransfersLengthRef.current = transfers.length;
+    if (transfers.length > prev) {
       const latestTransfer = transfers[transfers.length - 1];
       if (!latestTransfer) {
-        logger.error('Expected latest transfer while transferLoading is true', transfers);
+        logger.error('Expected latest transfer on new transfer', transfers);
         return;
       }
       setSelectedTransfer(latestTransfer);
       setIsOpen(true);
     }
-    // Same pattern as SideBarMenu — open modal when new transfer detected
-  }, [transfers, transferLoading]);
+  }, [transfers]);
 
   const close = () => {
     setIsOpen(false);


### PR DESCRIPTION
## Problem

When submitting a second transfer while the details modal is open (or being re-opened), the popup briefly flashes the **previous** transfer's sender address, origin tx hash, and message ID before switching to the new transfer's spinner.

**Root cause:** `setTransferLoading(true)` is called in `TransferTokenForm` *before* `addTransfer` runs (which happens later inside the async `triggerTransactions` call). The `useEffect` in both `SideBarMenu` and `useAutoTransferModal` (embed page) triggered on `transferLoading` changing to `true` — at that moment `transfers[last]` is still the previous completed transfer, so the modal opened with stale data.

## Solution

Trigger modal open on `transfers.length` increasing (i.e., when the new transfer is actually in the array) rather than on `transferLoading`. A `prevTransfersLengthRef` tracks the previous count so the effect only fires on genuine additions, not on mount (which would otherwise re-open the modal for persisted transfers from prior sessions).

Applied to both:
- `src/features/wallet/SideBarMenu.tsx`
- `src/pages/embed.tsx` (`useAutoTransferModal`)

## Test plan

- [ ] Submit a transfer, let the modal open and show final data (sender, origin tx, message ID)
- [ ] Submit a second transfer — modal should immediately show the spinner with no flash of the first transfer's data
- [ ] Refresh the page (persisted transfers in sidebar) — modal should not auto-open on load
- [ ] Embed page (`/embed`): same two checks above

🤖 Generated with [Claude Code](https://claude.com/claude-code)