### PR TITLE
fix: amount input background in dark review mode

### DIFF
--- a/src/components/input/TextField.tsx
+++ b/src/components/input/TextField.tsx
@@ -30,4 +30,4 @@ export const TextInput = forwardRef(function _TextInput(
 });
 
 const defaultClassName =
-  'rounded-lg border border-primary-300 focus:border-primary-500 disabled:bg-gray-150 outline-none transition-all duration-300';
+  'rounded-lg border border-primary-300 focus:border-primary-500 disabled:bg-gray-150 outline-none transition-all duration-300 dark:disabled:bg-background/40';

--- a/src/components/input/TextField.tsx
+++ b/src/components/input/TextField.tsx
@@ -30,4 +30,4 @@ export const TextInput = forwardRef(function _TextInput(
 });
 
 const defaultClassName =
-  'rounded-lg border border-primary-300 focus:border-primary-500 disabled:bg-gray-150 outline-none transition-all duration-300 dark:disabled:bg-background/40';
+  'rounded-lg border border-primary-300 focus:border-primary-500 disabled:bg-gray-150 outline-none transition-all duration-300';

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -306,7 +306,7 @@ function OriginTokenCard({
           <TextField
             name="amount"
             placeholder="0"
-            className="transfer-text-input w-full flex-1 border-none bg-transparent font-secondary text-xl font-normal text-gray-900 outline-none placeholder:text-gray-900 dark:text-foreground-primary dark:placeholder:text-foreground-secondary"
+            className="transfer-text-input w-full flex-1 border-none bg-transparent font-secondary text-xl font-normal text-gray-900 outline-none placeholder:text-gray-900 dark:text-foreground-primary dark:placeholder:text-foreground-secondary dark:disabled:bg-transparent"
             type="number"
             step="any"
             disabled={isReview}


### PR DESCRIPTION
## Summary
- keep the transfer amount input transparent when disabled in dark mode
- fixes the amount input turning white after entering review mode and returning to edit mode

## Root Cause
The shared `TextField` default class applies `disabled:bg-gray-150`. The transfer amount field is disabled while reviewing, so that light disabled background overrode the dark transfer-card styling.

## Validation
- `pnpm typecheck`
- `git diff --check`
