### PR TITLE
test: harden EVM e2e tests against CROSS-route dedup

### DIFF
--- a/tests/e2e-wallet/destination-router/evm.spec.ts
+++ b/tests/e2e-wallet/destination-router/evm.spec.ts
@@ -13,12 +13,26 @@ test.describe('EVM destination router selection', () => {
     await selectDestinationToken(page, destPattern);
     await enterAmount(page, '1');
     await clickContinue(page);
+    // Gate on the Send button — only renders when isReview=true (validate
+    // passed). The .transfer-review-panel element stays in DOM with max-h-0
+    // even when isReview=false, so reading its text directly would silently
+    // succeed on a validate failure.
+    await expect(page.getByRole('button', { name: /Send to /i })).toBeVisible({
+      timeout: 30_000,
+    });
+    // Then wait for fee quotes to settle — the panel renders a spinner while
+    // isLoading=true, and the Transfer Remote section only mounts afterwards.
     const reviewPanel = page.locator('.transfer-review-panel').first();
-    await expect(reviewPanel).toContainText(/Transfer Remote/i, { timeout: 30_000 });
+    await expect(reviewPanel).toContainText(/Remote Token/i, { timeout: 30_000 });
     const text = await reviewPanel.innerText();
     return text.split('Transfer Remote')[1]?.match(REMOTE_ADDRESS_RE)?.[0];
   }
 
+  // defaultBalance seeds the destination-collateral check in
+  // WarpCore.validateTransfer. Without it, balanceOf(warpRouter) returns 0
+  // for any USDC route on Base/Arbitrum and validate short-circuits with
+  // "Insufficient collateral on destination" before isReview can flip true.
+  const COLLATERAL_SEED = '0xffffffffffffffff';
   const rpcConfig = {
     chainUrlMap: [
       { chainId: 1, urlMatch: /ethereum\.|eth\.drpc/i },
@@ -26,8 +40,10 @@ test.describe('EVM destination router selection', () => {
       { chainId: 42161, urlMatch: /arb1\.arbitrum|arbitrum\.rpc/i },
     ],
     erc20: {
+      '*': { decimals: 6, defaultBalance: COLLATERAL_SEED },
       [`1:${USDC_ETHEREUM}`]: {
         decimals: 6,
+        defaultBalance: COLLATERAL_SEED,
         balances: { [MOCK_EVM_ADDRESS.toLowerCase()]: '0x3b9aca00' },
       },
     },

--- a/tests/e2e-wallet/destination-router/evm.spec.ts
+++ b/tests/e2e-wallet/destination-router/evm.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import { MOCK_EVM_ADDRESS } from '../helpers/constants';
-import { installEvmRpcMock } from '../helpers/evmRpc';
+import { installEvmRpcMock, ROUTER_COLLATERAL_SEED } from '../helpers/evmRpc';
 import { clickContinue, enterAmount, selectDestinationToken } from '../helpers/formFlow';
 import { openE2EApp, waitForWarpRuntime } from '../helpers/page-setup';
 
@@ -25,14 +25,9 @@ test.describe('EVM destination router selection', () => {
     const reviewPanel = page.locator('.transfer-review-panel').first();
     await expect(reviewPanel).toContainText(/Remote Token/i, { timeout: 30_000 });
     const text = await reviewPanel.innerText();
-    return text.split('Transfer Remote')[1]?.match(REMOTE_ADDRESS_RE)?.[0];
+    return text.split('Remote Token')[1]?.match(REMOTE_ADDRESS_RE)?.[0];
   }
 
-  // defaultBalance seeds the destination-collateral check in
-  // WarpCore.validateTransfer. Without it, balanceOf(warpRouter) returns 0
-  // for any USDC route on Base/Arbitrum and validate short-circuits with
-  // "Insufficient collateral on destination" before isReview can flip true.
-  const COLLATERAL_SEED = '0xffffffffffffffff';
   const rpcConfig = {
     chainUrlMap: [
       { chainId: 1, urlMatch: /ethereum\.|eth\.drpc/i },
@@ -40,10 +35,14 @@ test.describe('EVM destination router selection', () => {
       { chainId: 42161, urlMatch: /arb1\.arbitrum|arbitrum\.rpc/i },
     ],
     erc20: {
-      '*': { decimals: 6, defaultBalance: COLLATERAL_SEED },
+      '*': { decimals: 6, defaultBalance: ROUTER_COLLATERAL_SEED },
       [`1:${USDC_ETHEREUM}`]: {
         decimals: 6,
-        defaultBalance: COLLATERAL_SEED,
+        // Fixture lookup is first-match-wins, not a field merge (see
+        // handleEthCall: erc20[key] ?? erc20[to] ?? erc20['*']) — once this
+        // specific key resolves the '*' wildcard is ignored, so the seed
+        // must be repeated here for owners other than MOCK_EVM_ADDRESS.
+        defaultBalance: ROUTER_COLLATERAL_SEED,
         balances: { [MOCK_EVM_ADDRESS.toLowerCase()]: '0x3b9aca00' },
       },
     },

--- a/tests/e2e-wallet/helpers/evmRpc.ts
+++ b/tests/e2e-wallet/helpers/evmRpc.ts
@@ -8,6 +8,13 @@ const DEFAULT_GAS_PRICE = '0x3b9aca00'; // 1 gwei
 const DEFAULT_BLOCK_HEX = '0x12345';
 const MAX_UINT256 = '0x' + 'f'.repeat(64);
 
+// Sentinel for "practically infinite collateral" — seed via `defaultBalance`
+// on an Erc20Fixture so `balanceOf(warpRouter)` reports a large value and
+// WarpCore.validateTransfer's destination-collateral check passes. Without
+// this, validate short-circuits with "Insufficient collateral on
+// destination" and the form never enters review state.
+export const ROUTER_COLLATERAL_SEED = MAX_UINT256;
+
 export interface ChainUrlMatcher {
   chainId: number;
   urlMatch: RegExp;

--- a/tests/e2e-wallet/same-symbol-dedup/evm.spec.ts
+++ b/tests/e2e-wallet/same-symbol-dedup/evm.spec.ts
@@ -10,6 +10,11 @@ test.describe('EVM same-symbol dedup', () => {
   test('selecting Arbitrum USDC resolves the Arbitrum-scoped route (not Ethereum)', async ({
     page,
   }) => {
+    // defaultBalance seeds the destination-collateral check in
+    // WarpCore.validateTransfer. Without it, balanceOf(warpRouter) returns 0
+    // on the destination chain and validate short-circuits with
+    // "Insufficient collateral on destination" before isReview flips true.
+    const COLLATERAL_SEED = '0xffffffffffffffff';
     await installEvmRpcMock(page, {
       chainUrlMap: [
         { chainId: 1, urlMatch: /ethereum\.|eth\.drpc|eth-mainnet/i },
@@ -17,8 +22,10 @@ test.describe('EVM same-symbol dedup', () => {
         { chainId: 42161, urlMatch: /arb1\.arbitrum|arbitrum\.rpc|arbitrum-mainnet/i },
       ],
       erc20: {
+        '*': { decimals: 6, defaultBalance: COLLATERAL_SEED },
         [`42161:${USDC_ARBITRUM}`]: {
           decimals: 6,
+          defaultBalance: COLLATERAL_SEED,
           balances: { [MOCK_EVM_ADDRESS.toLowerCase()]: '0x3b9aca00' }, // 1000 USDC
         },
       },
@@ -36,11 +43,19 @@ test.describe('EVM same-symbol dedup', () => {
     await enterAmount(page, '1');
     await page.getByRole('button', { name: /^Continue$/ }).click();
 
+    // Gate on the Send button — only renders when isReview=true (validate
+    // passed). The .transfer-review-panel element stays in DOM with max-h-0
+    // even when isReview=false, so checking its text directly would silently
+    // succeed on a validate failure and miss the regression below.
+    await expect(page.getByRole('button', { name: /Send to /i })).toBeVisible({
+      timeout: 30_000,
+    });
+
     // Review panel populating with the Transfer Remote section proves the
     // route resolved against the Arbitrum-scoped USDC (a failed dedup would
     // surface a validation error or a different remote token address here).
     const reviewPanel = page.locator('.transfer-review-panel').first();
-    await expect(reviewPanel).toContainText(/Transfer Remote/i, { timeout: 30_000 });
+    await expect(reviewPanel).toContainText(/Transfer Remote/i);
     await expect(reviewPanel).toContainText(/1 USDC/);
     // Remote token must render as a 0x-address (non-empty, not a fallback string).
     await expect(reviewPanel).toContainText(/0x[0-9a-fA-F]{40}/);

--- a/tests/e2e-wallet/same-symbol-dedup/evm.spec.ts
+++ b/tests/e2e-wallet/same-symbol-dedup/evm.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { MOCK_EVM_ADDRESS } from '../helpers/constants';
-import { installEvmRpcMock } from '../helpers/evmRpc';
+import { installEvmRpcMock, ROUTER_COLLATERAL_SEED } from '../helpers/evmRpc';
 import { enterAmount, selectOriginToken } from '../helpers/formFlow';
 import { openE2EApp } from '../helpers/page-setup';
 
@@ -10,11 +10,6 @@ test.describe('EVM same-symbol dedup', () => {
   test('selecting Arbitrum USDC resolves the Arbitrum-scoped route (not Ethereum)', async ({
     page,
   }) => {
-    // defaultBalance seeds the destination-collateral check in
-    // WarpCore.validateTransfer. Without it, balanceOf(warpRouter) returns 0
-    // on the destination chain and validate short-circuits with
-    // "Insufficient collateral on destination" before isReview flips true.
-    const COLLATERAL_SEED = '0xffffffffffffffff';
     await installEvmRpcMock(page, {
       chainUrlMap: [
         { chainId: 1, urlMatch: /ethereum\.|eth\.drpc|eth-mainnet/i },
@@ -22,10 +17,14 @@ test.describe('EVM same-symbol dedup', () => {
         { chainId: 42161, urlMatch: /arb1\.arbitrum|arbitrum\.rpc|arbitrum-mainnet/i },
       ],
       erc20: {
-        '*': { decimals: 6, defaultBalance: COLLATERAL_SEED },
+        '*': { decimals: 6, defaultBalance: ROUTER_COLLATERAL_SEED },
         [`42161:${USDC_ARBITRUM}`]: {
           decimals: 6,
-          defaultBalance: COLLATERAL_SEED,
+          // Fixture lookup is first-match-wins, not a field merge (see
+          // handleEthCall: erc20[key] ?? erc20[to] ?? erc20['*']) — once this
+          // specific key resolves the '*' wildcard is ignored, so the seed
+          // must be repeated here for owners other than MOCK_EVM_ADDRESS.
+          defaultBalance: ROUTER_COLLATERAL_SEED,
           balances: { [MOCK_EVM_ADDRESS.toLowerCase()]: '0x3b9aca00' }, // 1000 USDC
         },
       },

--- a/tests/e2e-wallet/same-symbol-dedup/evm.spec.ts
+++ b/tests/e2e-wallet/same-symbol-dedup/evm.spec.ts
@@ -50,10 +50,16 @@ test.describe('EVM same-symbol dedup', () => {
       timeout: 30_000,
     });
 
+    // Then wait for fee quotes to settle — the panel renders a spinner while
+    // isLoading=true, and the Remote Token row only mounts afterwards. Without
+    // this, the 0x assertion below relies on Playwright's default 5s timeout
+    // which is tight on slow CI runners.
+    const reviewPanel = page.locator('.transfer-review-panel').first();
+    await expect(reviewPanel).toContainText(/Remote Token/i, { timeout: 30_000 });
+
     // Review panel populating with the Transfer Remote section proves the
     // route resolved against the Arbitrum-scoped USDC (a failed dedup would
     // surface a validation error or a different remote token address here).
-    const reviewPanel = page.locator('.transfer-review-panel').first();
     await expect(reviewPanel).toContainText(/Transfer Remote/i);
     await expect(reviewPanel).toContainText(/1 USDC/);
     // Remote token must render as a 0x-address (non-empty, not a fallback string).


### PR DESCRIPTION
## Summary

Two EVM e2e tests (`destination-router/evm`, `same-symbol-dedup/evm`) started failing on CI. Root cause is not in the app code, it's in the test setup interacting with a recent registry change.

### What changed in the world

The published registry's combined `warpRouteConfigs.yaml` got the `CROSS/ctusd-usdc-ironbridge` route promoted into it on 2026-05-11. `CROSS/` sorts alphabetically before `USDC/`, and the UI's `dedupeTokensByCollateral` keeps the first token per (chain, collateral). So the deduped picker now lands on the CROSS-route USDC for ETH / Base / Arbitrum.

### Why that broke the tests

CROSS USDC on each EVM chain only directly connects to citrea ctUSD — not to USDC on the other EVM chains. `validateForm` correctly falls back through the collateral group (`findRouteToken`) to pick an alternative origin warp route, and then `WarpCore.validateTransfer` runs the destination-collateral check via `balanceOf(warpRouter)` on the destination chain. The tests' RPC mocks never seeded a balance for the destination chain's USDC contract, so the router appears uncollateralized → validate returns `"Insufficient collateral on destination"` → Formik never calls `onSubmit` → `isReview` stays false.

Meanwhile, the `.transfer-review-panel` element is in the DOM with `max-h-0` regardless of `isReview`, so `innerText` reads the collapsed-but-rendered text. The original assertions matched on `"Transfer Remote"` (rendered even when collapsed) but then expected the `Remote Token` 0x address line (only rendered when `isReview && !isLoading`) — silently failing as "address missing" when the real failure was "review never opened".

### What the patch does

1. Seeds `defaultBalance` on the EVM RPC mocks so `balanceOf(warpRouter)` returns a large value on every destination chain → validate's collateral check passes.
2. Gates assertions on `Send to ...` button visibility (only mounts when `isReview === true`) instead of on `Transfer Remote` text inside the panel.
3. In `destination-router`, also gates on the `Remote Token` label so the panel's `isLoading` spinner phase (fee quotes settling) doesn't race the `innerText` read.

### Verification

Tests pass locally against both SDK 33.1.0 (current `main`) and SDK 35.0.0 (the deps-update PR). No app code changed. No other tests touched.

### Note on targeting `main`

The fix is intentionally independent of the deps-update PR — the registry change that triggered the failures is live regardless of SDK version, and this fix unblocks both the deps PR and any future PR that runs CI.