### PR TITLE
feat: add evENI/bsc and PB/eni to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -398,6 +398,8 @@ export const warpRouteWhitelist: Array<string> | null = [
   'QUILL/eni',
   'BNB/eni',
   '1Piece/eni',
+  'evENI/bsc',
+  'PB/eni',
 
   // First Party Warp Routes
   'ETH/viction',


### PR DESCRIPTION
Adds the following warp routes to the Nexus UI whitelist:

| Field | Value |
| ----- | ----- |
| **Linear** | [AW-652](https://linear.app/hyperlane-xyz/issue/AW-652/eni-eco-eni-bsc) · [AW-655](https://linear.app/hyperlane-xyz/issue/AW-655/eni-pb-eni-synthetic-bsc-collateral) |

- `evENI/bsc`
- `PB/eni`