### PR TITLE
fix: silence smart contract check RPC errors from user-facing toast

### DIFF
--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -20,7 +20,6 @@ import { type AccountInfo } from '@hyperlane-xyz/widgets/walletIntegrations/type
 import BigNumber from 'bignumber.js';
 import { Form, Formik, useFormikContext } from 'formik';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { RecipientWarningBanner } from '../../components/banner/RecipientWarningBanner';
 import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareSubmitButton';
@@ -619,7 +618,7 @@ function ButtonSection({
       const isSelfRecipient = eqAddress(recipient, connectedWallet);
 
       if (senderCheckError || recipientCheckError) {
-        toast.error(senderCheckError || recipientCheckError);
+        logger.warn(senderCheckError || recipientCheckError);
         setRecipientInfos({ addressConfirmed: true, showWarning: false });
         return;
       }


### PR DESCRIPTION
## Summary

- `isSmartContract` (`eth_getCode`) is a best-effort UX guard that warns users when their smart contract wallet address doesn't exist as a contract on the destination chain
- When the RPC call fails — most likely rate limiting on public BSC RPCs — it was surfacing as `toast.error`, showing a confusing error to users even though the transfer itself is completely unaffected
- Downgrade from `toast.error` to `logger.warn` so failures are captured in logs but not shown to users

## Test plan

- [ ] Bridge between two EVM chains with a smart contract wallet — warning banner still appears when expected
- [ ] Confirm no error toast appears when BSC RPC is flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)