### PR TITLE
fix: show max button spinner in dark mode

### DIFF
--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -451,7 +451,25 @@ function MaxButton({
       disabled={isDisabled}
       className="transfer-max-btn rounded border border-gray-300 px-2 py-0.5 font-secondary text-sm text-gray-450 transition-colors hover:border-gray-400 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-300/40 dark:text-foreground-secondary dark:hover:border-primary-300/65 dark:hover:text-foreground-primary"
     >
-      {isLoading ? <SpinnerIcon className="h-4 w-4" /> : 'Max'}
+      {isLoading ? (
+        <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+          />
+        </svg>
+      ) : (
+        'Max'
+      )}
     </button>
   );
 }

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -452,21 +452,7 @@ function MaxButton({
       className="transfer-max-btn rounded border border-gray-300 px-2 py-0.5 font-secondary text-sm text-gray-450 transition-colors hover:border-gray-400 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50 dark:border-primary-300/40 dark:text-foreground-secondary dark:hover:border-primary-300/65 dark:hover:text-foreground-primary"
     >
       {isLoading ? (
-        <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-          <circle
-            className="opacity-25"
-            cx="12"
-            cy="12"
-            r="10"
-            stroke="currentColor"
-            strokeWidth="4"
-          />
-          <path
-            className="opacity-75"
-            fill="currentColor"
-            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-          />
-        </svg>
+        <SpinnerIcon className="h-4 w-4" color="currentColor" style={{ color: 'inherit' }} />
       ) : (
         'Max'
       )}


### PR DESCRIPTION
## Summary

- The max button loading spinner was invisible in dark mode
- Root cause: `SpinnerIcon` from `@hyperlane-xyz/widgets` hardcodes `htw-text-black` on the SVG element, making the spinner always black regardless of the parent's text color
- Fix: pass `color="currentColor"` so SVG paths use CSS `currentColor`, and `style={{ color: 'inherit' }}` as an inline style (higher specificity than the hardcoded class) to inherit the button's dark mode text color (`dark:text-foreground-secondary`)

## Test plan

- [x] Click "Max" on a transfer with a connected wallet in **light mode** — spinner appears while loading
- [x] Click "Max" in **dark mode** — spinner is now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)