### PR TITLE
feat(prices): shared CoinGecko cache + swap USD display

### DIFF
--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -132,6 +132,13 @@ export interface AppState {
   knownTokens: Map<string, UiToken>;
   syncTokens: (tokens: UiToken[]) => void;
 
+  // Sticky USD price cache, keyed by coinGeckoId. Per-id `fetchedAt` so
+  // chain switches that grow the token catalogue only fetch the deltas.
+  // Entries with `usd` absent are negative-cached (CoinGecko had no
+  // price) so we don't retry in a tight loop.
+  tokenPrices: Record<string, { usd?: number; fetchedAt: number }>;
+  mergeTokenPrices: (requestedIds: string[], fetched: Record<string, number>) => void;
+
   // Shared component state
   transferLoading: boolean;
   setTransferLoading: (isLoading: boolean) => void;
@@ -327,6 +334,18 @@ export const useStore = create<AppState>()(
             }
           }
           return added > 0 ? { knownTokens: next } : state;
+        });
+      },
+
+      tokenPrices: {},
+      mergeTokenPrices: (requestedIds, fetched) => {
+        set((state) => {
+          const now = Date.now();
+          const next = { ...state.tokenPrices };
+          for (const id of requestedIds) {
+            next[id] = { usd: fetched[id], fetchedAt: now };
+          }
+          return { tokenPrices: next };
         });
       },
 

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -160,12 +160,14 @@ export interface AppState {
   // at WarpContext init). Consumed by the bridge `useTokenPrices` wrapper
   // which delegates to the shared `useTokenPricesByIds` cache below.
   coinGeckoIds: string[];
-  // Sticky USD price cache, keyed by coinGeckoId. Per-id `fetchedAt` so
-  // chain switches that grow the token catalogue only fetch the deltas.
-  // Entries with `usd` absent are negative-cached (CoinGecko had no
-  // price) so we don't retry in a tight loop.
-  tokenPrices: Record<string, { usd?: number; fetchedAt: number }>;
-  mergeTokenPrices: (requestedIds: string[], fetched: Record<string, number>) => void;
+  // Session-scoped USD price cache, keyed by coinGeckoId. `failedAt`
+  // backs off retries after rate-limit / network failures.
+  tokenPrices: Record<string, { usd?: number; fetchedAt?: number; failedAt?: number }>;
+  mergeTokenPrices: (
+    succeededIds: string[],
+    fetched: Record<string, number>,
+    failedIds: string[],
+  ) => void;
 }
 
 export const useStore = create<AppState>()(
@@ -339,12 +341,15 @@ export const useStore = create<AppState>()(
       },
 
       tokenPrices: {},
-      mergeTokenPrices: (requestedIds, fetched) => {
+      mergeTokenPrices: (succeededIds, fetched, failedIds) => {
         set((state) => {
           const now = Date.now();
           const next = { ...state.tokenPrices };
-          for (const id of requestedIds) {
+          for (const id of succeededIds) {
             next[id] = { usd: fetched[id], fetchedAt: now };
+          }
+          for (const id of failedIds) {
+            next[id] = { ...next[id], failedAt: now };
           }
           return { tokenPrices: next };
         });

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -132,13 +132,6 @@ export interface AppState {
   knownTokens: Map<string, UiToken>;
   syncTokens: (tokens: UiToken[]) => void;
 
-  // Sticky USD price cache, keyed by coinGeckoId. Per-id `fetchedAt` so
-  // chain switches that grow the token catalogue only fetch the deltas.
-  // Entries with `usd` absent are negative-cached (CoinGecko had no
-  // price) so we don't retry in a tight loop.
-  tokenPrices: Record<string, { usd?: number; fetchedAt: number }>;
-  mergeTokenPrices: (requestedIds: string[], fetched: Record<string, number>) => void;
-
   // Shared component state
   transferLoading: boolean;
   setTransferLoading: (isLoading: boolean) => void;
@@ -163,8 +156,16 @@ export interface AppState {
   // Set of router addresses per chain — used to prevent sending to warp route
   // addresses and to filter message API results
   routerAddressesByChainMap: Record<ChainName, Set<string>>;
-  // Deduplicated, sorted CoinGecko IDs for all tokens (used by useTokenPrices)
+  // Deduplicated, sorted CoinGecko IDs for the warpCore token set (built
+  // at WarpContext init). Consumed by the bridge `useTokenPrices` wrapper
+  // which delegates to the shared `useTokenPricesByIds` cache below.
   coinGeckoIds: string[];
+  // Sticky USD price cache, keyed by coinGeckoId. Per-id `fetchedAt` so
+  // chain switches that grow the token catalogue only fetch the deltas.
+  // Entries with `usd` absent are negative-cached (CoinGecko had no
+  // price) so we don't retry in a tight loop.
+  tokenPrices: Record<string, { usd?: number; fetchedAt: number }>;
+  mergeTokenPrices: (requestedIds: string[], fetched: Record<string, number>) => void;
 }
 
 export const useStore = create<AppState>()(

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -24,7 +24,7 @@ import { RecipientConfirmationModal } from '../wallet/RecipientConfirmationModal
 import { WalletConnectionWarning } from '../wallet/WalletConnectionWarning';
 import { WalletDropdown } from '../wallet/WalletDropdown';
 import { useTokenBalance } from './balances/hooks';
-import { formatBalance, formatFeeAmount } from './balances/utils';
+import { formatBalance, formatFeeAmount, formatUsd } from './balances/utils';
 import { FeeSectionButton } from './FeeSectionButton';
 import { MaxButton } from './MaxButton';
 import {
@@ -38,6 +38,7 @@ import { TokenBalance } from './TokenBalance';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
 import { TokenSelectField } from './tokens/TokenSelectField';
 import type { UiToken } from './tokens/types';
+import { useTokenUsdValue } from './tokens/useTokenPrice';
 import {
   FinalSwapStatuses,
   SwapStatus,
@@ -495,7 +496,9 @@ function OriginTokenCard({
   srcToken: UiToken | undefined;
   amountError: string | undefined;
 }) {
+  const { values } = useFormikContext<SwapFormValues>();
   const { data: balance, isLoading: isBalanceLoading } = useTokenBalance(srcToken);
+  const amountUsd = useTokenUsdValue(srcToken, values.amount);
 
   return (
     <div>
@@ -530,7 +533,7 @@ function OriginTokenCard({
           />
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
-          <span>$0.00</span>
+          <span>{formatUsd(amountUsd)}</span>
           <TokenBalance label="Balance" balance={balance ?? null} token={srcToken} />
         </div>
       </div>
@@ -572,14 +575,14 @@ function DestinationTokenCard({
     }
   }, [bestRoute, dstToken]);
   const minOutputDisplay = useMemo(() => {
-    if (!bestRoute || !dstToken) return '';
-    if (bestRoute.isBridgeOnly) return '';
+    if (!bestRoute || !dstToken || bestRoute.isBridgeOnly) return '';
     try {
       return formatUnits(BigInt(bestRoute.raw.outputMin), dstToken.decimals);
     } catch {
       return '';
     }
   }, [bestRoute, dstToken]);
+  const outputUsd = useTokenUsdValue(dstToken, outputDisplay);
 
   return (
     <div>
@@ -611,7 +614,12 @@ function DestinationTokenCard({
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
           <span>
-            {minOutputDisplay ? `Min: ${minOutputDisplay} ${dstToken?.symbol ?? ''}` : ''}
+            {formatUsd(outputUsd)}
+            {minOutputDisplay && (
+              <span className="ml-1.5">
+                · Min: {minOutputDisplay} {dstToken?.symbol ?? ''}
+              </span>
+            )}
           </span>
           <TokenBalance label="Remote Balance" balance={balance ?? null} token={dstToken} />
         </div>

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -533,7 +533,7 @@ function OriginTokenCard({
           />
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
-          <span>{formatUsd(amountUsd)}</span>
+          <span>{amountUsd >= 0.01 ? formatUsd(amountUsd) : '$0.00'}</span>
           <TokenBalance label="Balance" balance={balance ?? null} token={srcToken} />
         </div>
       </div>
@@ -574,14 +574,6 @@ function DestinationTokenCard({
       return '';
     }
   }, [bestRoute, dstToken]);
-  const minOutputDisplay = useMemo(() => {
-    if (!bestRoute || !dstToken || bestRoute.isBridgeOnly) return '';
-    try {
-      return formatUnits(BigInt(bestRoute.raw.outputMin), dstToken.decimals);
-    } catch {
-      return '';
-    }
-  }, [bestRoute, dstToken]);
   const outputUsd = useTokenUsdValue(dstToken, outputDisplay);
 
   return (
@@ -613,14 +605,7 @@ function DestinationTokenCard({
           />
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
-          <span>
-            {formatUsd(outputUsd)}
-            {minOutputDisplay && (
-              <span className="ml-1.5">
-                · Min: {minOutputDisplay} {dstToken?.symbol ?? ''}
-              </span>
-            )}
-          </span>
+          <span>{outputUsd >= 0.01 ? formatUsd(outputUsd) : '$0.00'}</span>
           <TokenBalance label="Remote Balance" balance={balance ?? null} token={dstToken} />
         </div>
       </div>

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -38,7 +38,7 @@ import { TokenBalance } from './TokenBalance';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
 import { TokenSelectField } from './tokens/TokenSelectField';
 import type { UiToken } from './tokens/types';
-import { useTokenUsdValue } from './tokens/useTokenPrice';
+import { useTokenPrices, useTokenUsdValue } from './tokens/useTokenPrice';
 import {
   FinalSwapStatuses,
   SwapStatus,
@@ -69,6 +69,11 @@ export function SwapForm() {
 }
 
 function SwapFormContent() {
+  // Mounts the catalogue-wide price fetch once for the whole form. Cards
+  // and review modal read individual prices via `useTokenUsdValue` (pure
+  // store readers); without this top-level call, deep-linked URLs would
+  // render cards before the picker opens and see empty USD values.
+  useTokenPrices();
   const { values, errors, setErrors, setFieldValue, setValues } =
     useFormikContext<SwapFormValues>();
   const multiProvider = useMultiProvider();
@@ -533,7 +538,7 @@ function OriginTokenCard({
           />
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
-          <span>{amountUsd >= 0.01 ? formatUsd(amountUsd) : '$0.00'}</span>
+          <span>{!amountUsd ? '$0.00' : formatUsd(amountUsd)}</span>
           <TokenBalance label="Balance" balance={balance ?? null} token={srcToken} />
         </div>
       </div>
@@ -605,7 +610,7 @@ function DestinationTokenCard({
           />
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
-          <span>{outputUsd >= 0.01 ? formatUsd(outputUsd) : '$0.00'}</span>
+          <span>{!outputUsd ? '$0.00' : formatUsd(outputUsd)}</span>
           <TokenBalance label="Remote Balance" balance={balance ?? null} token={dstToken} />
         </div>
       </div>

--- a/src/features/swap/balances/utils.ts
+++ b/src/features/swap/balances/utils.ts
@@ -11,9 +11,7 @@ export function formatFeeAmount(amount: bigint, decimals: number): string {
   return fromWeiRounded(amount.toString(), decimals, 8);
 }
 
-// Swap-side getUsdValue keys USD prices by lowercase symbol because the
-// engine doesn't yet expose coinGeckoId per token. Bridge's version keys
-// by coinGeckoId — different lookup, kept separate.
+// Engine now exposes coinGeckoId per token; price map is keyed by it.
 export function getUsdValue(
   token: UiToken,
   balances: Record<string, bigint>,
@@ -21,9 +19,8 @@ export function getUsdValue(
 ): number | null {
   const key = getTokenKey(token);
   const bal = balances[key];
-  if (bal == null) return null;
-  const symbolKey = token.symbol.toLowerCase();
-  const price = prices[symbolKey];
+  if (bal == null || !token.coinGeckoId) return null;
+  const price = prices[token.coinGeckoId];
   if (price == null) return null;
   return (Number(bal) / 10 ** token.decimals) * price;
 }

--- a/src/features/swap/tokens/useTokenPrice.tsx
+++ b/src/features/swap/tokens/useTokenPrice.tsx
@@ -1,6 +1,36 @@
-// Engine doesn't expose token USD prices yet. Shape mirrors warp UI's
-// useTokenPrices so TokenList consumes it without changes; the price
-// map is empty for now.
+import { useMemo } from 'react';
+
+import { useStore } from '../../store';
+import { useTokenPricesByIds } from '../../tokens/useTokenPrice';
+import type { UiToken } from './types';
+
+// Swap-side prices: derive coinGeckoIds from the engine token catalogue
+// (knownTokens grows as the user browses chains/tokens) and delegate to
+// the shared store-backed cache. Overlapping IDs with the bridge tab
+// (ETH, USDC, etc.) are fetched once total.
 export function useTokenPrices(): { prices: Record<string, number>; isLoading: boolean } {
-  return { prices: {}, isLoading: false };
+  const knownTokens = useStore((s) => s.knownTokens);
+
+  const ids = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of knownTokens.values()) {
+      if (t.coinGeckoId) set.add(t.coinGeckoId);
+    }
+    return Array.from(set).sort();
+  }, [knownTokens]);
+
+  return useTokenPricesByIds(ids);
+}
+
+// Convenience: USD value of a decimal-formatted token `amount` string.
+// Returns 0 when token has no coinGeckoId, no cached price, or the
+// amount fails to parse.
+export function useTokenUsdValue(token: UiToken | undefined, amount: string): number {
+  const { prices } = useTokenPrices();
+  const price = token?.coinGeckoId ? prices[token.coinGeckoId] : undefined;
+  return useMemo(() => {
+    const a = parseFloat(amount);
+    if (!price || isNaN(a)) return 0;
+    return a * price;
+  }, [amount, price]);
 }

--- a/src/features/swap/tokens/useTokenPrice.tsx
+++ b/src/features/swap/tokens/useTokenPrice.tsx
@@ -29,7 +29,9 @@ export function useTokenUsdValue(token: UiToken | undefined, amount: string): nu
   const { prices } = useTokenPrices();
   const price = token?.coinGeckoId ? prices[token.coinGeckoId] : undefined;
   return useMemo(() => {
-    const a = parseFloat(amount);
+    // Coerce + strip grouping separators — Formik may hand us a number/null
+    // and parseFloat("1,234.56") returns 1 without the strip.
+    const a = parseFloat(String(amount ?? '').replace(/,/g, ''));
     if (!price || isNaN(a)) return 0;
     return a * price;
   }, [amount, price]);

--- a/src/features/swap/tokens/useTokenPrice.tsx
+++ b/src/features/swap/tokens/useTokenPrice.tsx
@@ -22,19 +22,19 @@ export function useTokenPrices(): { prices: Record<string, number>; isLoading: b
   return useTokenPricesByIds(ids);
 }
 
-// USD value of a token `amount` string. Reads the single price via a
-// parameterized selector so consumers don't re-render on unrelated
-// tokenPrices mutations.
-export function useTokenUsdValue(token: UiToken | undefined, amount: string): number {
-  // Side-effect mount: keeps the catalogue-wide fetch hot for deep-linked
-  // URLs where cards render before the picker opens.
-  useTokenPrices();
+// USD value of a token `amount` string. Returns null when there's no info
+// (no coinGeckoId, no cached price, NaN/Infinity amount) so call sites can
+// distinguish "no data → $0.00" from "tiny positive → <$0.01" via formatUsd.
+// Pure read — relies on a parent mounting `useTokenPrices()` to keep the
+// store cache populated (see SwapFormContent). Per-id selector keeps
+// consumers from re-rendering on unrelated tokenPrices mutations.
+export function useTokenUsdValue(token: UiToken | undefined, amount: string): number | null {
   const id = token?.coinGeckoId;
   const price = useStore((s) => (id ? s.tokenPrices[id]?.usd : undefined));
   return useMemo(() => {
     // Strip grouping separators — parseFloat("1,234.56") returns 1 otherwise.
     const a = parseFloat(String(amount ?? '').replace(/,/g, ''));
-    if (!price || isNaN(a)) return 0;
+    if (!price || !Number.isFinite(a)) return null;
     return a * price;
   }, [amount, price]);
 }

--- a/src/features/swap/tokens/useTokenPrice.tsx
+++ b/src/features/swap/tokens/useTokenPrice.tsx
@@ -22,15 +22,17 @@ export function useTokenPrices(): { prices: Record<string, number>; isLoading: b
   return useTokenPricesByIds(ids);
 }
 
-// Convenience: USD value of a decimal-formatted token `amount` string.
-// Returns 0 when token has no coinGeckoId, no cached price, or the
-// amount fails to parse.
+// USD value of a token `amount` string. Reads the single price via a
+// parameterized selector so consumers don't re-render on unrelated
+// tokenPrices mutations.
 export function useTokenUsdValue(token: UiToken | undefined, amount: string): number {
-  const { prices } = useTokenPrices();
-  const price = token?.coinGeckoId ? prices[token.coinGeckoId] : undefined;
+  // Side-effect mount: keeps the catalogue-wide fetch hot for deep-linked
+  // URLs where cards render before the picker opens.
+  useTokenPrices();
+  const id = token?.coinGeckoId;
+  const price = useStore((s) => (id ? s.tokenPrices[id]?.usd : undefined));
   return useMemo(() => {
-    // Coerce + strip grouping separators — Formik may hand us a number/null
-    // and parseFloat("1,234.56") returns 1 without the strip.
+    // Strip grouping separators — parseFloat("1,234.56") returns 1 otherwise.
     const a = parseFloat(String(amount ?? '').replace(/,/g, ''));
     if (!price || isNaN(a)) return 0;
     return a * price;

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -5,6 +5,13 @@ import { useMemo } from 'react';
 import { logger } from '../../utils/logger';
 import { useStore } from '../store';
 
+type PriceCache = Record<string, { usd?: number; fetchedAt?: number; failedAt?: number }>;
+type MergeFn = (
+  succeededIds: string[],
+  fetched: Record<string, number>,
+  failedIds: string[],
+) => void;
+
 const PRICE_CACHE_MS = 15 * 60_000;
 const FAILED_BACKOFF_MS = 30_000;
 // 100 keeps the URL well under the ~6KB Cloudflare 414 threshold. Chunks run
@@ -65,8 +72,33 @@ async function fetchPricesBatched(ids: string[]): Promise<BatchedFetchResult> {
   return { requestedIds, prices };
 }
 
-// Shared core: delta-fetch into the store's `tokenPrices` cache. Bridge
+// Filter input IDs against the cache, fetch whatever is missing / stale /
+// past its backoff window, and merge results back into the store. Called
+// by both initial mount and the periodic refetch tick — on first call
+// the cache is empty so every ID flows through.
+async function fetchTokenPrices(ids: string[], cache: PriceCache, merge: MergeFn): Promise<null> {
+  const now = Date.now();
+  const idsToFetch = ids.filter((id) => {
+    const entry = cache[id];
+    if (!entry) return true;
+    if (entry.fetchedAt && now - entry.fetchedAt < PRICE_CACHE_MS) return false;
+    if (entry.failedAt && now - entry.failedAt < FAILED_BACKOFF_MS) return false;
+    return true;
+  });
+  if (idsToFetch.length === 0) return null;
+  const { requestedIds, prices } = await fetchPricesBatched(idsToFetch);
+  const failedIds = idsToFetch.filter((id) => !requestedIds.includes(id));
+  merge(requestedIds, prices, failedIds);
+  if (requestedIds.length === 0) {
+    throw new Error('All CoinGecko price chunks failed');
+  }
+  return null;
+}
+
+// Shared core: keep the store's `tokenPrices` cache fresh for `ids`. Bridge
 // + swap wrap with their own ID sources (warp routes vs engine catalogue).
+// TQ's `refetchInterval` drives periodic re-evaluation against the cache;
+// queryFn is a no-op when nothing is stale.
 export function useTokenPricesByIds(ids: string[]): {
   prices: Record<string, number>;
   isLoading: boolean;
@@ -78,32 +110,12 @@ export function useTokenPricesByIds(ids: string[]): {
   // a leading-edge debounce if it shows up in practice.
   const debouncedIds = useDebounce(ids, 300);
 
-  const idsToFetch = useMemo(() => {
-    const now = Date.now();
-    return debouncedIds.filter((id) => {
-      const entry = tokenPrices[id];
-      if (!entry) return true;
-      if (entry.fetchedAt && now - entry.fetchedAt < PRICE_CACHE_MS) return false;
-      if (entry.failedAt && now - entry.failedAt < FAILED_BACKOFF_MS) return false;
-      return true;
-    });
-  }, [debouncedIds, tokenPrices]);
-
   const { isLoading } = useQuery({
-    queryKey: ['tokenPrices', idsToFetch],
-    queryFn: async () => {
-      const { requestedIds, prices } = await fetchPricesBatched(idsToFetch);
-      const failedIds = idsToFetch.filter((id) => !requestedIds.includes(id));
-      mergeTokenPrices(requestedIds, prices, failedIds);
-      if (requestedIds.length === 0) {
-        throw new Error('All CoinGecko price chunks failed');
-      }
-      // Cache truth lives in Zustand + the idsToFetch filter; TQ is just
-      // a debounced trigger + retry mechanism. No staleTime / refetchOn*
-      // needed — queryKey content shifts on each successful merge.
-      return null;
-    },
-    enabled: idsToFetch.length > 0,
+    queryKey: ['tokenPrices', debouncedIds],
+    queryFn: () => fetchTokenPrices(debouncedIds, tokenPrices, mergeTokenPrices),
+    enabled: debouncedIds.length > 0,
+    refetchInterval: PRICE_CACHE_MS / 2,
+    refetchOnWindowFocus: false,
   });
 
   // Flatten the entry shape → bare USD numbers for consumers.

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -1,3 +1,4 @@
+import { useDebounce } from '@hyperlane-xyz/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -12,37 +13,56 @@ const COINGECKO_BATCH = 250;
 
 type CoinGeckoResponse = Record<string, { usd: number }>;
 
-/** Fetch USD prices from CoinGecko for one or more coinGeckoIds. */
+/**
+ * Fetch USD prices from CoinGecko for one or more coinGeckoIds. Throws on
+ * network or HTTP errors so callers can distinguish a real failure from a
+ * 200-OK-with-missing-ids (legit "CoinGecko has no price for this id").
+ */
 export async function fetchPrices(ids: string[]): Promise<Record<string, number>> {
   if (ids.length === 0) return {};
-  try {
-    const res = await fetch(
-      `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(',')}&vs_currencies=usd`,
-    );
-    if (!res.ok) {
-      logger.warn(`CoinGecko API error: ${res.status} ${res.statusText}`);
-      return {};
-    }
-    const data: CoinGeckoResponse = await res.json();
-    const result: Record<string, number> = {};
-    for (const [id, priceData] of Object.entries(data)) {
-      if (priceData?.usd != null) result[id] = priceData.usd;
-    }
-    return result;
-  } catch (error) {
-    logger.warn('Failed to fetch token prices', error);
-    return {};
+  const res = await fetch(
+    `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(',')}&vs_currencies=usd`,
+  );
+  if (!res.ok) {
+    throw new Error(`CoinGecko ${res.status} ${res.statusText}`);
   }
+  const data: CoinGeckoResponse = await res.json();
+  const result: Record<string, number> = {};
+  for (const [id, priceData] of Object.entries(data)) {
+    if (priceData?.usd != null) result[id] = priceData.usd;
+  }
+  return result;
 }
 
-async function fetchPricesBatched(ids: string[]): Promise<Record<string, number>> {
-  if (ids.length === 0) return {};
+interface BatchedFetchResult {
+  /** IDs from chunks that resolved successfully — safe to negative-cache. */
+  requestedIds: string[];
+  prices: Record<string, number>;
+}
+
+// Per-chunk Promise.allSettled so a 429 on one chunk doesn't poison the
+// rest. Only successful chunks contribute to `requestedIds` / `prices`;
+// failed chunks' IDs stay uncached and become eligible for refetch on
+// the next render.
+async function fetchPricesBatched(ids: string[]): Promise<BatchedFetchResult> {
+  if (ids.length === 0) return { requestedIds: [], prices: {} };
   const chunks: string[][] = [];
   for (let i = 0; i < ids.length; i += COINGECKO_BATCH) {
     chunks.push(ids.slice(i, i + COINGECKO_BATCH));
   }
-  const results = await Promise.all(chunks.map(fetchPrices));
-  return Object.assign({}, ...results);
+  const results = await Promise.allSettled(chunks.map(fetchPrices));
+  const requestedIds: string[] = [];
+  const prices: Record<string, number> = {};
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r.status === 'fulfilled') {
+      requestedIds.push(...chunks[i]);
+      Object.assign(prices, r.value);
+    } else {
+      logger.warn('Failed to fetch token prices chunk', r.reason);
+    }
+  }
+  return { requestedIds, prices };
 }
 
 // Shared core: delta-fetch USD prices for `ids` into the store's
@@ -55,21 +75,34 @@ export function useTokenPricesByIds(ids: string[]): {
 } {
   const tokenPrices = useStore((s) => s.tokenPrices);
   const mergeTokenPrices = useStore((s) => s.mergeTokenPrices);
+  // Debounce the input id set — rapid catalogue growth (e.g. picker
+  // browsing chains) batches into one queryKey update instead of firing
+  // redundant in-flight fetches that all overlap on the same IDs.
+  const debouncedIds = useDebounce(ids, 300);
 
   const idsToFetch = useMemo(() => {
     const now = Date.now();
-    return ids.filter((id) => {
+    return debouncedIds.filter((id) => {
       const entry = tokenPrices[id];
       return !entry || now - entry.fetchedAt > PRICE_CACHE_MS;
     });
-  }, [ids, tokenPrices]);
+  }, [debouncedIds, tokenPrices]);
 
   const { isLoading } = useQuery({
     queryKey: ['tokenPrices', idsToFetch],
     queryFn: async () => {
-      const fresh = await fetchPricesBatched(idsToFetch);
-      mergeTokenPrices(idsToFetch, fresh);
-      return fresh;
+      const { requestedIds, prices } = await fetchPricesBatched(idsToFetch);
+      // Partial: merge what we got. Next render's `idsToFetch` shrinks
+      // to just the still-missing IDs → fresh queryKey fires a follow-up
+      // fetch for those automatically.
+      if (requestedIds.length > 0) {
+        mergeTokenPrices(requestedIds, prices);
+        return prices;
+      }
+      // Total failure: throw so TQ marks errored + retries (default 3x
+      // with exp backoff). Returning {} here would cache an empty
+      // "success" and lock the same queryKey out of refetching.
+      throw new Error('All CoinGecko price chunks failed');
     },
     enabled: idsToFetch.length > 0,
     staleTime: PRICE_CACHE_MS,

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -1,9 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 
 import { logger } from '../../utils/logger';
 import { useStore } from '../store';
 
-const PRICE_STALE_TIME = 300_000; // 5 min
+const PRICE_CACHE_MS = 60 * 60_000; // 1 hour
+// CoinGecko /simple/price ids= has no documented hard limit. Rate limits
+// are per-request (free tier ~5-15/min), so bigger batches = fewer
+// requests = less throttling. 250 matches /coins/markets per_page cap.
+const COINGECKO_BATCH = 250;
 
 type CoinGeckoResponse = Record<string, { usd: number }>;
 
@@ -30,23 +35,63 @@ export async function fetchPrices(ids: string[]): Promise<Record<string, number>
   }
 }
 
-/**
- * Batch-fetch USD prices for all tokens via CoinGecko.
- * Uses deduplicated coinGeckoIds from the store (computed during init).
- * Single query shared across all consumers via TanStack Query deduplication.
- */
-export function useTokenPrices() {
-  const coinGeckoIds = useStore((s) => s.coinGeckoIds);
+async function fetchPricesBatched(ids: string[]): Promise<Record<string, number>> {
+  if (ids.length === 0) return {};
+  const chunks: string[][] = [];
+  for (let i = 0; i < ids.length; i += COINGECKO_BATCH) {
+    chunks.push(ids.slice(i, i + COINGECKO_BATCH));
+  }
+  const results = await Promise.all(chunks.map(fetchPrices));
+  return Object.assign({}, ...results);
+}
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['tokenPrices', coinGeckoIds],
-    queryFn: () => fetchPrices(coinGeckoIds),
-    enabled: coinGeckoIds.length > 0,
-    staleTime: PRICE_STALE_TIME,
-    refetchInterval: PRICE_STALE_TIME,
+// Shared core: delta-fetch USD prices for `ids` into the store's
+// `tokenPrices` cache. Already-cached entries < 1h old are reused —
+// only the new IDs hit CoinGecko. Bridge + swap both wrap this with
+// their own ID sources (warp routes vs engine token catalogue).
+export function useTokenPricesByIds(ids: string[]): {
+  prices: Record<string, number>;
+  isLoading: boolean;
+} {
+  const tokenPrices = useStore((s) => s.tokenPrices);
+  const mergeTokenPrices = useStore((s) => s.mergeTokenPrices);
+
+  const idsToFetch = useMemo(() => {
+    const now = Date.now();
+    return ids.filter((id) => {
+      const entry = tokenPrices[id];
+      return !entry || now - entry.fetchedAt > PRICE_CACHE_MS;
+    });
+  }, [ids, tokenPrices]);
+
+  const { isLoading } = useQuery({
+    queryKey: ['tokenPrices', idsToFetch],
+    queryFn: async () => {
+      const fresh = await fetchPricesBatched(idsToFetch);
+      mergeTokenPrices(idsToFetch, fresh);
+      return fresh;
+    },
+    enabled: idsToFetch.length > 0,
+    staleTime: PRICE_CACHE_MS,
+    refetchInterval: false,
     refetchOnWindowFocus: false,
     refetchOnMount: false,
   });
 
-  return { prices: data ?? {}, isLoading };
+  // Flatten { usd, fetchedAt } → number for the consumer shape.
+  const prices = useMemo(() => {
+    const out: Record<string, number> = {};
+    for (const [id, entry] of Object.entries(tokenPrices)) {
+      if (entry.usd != null) out[id] = entry.usd;
+    }
+    return out;
+  }, [tokenPrices]);
+
+  return { prices, isLoading };
+}
+
+/** Bridge-side hook: prices the warpCore token set (built at init). */
+export function useTokenPrices() {
+  const coinGeckoIds = useStore((s) => s.coinGeckoIds);
+  return useTokenPricesByIds(coinGeckoIds);
 }

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -5,11 +5,12 @@ import { useMemo } from 'react';
 import { logger } from '../../utils/logger';
 import { useStore } from '../store';
 
-const PRICE_CACHE_MS = 60 * 60_000; // 1 hour
-// CoinGecko /simple/price ids= has no documented hard limit. Rate limits
-// are per-request (free tier ~5-15/min), so bigger batches = fewer
-// requests = less throttling. 250 matches /coins/markets per_page cap.
-const COINGECKO_BATCH = 250;
+const PRICE_CACHE_MS = 15 * 60_000;
+const FAILED_BACKOFF_MS = 30_000;
+// 100 keeps the URL well under the ~6KB Cloudflare 414 threshold. Chunks run
+// sequentially (free tier is ~5-15 req/min, parallel firing burns quota fast).
+const COINGECKO_BATCH = 100;
+const CHUNK_DELAY_MS = 200;
 
 type CoinGeckoResponse = Record<string, { usd: number }>;
 
@@ -20,11 +21,11 @@ type CoinGeckoResponse = Record<string, { usd: number }>;
  */
 export async function fetchPrices(ids: string[]): Promise<Record<string, number>> {
   if (ids.length === 0) return {};
-  const res = await fetch(
-    `https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(',')}&vs_currencies=usd`,
-  );
+  const url = `https://api.coingecko.com/api/v3/simple/price?ids=${ids.map(encodeURIComponent).join(',')}&vs_currencies=usd`;
+  const res = await fetch(url);
   if (!res.ok) {
-    throw new Error(`CoinGecko ${res.status} ${res.statusText}`);
+    const body = await res.text().catch(() => '');
+    throw new Error(`CoinGecko ${res.status} ${res.statusText}${body ? `: ${body}` : ''}`);
   }
   const data: CoinGeckoResponse = await res.json();
   const result: Record<string, number> = {};
@@ -35,56 +36,56 @@ export async function fetchPrices(ids: string[]): Promise<Record<string, number>
 }
 
 interface BatchedFetchResult {
-  /** IDs from chunks that resolved successfully — safe to negative-cache. */
+  /** IDs from chunks that resolved successfully. */
   requestedIds: string[];
   prices: Record<string, number>;
 }
 
-// Per-chunk Promise.allSettled so a 429 on one chunk doesn't poison the
-// rest. Only successful chunks contribute to `requestedIds` / `prices`;
-// failed chunks' IDs stay uncached and become eligible for refetch on
-// the next render.
+// Per-chunk try/catch so a 429 on one chunk doesn't block the rest —
+// failed chunks' IDs simply don't appear in `requestedIds`.
 async function fetchPricesBatched(ids: string[]): Promise<BatchedFetchResult> {
   if (ids.length === 0) return { requestedIds: [], prices: {} };
   const chunks: string[][] = [];
   for (let i = 0; i < ids.length; i += COINGECKO_BATCH) {
     chunks.push(ids.slice(i, i + COINGECKO_BATCH));
   }
-  const results = await Promise.allSettled(chunks.map(fetchPrices));
   const requestedIds: string[] = [];
   const prices: Record<string, number> = {};
-  for (let i = 0; i < results.length; i++) {
-    const r = results[i];
-    if (r.status === 'fulfilled') {
-      requestedIds.push(...chunks[i]);
-      Object.assign(prices, r.value);
-    } else {
-      logger.warn('Failed to fetch token prices chunk', r.reason);
+  for (let i = 0; i < chunks.length; i++) {
+    if (i > 0) await new Promise((r) => setTimeout(r, CHUNK_DELAY_MS));
+    const chunk = chunks[i];
+    try {
+      const result = await fetchPrices(chunk);
+      requestedIds.push(...chunk);
+      Object.assign(prices, result);
+    } catch (e) {
+      logger.warn('Failed to fetch token prices chunk', e);
     }
   }
   return { requestedIds, prices };
 }
 
-// Shared core: delta-fetch USD prices for `ids` into the store's
-// `tokenPrices` cache. Already-cached entries < 1h old are reused —
-// only the new IDs hit CoinGecko. Bridge + swap both wrap this with
-// their own ID sources (warp routes vs engine token catalogue).
+// Shared core: delta-fetch into the store's `tokenPrices` cache. Bridge
+// + swap wrap with their own ID sources (warp routes vs engine catalogue).
 export function useTokenPricesByIds(ids: string[]): {
   prices: Record<string, number>;
   isLoading: boolean;
 } {
   const tokenPrices = useStore((s) => s.tokenPrices);
   const mergeTokenPrices = useStore((s) => s.mergeTokenPrices);
-  // Debounce the input id set — rapid catalogue growth (e.g. picker
-  // browsing chains) batches into one queryKey update instead of firing
-  // redundant in-flight fetches that all overlap on the same IDs.
+  // TODO: rapid `ids` churn during initial bootstrap can keep the 300ms
+  // timer resetting and delay USD display on slow networks. Revisit with
+  // a leading-edge debounce if it shows up in practice.
   const debouncedIds = useDebounce(ids, 300);
 
   const idsToFetch = useMemo(() => {
     const now = Date.now();
     return debouncedIds.filter((id) => {
       const entry = tokenPrices[id];
-      return !entry || now - entry.fetchedAt > PRICE_CACHE_MS;
+      if (!entry) return true;
+      if (entry.fetchedAt && now - entry.fetchedAt < PRICE_CACHE_MS) return false;
+      if (entry.failedAt && now - entry.failedAt < FAILED_BACKOFF_MS) return false;
+      return true;
     });
   }, [debouncedIds, tokenPrices]);
 
@@ -92,26 +93,20 @@ export function useTokenPricesByIds(ids: string[]): {
     queryKey: ['tokenPrices', idsToFetch],
     queryFn: async () => {
       const { requestedIds, prices } = await fetchPricesBatched(idsToFetch);
-      // Partial: merge what we got. Next render's `idsToFetch` shrinks
-      // to just the still-missing IDs → fresh queryKey fires a follow-up
-      // fetch for those automatically.
-      if (requestedIds.length > 0) {
-        mergeTokenPrices(requestedIds, prices);
-        return prices;
+      const failedIds = idsToFetch.filter((id) => !requestedIds.includes(id));
+      mergeTokenPrices(requestedIds, prices, failedIds);
+      if (requestedIds.length === 0) {
+        throw new Error('All CoinGecko price chunks failed');
       }
-      // Total failure: throw so TQ marks errored + retries (default 3x
-      // with exp backoff). Returning {} here would cache an empty
-      // "success" and lock the same queryKey out of refetching.
-      throw new Error('All CoinGecko price chunks failed');
+      // Cache truth lives in Zustand + the idsToFetch filter; TQ is just
+      // a debounced trigger + retry mechanism. No staleTime / refetchOn*
+      // needed — queryKey content shifts on each successful merge.
+      return null;
     },
     enabled: idsToFetch.length > 0,
-    staleTime: PRICE_CACHE_MS,
-    refetchInterval: false,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
   });
 
-  // Flatten { usd, fetchedAt } → number for the consumer shape.
+  // Flatten the entry shape → bare USD numbers for consumers.
   const prices = useMemo(() => {
     const out: Record<string, number> = {};
     for (const [id, entry] of Object.entries(tokenPrices)) {

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -13,7 +13,10 @@ type MergeFn = (
 ) => void;
 
 const PRICE_CACHE_MS = 15 * 60_000;
-const FAILED_BACKOFF_MS = 30_000;
+// 90s clears CoinGecko's rolling 60s rate-limit window with breathing
+// room. Used for both the filter (skip failed IDs within this window)
+// and TQ's retry delay (one retry after this elapses).
+const FAILED_BACKOFF_MS = 90_000;
 // 100 keeps the URL well under the ~6KB Cloudflare 414 threshold. Chunks run
 // sequentially (free tier is ~5-15 req/min, parallel firing burns quota fast).
 const COINGECKO_BATCH = 100;
@@ -89,8 +92,12 @@ async function fetchTokenPrices(ids: string[], cache: PriceCache, merge: MergeFn
   const { requestedIds, prices } = await fetchPricesBatched(idsToFetch);
   const failedIds = idsToFetch.filter((id) => !requestedIds.includes(id));
   merge(requestedIds, prices, failedIds);
-  if (requestedIds.length === 0) {
-    throw new Error('All CoinGecko price chunks failed');
+  // Throw on ANY failed chunk so TQ marks the query errored and schedules
+  // the configured retry (see `retry` / `retryDelay` on useQuery). Successes
+  // are already merged into the store before the throw, so consumers see
+  // partial data immediately.
+  if (failedIds.length > 0) {
+    throw new Error(`CoinGecko fetch incomplete: ${failedIds.length} id(s) failed`);
   }
   return null;
 }
@@ -116,6 +123,10 @@ export function useTokenPricesByIds(ids: string[]): {
     enabled: debouncedIds.length > 0,
     refetchInterval: PRICE_CACHE_MS / 2,
     refetchOnWindowFocus: false,
+    // On partial/total failure: one retry after the rate-limit window
+    // elapses, then fall back to the normal refetchInterval cadence.
+    retry: 1,
+    retryDelay: FAILED_BACKOFF_MS,
   });
 
   // Flatten the entry shape → bare USD numbers for consumers.


### PR DESCRIPTION
## Summary

Unifies bridge and swap price fetching behind a single store-backed CoinGecko cache, and wires USD value into the swap form. Engine `/v1/tokens` now exposes `coinGeckoId` per token, so the swap side can finally key prices the same way the bridge does.

## Shared price cache

- New store field `tokenPrices: Record<string, { usd?, fetchedAt }>` + `mergeTokenPrices(requestedIds, fetched)`. Per-id `fetchedAt` so chain switches that grow the token catalogue only fetch the deltas; entries with `usd` absent are negative-cached so we don't retry IDs CoinGecko has no price for in a tight loop.
- New shared hook `useTokenPricesByIds(ids)` in `src/features/tokens/useTokenPrice.tsx` doing the delta-fetch into that cache. Batches at 250 IDs/request (CoinGecko free-tier rate-limits per-request, so bigger batches = fewer throttles). 1h cache. Bridge `useTokenPrices()` wraps it with the warpCore `coinGeckoIds`; swap `useTokenPrices()` wraps it with IDs derived + deduped from `knownTokens`. Overlapping IDs (ETH, USDC, ...) are fetched once total across both tabs.

## Failure handling

- `fetchPrices` throws on HTTP/network errors instead of swallowing into `{}` — lets the caller distinguish a real failure from a 200-OK-with-missing-IDs.
- `fetchPricesBatched` uses `Promise.allSettled` per-chunk so a 429 on one chunk doesn't poison the rest.
- queryFn: partial success merges what came back, next render's smaller `idsToFetch` fires a follow-up automatically. Total failure throws so TQ retries with default exponential backoff instead of caching an empty success.

## Stability

- Input `ids` is debounced (300ms) so rapid catalogue growth from the picker batches into one queryKey update — no overlapping in-flight fetches on the first page load. Debounced on input rather than the filter result so post-merge delta fetches fire without cascading 300ms waits.

## Swap UI

- New `useTokenUsdValue(token, amount)` convenience hook so origin + destination cards don't duplicate the price-lookup boilerplate. Coerces and strips grouping separators before `parseFloat` so a number/null/comma-formatted amount doesn't blow up.
- `SwapForm` shows `$1.23` next to the typed amount on origin and next to the expected output on destination. Destination row keeps the existing `Min: 0.99 ETH` indicator alongside USD.
- `getUsdValue` in `swap/balances/utils.ts` keys on `token.coinGeckoId` now that the engine provides it (was previously keying on lowercase symbol as a stopgap).