### PR TITLE
feat: add NES/bsc to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -424,6 +424,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // rise
   'RISE/bsc-ethereum',
 
+  // Nesa routes
+  'NES/bsc',
+
   // fluent
   'BLEND/fluent',
   'USDnr/usdnr',


### PR DESCRIPTION
Adds `NES/bsc` to the Nexus UI warp route whitelist.

| Field | Value |
| ----- | ----- |
| **Linear** | [AW-648](https://linear.app/hyperlane-xyz/issue/AW-648/nesa-nes-nesanativebscsynthetic) |
| **Warp route** | `NES/bsc` |