### PR TITLE
fix: resolve origin route token in form state for fee quoting

### DIFF
--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -498,19 +498,19 @@ function TransferCheckout({
   const warpCore = useWarpCore();
   const isRouteSupported = useIsRouteSupported();
 
-  // Resolve the origin token to a valid router for the selected pair.
-  // After Continue, validateForm stores the chosen multi-collateral / cross-asset token in
-  // routeOverrideToken, so use it directly to keep the offchain quote bound to the exact
-  // router. Before that (form state) routeOverrideToken is null, so fall back to
-  // findRouteToken — the raw key token may not be directly connected to the selected
-  // destination, which would leave destinationToken undefined and disable fee quoting.
+  // Origin router resolution, in priority: routeOverrideToken -> findRouteToken -> raw key token.
+  // routeOverrideToken (set by validateForm on Continue) binds to the exact validated router.
+  // In form state it's null, so findRouteToken resolves the connected route token — the raw key
+  // token may not directly connect to the destination, leaving destinationToken (and quoting) off.
+  // findRouteToken is undefined for unsupported pairs; the raw key token keeps the selection
+  // rendering (quoting stays gated off via destinationToken).
   const originTokenByKey = getTokenByKeyFromMap(tokenMap, values.originTokenKey);
   const destinationTokenByKey = getTokenByKeyFromMap(tokenMap, values.destinationTokenKey);
-  const originToken =
-    routeOverrideToken ||
-    (originTokenByKey && destinationTokenByKey
+  const routeToken =
+    !routeOverrideToken && originTokenByKey && destinationTokenByKey
       ? findRouteToken(warpCore, originTokenByKey, destinationTokenByKey)
-      : originTokenByKey);
+      : undefined;
+  const originToken = routeOverrideToken || routeToken || originTokenByKey;
   const destinationToken =
     originToken && destinationTokenByKey
       ? findConnectedDestinationToken(originToken, destinationTokenByKey)

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -58,7 +58,7 @@ import {
 import { ImportTokenButton } from '../tokens/ImportTokenButton';
 import { TokenSelectField } from '../tokens/TokenSelectField';
 import { useTokenPrices } from '../tokens/useTokenPrice';
-import { checkTokenHasRoute, findConnectedDestinationToken } from '../tokens/utils';
+import { checkTokenHasRoute, findConnectedDestinationToken, findRouteToken } from '../tokens/utils';
 import { WalletConnectionWarning } from '../wallet/WalletConnectionWarning';
 import { WalletDropdown } from '../wallet/WalletDropdown';
 import { getInterchainQuote, getTotalFee, getTransferToken } from './fees';
@@ -495,15 +495,22 @@ function TransferCheckout({
 }) {
   const { values } = useFormikContext<TransferFormValues>();
   const tokenMap = useTokenByKeyMap();
+  const warpCore = useWarpCore();
   const isRouteSupported = useIsRouteSupported();
 
-  // Use the same origin-token resolution as ButtonSection / executeTransfer so
-  // the offchain quote is bound to the same router the transfer will actually
-  // call. validateForm has already produced the multi-collateral / cross-asset
-  // optimal token and stored it in routeOverrideToken — no extra findRouteToken
-  // pass here.
-  const originToken = routeOverrideToken || getTokenByKeyFromMap(tokenMap, values.originTokenKey);
+  // Resolve the origin token to a valid router for the selected pair.
+  // After Continue, validateForm stores the chosen multi-collateral / cross-asset token in
+  // routeOverrideToken, so use it directly to keep the offchain quote bound to the exact
+  // router. Before that (form state) routeOverrideToken is null, so fall back to
+  // findRouteToken — the raw key token may not be directly connected to the selected
+  // destination, which would leave destinationToken undefined and disable fee quoting.
+  const originTokenByKey = getTokenByKeyFromMap(tokenMap, values.originTokenKey);
   const destinationTokenByKey = getTokenByKeyFromMap(tokenMap, values.destinationTokenKey);
+  const originToken =
+    routeOverrideToken ||
+    (originTokenByKey && destinationTokenByKey
+      ? findRouteToken(warpCore, originTokenByKey, destinationTokenByKey)
+      : originTokenByKey);
   const destinationToken =
     originToken && destinationTokenByKey
       ? findConnectedDestinationToken(originToken, destinationTokenByKey)


### PR DESCRIPTION
## Problem

The fee section showed `Fees: -` in the transfer form and never populated while typing an amount — it only resolved after clicking **Continue**.

## Cause

`TransferCheckout` resolves the origin token as `routeOverrideToken || rawKeyToken`. `routeOverrideToken` is only populated by `validateForm` on Continue, so in form state the origin is the raw key token. For multi-collateral routes (e.g. ETH ethereum → ETH arbitrum) that token isn't directly connected to the selected destination, so `findConnectedDestinationToken` returns `undefined` → `destinationToken`/`destination` undefined → both the onchain (`useFeeQuotes`) and offchain (`useQuotedCallsFeeQuotes`) quote gates are disabled.

A prior refactor dropped the `findRouteToken` resolution that previously ran unconditionally in `ReviewDetails`.

## Fix

Restore the `findRouteToken` fallback in `TransferCheckout` when `routeOverrideToken` is null (form state), and keep `routeOverrideToken` after Continue so the offchain quote / transfer stay bound to the exact validated router. The multi-collateral token selection (default route or balance-based) still runs async in `getTransferToken` inside `fetchFeeQuotes` (form) and `validateForm` (transfer); both start from `findRouteToken`, so the synchronous render gate stays consistent.

## Verification

- `pnpm typecheck`, `pnpm lint` (oxlint), `pnpm format` (oxfmt) clean
- `pnpm test:e2e` (chromium) green
- Manually confirmed fees populate in the form for ETH ethereum → ETH arbitrum without clicking Continue