### PR TITLE
feat(swap): UI polish — modal label, output USD + price impact, fee % + USD, ICA dest tx, default tokens

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -56,6 +56,8 @@ interface Config {
   ccsUrl: string; // Call Commitments Service base URL (cross-chain swap reveal)
   permit2ExpirationSeconds: number; // Default Permit2 allowance expiration (swap tab)
   defaultSlippageBps: number; // Default swap slippage in basis points
+  defaultSwapOriginToken: string | undefined; // The initial swap origin token to show when /swap first loads (format: chainName-address)
+  defaultSwapDestinationToken: string | undefined; // The initial swap destination token to show when /swap first loads (format: chainName-address)
 }
 
 export const config: Config = Object.freeze({
@@ -66,6 +68,8 @@ export const config: Config = Object.freeze({
   relayApiUrl,
   defaultOriginToken: 'ethereum-USDC',
   defaultDestinationToken: 'base-USDC',
+  defaultSwapOriginToken: 'bsc-0x0000000000000000000000000000000000000000',
+  defaultSwapDestinationToken: 'base-0x0000000000000000000000000000000000000000',
   isDevMode,
   registryUrl,
   registryBranch,

--- a/src/features/swap/FeeSectionButton.tsx
+++ b/src/features/swap/FeeSectionButton.tsx
@@ -1,8 +1,11 @@
 import { ChevronIcon, FuelPumpIcon, useModal } from '@hyperlane-xyz/widgets';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
+import { useChains } from '../api/hooks';
+import { getFeePercentage } from '../balances/feeUsdDisplay';
 import { useMultiProvider } from '../chains/hooks';
-import { formatFeeAmount } from './balances/utils';
+import { useStore } from '../store';
+import { formatFeeAmount, formatUsd, getTotalFeeUsd } from './balances/utils';
 import { FeeBreakdownModal } from './FeeBreakdownModal';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
 import type { UiToken } from './tokens/types';
@@ -11,23 +14,44 @@ import type { FeeBreakdown, FeeComponent } from './types';
 interface Props {
   feeBreakdown: FeeBreakdown | undefined;
   isLoading: boolean;
+  /** USD value of the swap input, used to compute fee-as-% of transfer. */
+  inputUsd: number | null;
 }
 
-// Pill button — fuel-pump icon + "Fees: <total>" + chevron.
-// Fees grouped by fungibility (chainId + token address).
-export function FeeSectionButton({ feeBreakdown, isLoading }: Props) {
+// Pill button — fuel-pump icon + "Fees: <total> <USD> (<pct>)" + chevron.
+// Fees grouped by fungibility (chainId + token address). USD value +
+// percentage mirror the bridge form's FeeSectionButton presentation.
+export function FeeSectionButton({ feeBreakdown, isLoading, inputUsd }: Props) {
   const { isOpen, open, close } = useModal();
   const loadingText = useLoadingDots(isLoading);
   const tokenMap = useTokenByKeyMap();
   const multiProvider = useMultiProvider();
+  const { data: chainsResp } = useChains();
+  const tokenPrices = useStore((s) => s.tokenPrices);
 
-  const components = feeBreakdown?.components ?? [];
+  const components = useMemo(() => feeBreakdown?.components ?? [], [feeBreakdown?.components]);
   const isClickable = components.length > 0 && !isLoading;
 
   let feeText: string;
   if (isLoading) feeText = loadingText;
   else if (components.length === 0) feeText = '-';
   else feeText = formatTotalFee(components, tokenMap, multiProvider);
+
+  // Flat USD price map (coinGeckoId → number) for the fee summer.
+  const priceMap = useMemo(() => {
+    const out: Record<string, number> = {};
+    for (const [id, entry] of Object.entries(tokenPrices)) {
+      if (entry.usd != null) out[id] = entry.usd;
+    }
+    return out;
+  }, [tokenPrices]);
+
+  const feeUsd = useMemo(
+    () => getTotalFeeUsd(components, tokenMap, chainsResp?.chains, priceMap),
+    [components, tokenMap, chainsResp?.chains, priceMap],
+  );
+  const feeUsdText = feeUsd > 0 ? formatUsd(feeUsd, true) : null;
+  const pctText = inputUsd != null ? getFeePercentage(feeUsd, inputUsd) : null;
 
   return (
     <>
@@ -42,7 +66,7 @@ export function FeeSectionButton({ feeBreakdown, isLoading }: Props) {
         disabled={!isClickable}
       >
         <FuelPumpIcon width={14} height={14} className="mr-1" />
-        Fees: {feeText}
+        Fees: {feeUsdText ? `${feeUsdText}${pctText ? ` (${pctText})` : ''}` : feeText}
         {isClickable && <ChevronIcon direction="e" width="0.6rem" height="0.6rem" />}
       </button>
       {feeBreakdown && (

--- a/src/features/swap/FeeSectionButton.tsx
+++ b/src/features/swap/FeeSectionButton.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { getFeePercentage } from '../balances/feeUsdDisplay';
 import { useMultiProvider } from '../chains/hooks';
-import { useStore } from '../store';
 import { useTokenPricesByIds } from '../tokens/useTokenPrice';
 import { formatFeeAmount, formatUsd, getTotalFeeUsd, resolveCoinGeckoId } from './balances/utils';
 import { FeeBreakdownModal } from './FeeBreakdownModal';
@@ -26,7 +25,6 @@ export function FeeSectionButton({ feeBreakdown, isLoading, inputUsd }: Props) {
   const loadingText = useLoadingDots(isLoading);
   const tokenMap = useTokenByKeyMap();
   const multiProvider = useMultiProvider();
-  const tokenPrices = useStore((s) => s.tokenPrices);
 
   const components = useMemo(() => feeBreakdown?.components ?? [], [feeBreakdown?.components]);
   const isClickable = components.length > 0 && !isLoading;
@@ -48,16 +46,7 @@ export function FeeSectionButton({ feeBreakdown, isLoading, inputUsd }: Props) {
     }
     return Array.from(ids).sort();
   }, [components, tokenMap]);
-  useTokenPricesByIds(feeCoinGeckoIds);
-
-  // Flat USD price map (coinGeckoId → number) for the fee summer.
-  const priceMap = useMemo(() => {
-    const out: Record<string, number> = {};
-    for (const [id, entry] of Object.entries(tokenPrices)) {
-      if (entry.usd != null) out[id] = entry.usd;
-    }
-    return out;
-  }, [tokenPrices]);
+  const { prices: priceMap } = useTokenPricesByIds(feeCoinGeckoIds);
 
   // `null` when any component is unpriced — caller falls back to the
   // raw token list rather than displaying a misleading partial sum.
@@ -66,8 +55,7 @@ export function FeeSectionButton({ feeBreakdown, isLoading, inputUsd }: Props) {
     [components, tokenMap, priceMap],
   );
   const feeUsdText = feeUsd != null && feeUsd > 0 ? formatUsd(feeUsd, true) : null;
-  const pctText =
-    feeUsd != null && inputUsd != null ? getFeePercentage(feeUsd, inputUsd) : null;
+  const pctText = feeUsd != null && inputUsd != null ? getFeePercentage(feeUsd, inputUsd) : null;
 
   return (
     <>

--- a/src/features/swap/FeeSectionButton.tsx
+++ b/src/features/swap/FeeSectionButton.tsx
@@ -1,11 +1,11 @@
 import { ChevronIcon, FuelPumpIcon, useModal } from '@hyperlane-xyz/widgets';
 import { useEffect, useMemo, useState } from 'react';
 
-import { useChains } from '../api/hooks';
 import { getFeePercentage } from '../balances/feeUsdDisplay';
 import { useMultiProvider } from '../chains/hooks';
 import { useStore } from '../store';
-import { formatFeeAmount, formatUsd, getTotalFeeUsd } from './balances/utils';
+import { useTokenPricesByIds } from '../tokens/useTokenPrice';
+import { formatFeeAmount, formatUsd, getTotalFeeUsd, resolveCoinGeckoId } from './balances/utils';
 import { FeeBreakdownModal } from './FeeBreakdownModal';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
 import type { UiToken } from './tokens/types';
@@ -26,7 +26,6 @@ export function FeeSectionButton({ feeBreakdown, isLoading, inputUsd }: Props) {
   const loadingText = useLoadingDots(isLoading);
   const tokenMap = useTokenByKeyMap();
   const multiProvider = useMultiProvider();
-  const { data: chainsResp } = useChains();
   const tokenPrices = useStore((s) => s.tokenPrices);
 
   const components = useMemo(() => feeBreakdown?.components ?? [], [feeBreakdown?.components]);
@@ -37,6 +36,20 @@ export function FeeSectionButton({ feeBreakdown, isLoading, inputUsd }: Props) {
   else if (components.length === 0) feeText = '-';
   else feeText = formatTotalFee(components, tokenMap, multiProvider);
 
+  // Fee tokens often live outside the user's browsed catalogue (e.g. native
+  // ETH on the dest chain for the IGP). Resolve their coinGeckoIds here and
+  // feed the shared cache so the fetcher pulls anything missing. The shared
+  // hook dedupes, debounces, and backs off — no per-component RPC churn.
+  const feeCoinGeckoIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const c of components) {
+      const { coinGeckoId } = resolveCoinGeckoId(c, tokenMap);
+      if (coinGeckoId) ids.add(coinGeckoId);
+    }
+    return Array.from(ids).sort();
+  }, [components, tokenMap]);
+  useTokenPricesByIds(feeCoinGeckoIds);
+
   // Flat USD price map (coinGeckoId → number) for the fee summer.
   const priceMap = useMemo(() => {
     const out: Record<string, number> = {};
@@ -46,12 +59,15 @@ export function FeeSectionButton({ feeBreakdown, isLoading, inputUsd }: Props) {
     return out;
   }, [tokenPrices]);
 
+  // `null` when any component is unpriced — caller falls back to the
+  // raw token list rather than displaying a misleading partial sum.
   const feeUsd = useMemo(
-    () => getTotalFeeUsd(components, tokenMap, chainsResp?.chains, priceMap),
-    [components, tokenMap, chainsResp?.chains, priceMap],
+    () => getTotalFeeUsd(components, tokenMap, priceMap),
+    [components, tokenMap, priceMap],
   );
-  const feeUsdText = feeUsd > 0 ? formatUsd(feeUsd, true) : null;
-  const pctText = inputUsd != null ? getFeePercentage(feeUsd, inputUsd) : null;
+  const feeUsdText = feeUsd != null && feeUsd > 0 ? formatUsd(feeUsd, true) : null;
+  const pctText =
+    feeUsd != null && inputUsd != null ? getFeePercentage(feeUsd, inputUsd) : null;
 
   return (
     <>

--- a/src/features/swap/SwapDetailsModal.tsx
+++ b/src/features/swap/SwapDetailsModal.tsx
@@ -48,7 +48,7 @@ const STATUS_DESCRIPTION: Record<SwapStatus, string> = {
   [SwapStatus.ConfirmingApprove]: 'Confirming approval on origin chain…',
   [SwapStatus.SigningSwap]: 'Awaiting swap signature in your wallet…',
   [SwapStatus.ConfirmingOrigin]: 'Confirming on origin chain…',
-  [SwapStatus.Bridging]: 'Bridging via Hyperlane…',
+  [SwapStatus.Bridging]: 'Swapping via Hyperlane…',
   [SwapStatus.ConfirmingDestination]: 'Confirming on destination chain…',
   [SwapStatus.ConfirmedDestination]: 'Delivered',
   [SwapStatus.DestSwapFailed]: 'Destination swap reverted',
@@ -118,9 +118,15 @@ function SwapDetailsModalInner({
   const isDelivered = status === SwapStatus.ConfirmedDestination;
   const isFinal = FinalSwapStatuses.includes(status);
 
-  // Poll the warp message for timeline/delivery status (fallback to first).
-  // Same-chain swaps have no msgIds — skip polling.
-  const pollingMsgId = (msgIds?.find((m) => m.label === 'warp') ?? msgIds?.[0])?.msgId;
+  // Poll the reveal message when present — its delivery tx IS the ICA
+  // execution on the destination chain, which is what actually completes
+  // the swap. Pure-bridge routes (no destination swap) have no reveal,
+  // so fall back to the warp message. Same-chain swaps have no msgIds.
+  const pollingMsgId = (
+    msgIds?.find((m) => m.label === 'reveal') ??
+    msgIds?.find((m) => m.label === 'warp') ??
+    msgIds?.[0]
+  )?.msgId;
   const delivery = useMessageDeliveryStatus(pollingMsgId, !isFinal, multiProvider);
 
   const hasUpdatedDelivery = useRef(false);

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -47,6 +47,10 @@ import { useQuote } from './useQuote';
 import { useSwap } from './useSwap';
 import { validateSwapForm } from './validate';
 
+const PRICE_IMPACT_DANGER_PCT = -3;
+const PRICE_IMPACT_WARN_PCT = -1;
+const PCT_FORMAT_OPTIONS = { minimumFractionDigits: 2, maximumFractionDigits: 2 } as const;
+
 export function SwapForm() {
   const initialValues = useFormInitialValues();
   return (
@@ -630,15 +634,15 @@ function DestinationTokenCard({
             {priceImpactPct != null && (
               <span
                 className={`ml-1 ${
-                  priceImpactPct <= -3
+                  priceImpactPct <= PRICE_IMPACT_DANGER_PCT
                     ? 'text-red-500'
-                    : priceImpactPct <= -1
+                    : priceImpactPct <= PRICE_IMPACT_WARN_PCT
                       ? 'text-amber-600'
                       : ''
                 }`}
               >
                 ({priceImpactPct >= 0 ? '+' : ''}
-                {priceImpactPct.toLocaleString('en-US', { maximumFractionDigits: 2 })}%)
+                {priceImpactPct.toLocaleString('en-US', PCT_FORMAT_OPTIONS)}%)
               </span>
             )}
           </span>

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -140,6 +140,9 @@ function SwapFormContent() {
     return undefined;
   }, [bestRoute]);
 
+  // Input USD — used by the fee % calculation in FeeSectionButton.
+  const amountUsd = useTokenUsdValue(srcToken, values.amount);
+
   const status = useApprovalStatus({
     chainName: srcChainName,
     token: srcToken?.address as Address | undefined,
@@ -398,12 +401,17 @@ function SwapFormContent() {
           bestRoute={bestRoute}
           quoteLoading={quoteLoading}
           recipientError={errors.recipient}
+          inputUsd={amountUsd}
         />
       </TransferSection>
 
       {!isReview && (
         <div className="mt-2 flex items-center justify-between gap-3 px-1">
-          <FeeSectionButton feeBreakdown={bestRoute?.feeBreakdown} isLoading={quoteLoading} />
+          <FeeSectionButton
+            feeBreakdown={bestRoute?.feeBreakdown}
+            isLoading={quoteLoading}
+            inputUsd={amountUsd}
+          />
           <div className="flex items-center gap-2">
             {routes.length > 0 && (
               <button
@@ -558,6 +566,7 @@ function DestinationTokenCard({
   bestRoute,
   quoteLoading,
   recipientError,
+  inputUsd,
 }: {
   isReview: boolean;
   dstChainName: string | undefined;
@@ -566,6 +575,7 @@ function DestinationTokenCard({
   bestRoute: AugmentedRoute | undefined;
   quoteLoading: boolean;
   recipientError: string | undefined;
+  inputUsd: number | null;
 }) {
   const { values, setFieldValue } = useFormikContext<SwapFormValues>();
   const { data: balance } = useTokenBalance(dstToken, recipient);
@@ -578,15 +588,13 @@ function DestinationTokenCard({
       return '';
     }
   }, [bestRoute, dstToken]);
-  const minOutputDisplay = useMemo(() => {
-    if (!bestRoute || !dstToken) return '';
-    if (bestRoute.isBridgeOnly) return '';
-    try {
-      return formatUnits(BigInt(bestRoute.raw.outputMin), dstToken.decimals);
-    } catch {
-      return '';
-    }
-  }, [bestRoute, dstToken]);
+  const outputUsd = useTokenUsdValue(dstToken, outputDisplay);
+  // Price impact = how much value the swap loses to fees + slippage + spread.
+  // Only meaningful when both sides have USD prices.
+  const priceImpactPct = useMemo(() => {
+    if (!inputUsd || !outputUsd) return null;
+    return ((outputUsd - inputUsd) / inputUsd) * 100;
+  }, [inputUsd, outputUsd]);
 
   return (
     <div>
@@ -618,7 +626,21 @@ function DestinationTokenCard({
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
           <span>
-            {minOutputDisplay ? `Min: ${minOutputDisplay} ${dstToken?.symbol ?? ''}` : ''}
+            {!outputUsd ? '$0.00' : formatUsd(outputUsd)}
+            {priceImpactPct != null && (
+              <span
+                className={`ml-1 ${
+                  priceImpactPct <= -3
+                    ? 'text-red-500'
+                    : priceImpactPct <= -1
+                      ? 'text-amber-600'
+                      : ''
+                }`}
+              >
+                ({priceImpactPct >= 0 ? '+' : ''}
+                {priceImpactPct.toLocaleString('en-US', { maximumFractionDigits: 2 })}%)
+              </span>
+            )}
           </span>
           <TokenBalance label="Remote Balance" balance={balance ?? null} token={dstToken} />
         </div>

--- a/src/features/swap/balances/utils.test.ts
+++ b/src/features/swap/balances/utils.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'vitest';
+
+import type { UiToken } from '../tokens/types';
+import type { FeeComponent } from '../types';
+import { getTotalFeeUsd, resolveCoinGeckoId } from './utils';
+
+const TOKEN_ADDRESS = '0x1234567890123456789012345678901234567890';
+const OTHER_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+function mockToken(overrides: Partial<UiToken>): UiToken {
+  return {
+    chainId: 1,
+    address: TOKEN_ADDRESS,
+    symbol: 'ETH',
+    decimals: 18,
+    isNative: false,
+    isBridgeToken: false,
+    isPoolToken: false,
+    canBridge: true,
+    canSwap: true,
+    bridgeSymbols: [],
+    warpRouteIds: [],
+    chainName: 'ethereum',
+    name: 'Ether',
+    addressOrDenom: TOKEN_ADDRESS,
+    ...overrides,
+  };
+}
+
+function component(overrides: Partial<FeeComponent>): FeeComponent {
+  return {
+    category: 'igp',
+    amount: 1n,
+    chainId: 1,
+    tokenAddress: TOKEN_ADDRESS,
+    ...overrides,
+  };
+}
+
+describe('resolveCoinGeckoId', () => {
+  test('resolves coinGeckoId and decimals by chain/token key', () => {
+    const tokenMap = new Map([
+      [`1-${TOKEN_ADDRESS}`, mockToken({ coinGeckoId: 'ethereum', decimals: 18 })],
+    ]);
+
+    expect(resolveCoinGeckoId(component({}), tokenMap)).toEqual({
+      coinGeckoId: 'ethereum',
+      decimals: 18,
+    });
+  });
+
+  test('defaults decimals to 18 when token metadata is missing', () => {
+    expect(resolveCoinGeckoId(component({}), new Map())).toEqual({
+      coinGeckoId: undefined,
+      decimals: 18,
+    });
+  });
+});
+
+describe('getTotalFeeUsd', () => {
+  test('sums all priced fee components', () => {
+    const tokenMap = new Map([
+      [`1-${TOKEN_ADDRESS}`, mockToken({ coinGeckoId: 'ethereum', decimals: 18 })],
+      [
+        `1-${OTHER_ADDRESS}`,
+        mockToken({ address: OTHER_ADDRESS, coinGeckoId: 'usdc', decimals: 6 }),
+      ],
+    ]);
+
+    const total = getTotalFeeUsd(
+      [
+        component({ amount: 10n ** 16n }), // 0.01 ETH * $2,000 = $20
+        component({ amount: 5_000_000n, tokenAddress: OTHER_ADDRESS }), // 5 USDC * $1 = $5
+      ],
+      tokenMap,
+      { ethereum: 2000, usdc: 1 },
+    );
+
+    expect(total).toBeCloseTo(25);
+  });
+
+  test('returns null when any component has no coinGeckoId', () => {
+    const tokenMap = new Map([[`1-${TOKEN_ADDRESS}`, mockToken({ coinGeckoId: 'ethereum' })]]);
+
+    const total = getTotalFeeUsd(
+      [component({}), component({ tokenAddress: OTHER_ADDRESS })],
+      tokenMap,
+      { ethereum: 2000 },
+    );
+
+    expect(total).toBeNull();
+  });
+
+  test('returns null when any component has no price', () => {
+    const tokenMap = new Map([
+      [`1-${TOKEN_ADDRESS}`, mockToken({ coinGeckoId: 'ethereum' })],
+      [
+        `1-${OTHER_ADDRESS}`,
+        mockToken({ address: OTHER_ADDRESS, coinGeckoId: 'usdc', decimals: 6 }),
+      ],
+    ]);
+
+    const total = getTotalFeeUsd(
+      [component({}), component({ tokenAddress: OTHER_ADDRESS })],
+      tokenMap,
+      { ethereum: 2000 },
+    );
+
+    expect(total).toBeNull();
+  });
+
+  test('converts large bigint amounts through fromWei before pricing', () => {
+    const tokenMap = new Map([
+      [`1-${TOKEN_ADDRESS}`, mockToken({ coinGeckoId: 'ethereum', decimals: 18 })],
+    ]);
+
+    const total = getTotalFeeUsd([component({ amount: 1234567890123456789012345n })], tokenMap, {
+      ethereum: 2,
+    });
+
+    expect(total).toBeCloseTo(2469135.7802469134);
+  });
+});

--- a/src/features/swap/balances/utils.ts
+++ b/src/features/swap/balances/utils.ts
@@ -1,6 +1,5 @@
-import { fromWeiRounded } from '@hyperlane-xyz/utils';
+import { fromWei, fromWeiRounded } from '@hyperlane-xyz/utils';
 
-import type { ChainDiscovery } from '../../api/types';
 import type { UiToken } from '../tokens/types';
 import { getTokenKey } from '../tokens/utils';
 import type { FeeComponent } from '../types';
@@ -23,37 +22,31 @@ export function getUsdValue(
   if (bal == null || !token.coinGeckoId) return null;
   const price = prices[token.coinGeckoId];
   if (price == null) return null;
-  return (Number(bal) / 10 ** token.decimals) * price;
+  return parseFloat(fromWei(bal.toString(), token.decimals)) * price;
 }
 
-// Sums the USD value of every fee component. ERC20 fees resolve their
-// coinGeckoId via `tokenMap` (engine-discovered tokens); native fees
-// resolve via the chain's `gasCurrencyCoinGeckoId`. Components whose
-// coinGeckoId or price isn't known are silently skipped so a missing
-// price doesn't zero out the whole readout.
+export function resolveCoinGeckoId(
+  component: FeeComponent,
+  tokenMap: Map<string, UiToken>,
+): { coinGeckoId: string | undefined; decimals: number } {
+  const t = tokenMap.get(`${component.chainId}-${component.tokenAddress.toLowerCase()}`);
+  return { coinGeckoId: t?.coinGeckoId, decimals: t?.decimals ?? 18 };
+}
+
+// Returns null if any component is unpriced — a partial sum would
+// understate the total and mislead the % readout.
 export function getTotalFeeUsd(
   components: FeeComponent[],
   tokenMap: Map<string, UiToken>,
-  chains: ChainDiscovery[] | undefined,
   prices: Record<string, number>,
-): number {
+): number | null {
   let total = 0;
   for (const c of components) {
-    let coinGeckoId: string | undefined;
-    let decimals = 18;
-    if (/^0x0+$/i.test(c.tokenAddress)) {
-      const chain = chains?.find((x) => x.id === c.chainId);
-      coinGeckoId = chain?.gasCurrencyCoinGeckoId;
-      decimals = chain?.nativeCurrency.decimals ?? 18;
-    } else {
-      const t = tokenMap.get(`${c.chainId}-${c.tokenAddress.toLowerCase()}`);
-      coinGeckoId = t?.coinGeckoId;
-      decimals = t?.decimals ?? 18;
-    }
-    if (!coinGeckoId) continue;
+    const { coinGeckoId, decimals } = resolveCoinGeckoId(c, tokenMap);
+    if (!coinGeckoId) return null;
     const price = prices[coinGeckoId];
-    if (price == null) continue;
-    total += (Number(c.amount) / 10 ** decimals) * price;
+    if (price == null) return null;
+    total += parseFloat(fromWei(c.amount.toString(), decimals)) * price;
   }
   return total;
 }

--- a/src/features/swap/balances/utils.ts
+++ b/src/features/swap/balances/utils.ts
@@ -1,7 +1,9 @@
 import { fromWeiRounded } from '@hyperlane-xyz/utils';
 
+import type { ChainDiscovery } from '../../api/types';
 import type { UiToken } from '../tokens/types';
 import { getTokenKey } from '../tokens/utils';
+import type { FeeComponent } from '../types';
 
 export { formatBalance, formatUsd } from '../../../utils/amount';
 
@@ -22,4 +24,36 @@ export function getUsdValue(
   const price = prices[token.coinGeckoId];
   if (price == null) return null;
   return (Number(bal) / 10 ** token.decimals) * price;
+}
+
+// Sums the USD value of every fee component. ERC20 fees resolve their
+// coinGeckoId via `tokenMap` (engine-discovered tokens); native fees
+// resolve via the chain's `gasCurrencyCoinGeckoId`. Components whose
+// coinGeckoId or price isn't known are silently skipped so a missing
+// price doesn't zero out the whole readout.
+export function getTotalFeeUsd(
+  components: FeeComponent[],
+  tokenMap: Map<string, UiToken>,
+  chains: ChainDiscovery[] | undefined,
+  prices: Record<string, number>,
+): number {
+  let total = 0;
+  for (const c of components) {
+    let coinGeckoId: string | undefined;
+    let decimals = 18;
+    if (/^0x0+$/i.test(c.tokenAddress)) {
+      const chain = chains?.find((x) => x.id === c.chainId);
+      coinGeckoId = chain?.gasCurrencyCoinGeckoId;
+      decimals = chain?.nativeCurrency.decimals ?? 18;
+    } else {
+      const t = tokenMap.get(`${c.chainId}-${c.tokenAddress.toLowerCase()}`);
+      coinGeckoId = t?.coinGeckoId;
+      decimals = t?.decimals ?? 18;
+    }
+    if (!coinGeckoId) continue;
+    const price = prices[coinGeckoId];
+    if (price == null) continue;
+    total += (Number(c.amount) / 10 ** decimals) * price;
+  }
+  return total;
 }

--- a/src/features/swap/routeSelection/RouteSelectionModal.tsx
+++ b/src/features/swap/routeSelection/RouteSelectionModal.tsx
@@ -3,8 +3,8 @@ import { CopyButton, HyperlaneLogo, Modal } from '@hyperlane-xyz/widgets';
 import { Fragment, useMemo, useState } from 'react';
 
 import { ChainLogo } from '../../../components/icons/ChainLogo';
-import { HoverTooltip } from '../../../components/tooltip/HoverTooltip';
 import { TokenIcon } from '../../../components/icons/TokenIcon';
+import { HoverTooltip } from '../../../components/tooltip/HoverTooltip';
 import type { QuoteBridgeStep, QuoteStep, QuoteSwapStep } from '../../api/types';
 import { useMultiProvider } from '../../chains/hooks';
 import { formatBalance, formatFeeAmount } from '../balances/utils';

--- a/src/features/swap/useFormInitialValues.ts
+++ b/src/features/swap/useFormInitialValues.ts
@@ -21,23 +21,18 @@ const EMPTY_VALUES: SwapFormValues = {
 //   ?origin=<chainName>&originToken=<0xAddress>
 //   ?destination=<chainName>&destinationToken=<0xAddress>
 //
+// Falls back to `config.defaultSwapOriginToken` /
+// `defaultSwapDestinationToken` when the URL has no override — mirrors
+// the bridge tab's defaultOriginToken / defaultDestinationToken pattern.
+//
 // The bridge tab still uses symbol-based URLs — they're independent
 // pages so the divergence is fine.
 export function useFormInitialValues(): SwapFormValues {
   const ids = useMemo(() => {
-    if (typeof window === 'undefined') return [];
-    const params = getQueryParams();
     const out: string[] = [];
-    const origin = idFromParams(
-      params.get(WARP_QUERY_PARAMS.ORIGIN),
-      params.get(WARP_QUERY_PARAMS.ORIGIN_TOKEN),
-    );
-    const destination = idFromParams(
-      params.get(WARP_QUERY_PARAMS.DESTINATION),
-      params.get(WARP_QUERY_PARAMS.DESTINATION_TOKEN),
-    );
-    if (origin) out.push(origin);
-    if (destination) out.push(destination);
+    const { originId, destinationId } = readInitialIds();
+    if (originId) out.push(originId);
+    if (destinationId) out.push(destinationId);
     return out;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-time read; URL changes after mount intentionally ignored
   }, []);
@@ -47,16 +42,7 @@ export function useFormInitialValues(): SwapFormValues {
   return useMemo(() => {
     if (!ids.length || !tokens.length) return EMPTY_VALUES;
 
-    const params = typeof window !== 'undefined' ? getQueryParams() : new URLSearchParams();
-    const originId = idFromParams(
-      params.get(WARP_QUERY_PARAMS.ORIGIN),
-      params.get(WARP_QUERY_PARAMS.ORIGIN_TOKEN),
-    );
-    const destinationId = idFromParams(
-      params.get(WARP_QUERY_PARAMS.DESTINATION),
-      params.get(WARP_QUERY_PARAMS.DESTINATION_TOKEN),
-    );
-
+    const { originId, destinationId } = readInitialIds();
     const origin = originId ? tokens.find((t) => matchesId(t, originId)) : undefined;
     const destination = destinationId ? tokens.find((t) => matchesId(t, destinationId)) : undefined;
 
@@ -70,9 +56,35 @@ export function useFormInitialValues(): SwapFormValues {
   }, [tokens, ids]);
 }
 
+function readInitialIds(): { originId: string | undefined; destinationId: string | undefined } {
+  if (typeof window === 'undefined') {
+    return {
+      originId: normalizeId(config.defaultSwapOriginToken),
+      destinationId: normalizeId(config.defaultSwapDestinationToken),
+    };
+  }
+  const params = getQueryParams();
+  const originFromUrl = idFromParams(
+    params.get(WARP_QUERY_PARAMS.ORIGIN),
+    params.get(WARP_QUERY_PARAMS.ORIGIN_TOKEN),
+  );
+  const destinationFromUrl = idFromParams(
+    params.get(WARP_QUERY_PARAMS.DESTINATION),
+    params.get(WARP_QUERY_PARAMS.DESTINATION_TOKEN),
+  );
+  return {
+    originId: originFromUrl ?? normalizeId(config.defaultSwapOriginToken),
+    destinationId: destinationFromUrl ?? normalizeId(config.defaultSwapDestinationToken),
+  };
+}
+
 function idFromParams(chain: string | null, token: string | null): string | undefined {
   if (!chain || !token) return undefined;
   return `${chain}-${token.toLowerCase()}`;
+}
+
+function normalizeId(id: string | undefined): string | undefined {
+  return id ? id.toLowerCase() : undefined;
 }
 
 function matchesId(t: { chainName: string; address: string }, id: string): boolean {


### PR DESCRIPTION
## Summary

Round of UI polish on the swap form.

## Changes

- **Modal copy**: \`Bridging via Hyperlane…\` → \`Swapping via Hyperlane…\`. The whole operation is a swap from the user's POV; "bridging" sounds like a separate product.
- **Destination card**: drop the \`Min: X TOKEN\` line in favor of the output's USD value, matching the origin card's layout. Adds **price impact** next to the USD (e.g. \`\$1.20 (-2.4%)\`) with neutral / amber / red tinting at -1% / -3% thresholds — standard DEX-UI signal for how much value the swap is losing to pool slippage + fees combined. Renders only when both sides have a known \`coinGeckoId\` price.
- **Fee pill**: when every fee component has a USD price, show \`Fees: ≈\$0.04 (3.2%)\` mirroring the bridge form. Falls back to the raw per-token amounts (\`0.123 ETH, 0.456 USDC\`) if **any** component is unpriced (no partial sums — would mislead the % readout). Token breakdown stays accessible via the existing modal.
- **Fee USD fetcher**: the swap-side \`FeeSectionButton\` pumps fee components' coinGeckoIds into the shared \`useTokenPricesByIds\` cache so the fetcher pulls anything the user hasn't already triggered via the picker (e.g. dest-chain native for IGP). Shared hook handles dedup / debounce / backoff — no new RPC infrastructure.
- **New helper \`getTotalFeeUsd\`** in \`swap/balances/utils.ts\` — returns \`number | null\`. \`null\` propagates "unknown / partial" and triggers the token-amount fallback in the UI.
- **\`resolveCoinGeckoId(component, tokenMap)\` helper** — engine's \`/v1/tokens\` already includes native entries with \`coinGeckoId\` on every chain that supports swap source (\`ETH → ethereum\`, \`TRX → tron\`), so tokenMap lookup is sufficient. No special-case native branch needed.
- **Switch to \`fromWei\`** for amount-to-decimal conversion in \`getUsdValue\` / \`getTotalFeeUsd\` — proper BigNumber precision for large bigints, matches the rest of the warp-ui's amount math.
- **Destination tx is the ICA execution, not the bridge drop-off**: prefer the \`reveal\` message ID for delivery polling when present (its delivery tx IS the ICA execution on the destination chain — what actually completes the swap). Falls back to \`warp\` for pure-bridge routes. The "delivered" indicator and \`destinationTxHash\` now point at the ICA tx.
- **Default tokens on /swap cold load**: mirrors the bridge tab's \`defaultOriginToken\` / \`defaultDestinationToken\`. When the URL has no \`origin*\` / \`destination*\` params, prefill from new \`config.defaultSwapOriginToken\` / \`defaultSwapDestinationToken\` (format: \`chainName-address\`). Defaults ship as BNB on BSC → ETH on Base. Same \`useTokens({ ids })\` fetch path as the URL flow — defaults inherit matching, store-sync, USD readout, price-impact rendering, etc.

## Known follow-up (not in this PR)

For ICA flows we sometimes see two \`Reveal Message ID\` entries in the details modal — one is likely the bridge message getting mislabeled because \`route.raw.steps[*].router\` doesn't match the on-chain dispatcher for some bridge types (CCTP-v2-fast, XVELO etc). The labeler in \`useSwap.ts:labelMessages\` needs a wider sender check (or an engine-side \`dispatcher\` field). Tracking separately.