### PR TITLE
feat: unify transaction history

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -9,6 +9,7 @@ import { EVENT_NAME } from '../../features/analytics/types';
 import { useWalletConnectionTracking } from '../../features/analytics/useWalletConnectionTracking';
 import { trackEvent } from '../../features/analytics/utils';
 import { useStore } from '../../features/store';
+import { SwapDetailsModal } from '../../features/swap/SwapDetailsModal';
 import { SideBarMenu } from '../../features/wallet/SideBarMenu';
 import { WalletProtocolModal } from '../../features/wallet/WalletProtocolModal';
 import { Footer } from '../nav/Footer';
@@ -63,6 +64,7 @@ export function AppLayout({ children }: PropsWithChildren) {
         isOpen={isSideBarOpen}
         onClickConnectWallet={() => setShowEnvSelectModal(true)}
       />
+      <SwapDetailsModal />
     </>
   );
 }

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -263,7 +263,7 @@ export const useStore = create<AppState>()(
       // User transaction history
       transactionHistory: [],
       addBridgeTransaction: (data) => {
-        const id = makeTransactionId(TransactionHistoryItemType.Bridge, data.timestamp);
+        const id = createTransactionId(TransactionHistoryItemType.Bridge, data.timestamp);
         set((state) => ({
           transactionHistory: [
             ...state.transactionHistory,
@@ -273,7 +273,7 @@ export const useStore = create<AppState>()(
         return id;
       },
       addSwapTransaction: (data) => {
-        const id = makeTransactionId(TransactionHistoryItemType.Swap, data.timestamp);
+        const id = createTransactionId(TransactionHistoryItemType.Swap, data.timestamp);
         set((state) => ({
           transactionHistory: [
             ...state.transactionHistory,
@@ -419,21 +419,23 @@ export const useStore = create<AppState>()(
           transfers?: TransferContext[];
           swaps?: SwapHistoryItem[];
         };
-        if (state.transactionHistory) {
+        if (Array.isArray(state.transactionHistory)) {
           return {
             chainMetadataOverrides: state.chainMetadataOverrides ?? {},
             transactionHistory: state.transactionHistory,
           };
         }
 
+        const transfers = Array.isArray(state.transfers) ? state.transfers : [];
+        const swaps = Array.isArray(state.swaps) ? state.swaps : [];
         const transactionHistory: TransactionHistoryItem[] = [
-          ...(state.transfers ?? []).map((data) => ({
-            id: makeTransactionId(TransactionHistoryItemType.Bridge, data.timestamp),
+          ...transfers.map((data) => ({
+            id: createTransactionId(TransactionHistoryItemType.Bridge, data.timestamp),
             type: TransactionHistoryItemType.Bridge,
             data,
           })),
-          ...(state.swaps ?? []).map((data) => ({
-            id: makeTransactionId(TransactionHistoryItemType.Swap, data.timestamp),
+          ...swaps.map((data) => ({
+            id: createTransactionId(TransactionHistoryItemType.Swap, data.timestamp),
             type: TransactionHistoryItemType.Swap,
             data,
           })),
@@ -462,8 +464,11 @@ export const useStore = create<AppState>()(
   ),
 );
 
-function makeTransactionId(type: TransactionHistoryItem['type'], timestamp: number): string {
-  return `${type}-${timestamp}-${Math.random().toString(16).slice(2)}`;
+function createTransactionId(type: TransactionHistoryItem['type'], timestamp: number): string {
+  const suffix =
+    crypto.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+
+  return `${type}-${timestamp}-${suffix}`;
 }
 
 async function initWarpContext({

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -41,7 +41,16 @@ import {
 import { assembleWarpCoreConfig } from './warpCore/warpCoreConfig';
 
 // Increment this when persist state has breaking changes
-const PERSIST_STATE_VERSION = 2;
+const PERSIST_STATE_VERSION = 3;
+
+export const TransactionHistoryItemType = {
+  Bridge: 'bridge',
+  Swap: 'swap',
+} as const;
+
+export type TransactionHistoryItem =
+  | { id: string; type: typeof TransactionHistoryItemType.Bridge; data: TransferContext }
+  | { id: string; type: typeof TransactionHistoryItemType.Swap; data: SwapHistoryItem };
 
 interface WarpContext {
   registry: IRegistry;
@@ -91,12 +100,13 @@ export interface AppState {
   warpCore: WarpCore;
   setWarpContext: (context: WarpContext) => void;
 
-  // User history
-  transfers: TransferContext[];
-  addTransfer: (t: TransferContext) => void;
-  resetTransfers: () => void;
-  updateTransferStatus: (
-    i: number,
+  // User transaction history
+  transactionHistory: TransactionHistoryItem[];
+  addBridgeTransaction: (t: TransferContext) => string;
+  addSwapTransaction: (s: SwapHistoryItem) => string;
+  resetTransactionHistory: () => void;
+  updateBridgeTransactionStatus: (
+    id: string,
     s: TransferStatus,
     options?: {
       msgId?: string;
@@ -105,14 +115,8 @@ export interface AppState {
       destinationTxHash?: string;
     },
   ) => void;
-  failUnconfirmedTransfers: () => void;
-
-  // Swap history (in-memory only; not persisted). Mirrors `transfers` shape.
-  swaps: SwapHistoryItem[];
-  addSwap: (s: SwapHistoryItem) => void;
-  resetSwaps: () => void;
-  updateSwapStatus: (
-    i: number,
+  updateSwapTransactionStatus: (
+    id: string,
     status: SwapStatus,
     options?: {
       msgIds?: LabeledMsgId[];
@@ -121,11 +125,9 @@ export interface AppState {
       destinationTxHash?: string;
     },
   ) => void;
-  failUnconfirmedSwaps: () => void;
-  // Index into `swaps` of the swap currently being viewed in the
-  // SwapDetailsModal. Set by useSwap.execute when a swap starts.
-  activeSwapIndex: number | null;
-  setActiveSwapIndex: (i: number | null) => void;
+  failUnconfirmedTransactions: () => void;
+  selectedTransactionId: string | null;
+  setSelectedTransactionId: (id: string | null) => void;
   // Accumulated engine-token catalogue. Every useTokens() result funnels
   // through syncTokens so SwapForm / SwapDetailsModal lookups go through
   // one place. Keyed by getSwapTokenKey (chainId-address). Not persisted.
@@ -256,73 +258,83 @@ export const useStore = create<AppState>()(
         set(context);
       },
 
-      // User history
-      transfers: [],
-      addTransfer: (t) => {
-        set((state) => ({ transfers: [...state.transfers, t] }));
-      },
-      resetTransfers: () => {
-        set(() => ({ transfers: [] }));
-      },
-      updateTransferStatus: (i, s, options) => {
-        set((state) => {
-          if (i >= state.transfers.length) return state;
-          const txs = [...state.transfers];
-          txs[i].status = s;
-          txs[i].msgId ||= options?.msgId;
-          txs[i].originTxHash ||= options?.originTxHash;
-          txs[i].originBlockNumber ||= options?.originBlockNumber;
-          txs[i].destinationTxHash ||= options?.destinationTxHash;
-          return {
-            transfers: txs,
-          };
-        });
-      },
-      failUnconfirmedTransfers: () => {
+      // User transaction history
+      transactionHistory: [],
+      addBridgeTransaction: (data) => {
+        const id = makeTransactionId(TransactionHistoryItemType.Bridge, data.timestamp);
         set((state) => ({
-          transfers: state.transfers.map((t) =>
-            FinalTransferStatuses.includes(t.status) ? t : { ...t, status: TransferStatus.Failed },
-          ),
+          transactionHistory: [
+            ...state.transactionHistory,
+            { id, type: TransactionHistoryItemType.Bridge, data },
+          ],
         }));
+        return id;
       },
-
-      // Swap history (in-memory only)
-      swaps: [],
-      addSwap: (s) => {
-        set((state) => ({ swaps: [...state.swaps, s] }));
-      },
-      resetSwaps: () => {
-        set(() => ({ swaps: [] }));
-      },
-      updateSwapStatus: (i, status, options) => {
-        set((state) => {
-          if (i >= state.swaps.length) return state;
-          const swaps = [...state.swaps];
-          swaps[i] = {
-            ...swaps[i],
-            status,
-            msgIds: swaps[i].msgIds ?? options?.msgIds,
-            originTxHash: swaps[i].originTxHash ?? options?.originTxHash,
-            originBlockNumber: swaps[i].originBlockNumber ?? options?.originBlockNumber,
-            destinationTxHash: swaps[i].destinationTxHash ?? options?.destinationTxHash,
-          };
-          return { swaps };
-        });
-      },
-      failUnconfirmedSwaps: () => {
-        // Only mark Failed if the swap never broadcast an origin tx.
-        // A swap with an originTxHash may still be bridging.
+      addSwapTransaction: (data) => {
+        const id = makeTransactionId(TransactionHistoryItemType.Swap, data.timestamp);
         set((state) => ({
-          swaps: state.swaps.map((s) => {
-            if (FinalSwapStatuses.includes(s.status)) return s;
-            if (s.originTxHash) return s;
-            return { ...s, status: SwapStatus.Failed };
+          transactionHistory: [
+            ...state.transactionHistory,
+            { id, type: TransactionHistoryItemType.Swap, data },
+          ],
+        }));
+        return id;
+      },
+      resetTransactionHistory: () => {
+        set(() => ({ transactionHistory: [] }));
+      },
+      updateBridgeTransactionStatus: (id, status, options) => {
+        set((state) => ({
+          transactionHistory: state.transactionHistory.map((item) => {
+            if (item.id !== id || item.type !== TransactionHistoryItemType.Bridge) return item;
+            return {
+              ...item,
+              data: {
+                ...item.data,
+                status,
+                msgId: item.data.msgId ?? options?.msgId,
+                originTxHash: item.data.originTxHash ?? options?.originTxHash,
+                originBlockNumber: item.data.originBlockNumber ?? options?.originBlockNumber,
+                destinationTxHash: item.data.destinationTxHash ?? options?.destinationTxHash,
+              },
+            };
           }),
         }));
       },
-      activeSwapIndex: null,
-      setActiveSwapIndex: (activeSwapIndex) => {
-        set(() => ({ activeSwapIndex }));
+      updateSwapTransactionStatus: (id, status, options) => {
+        set((state) => ({
+          transactionHistory: state.transactionHistory.map((item) => {
+            if (item.id !== id || item.type !== TransactionHistoryItemType.Swap) return item;
+            return {
+              ...item,
+              data: {
+                ...item.data,
+                status,
+                msgIds: item.data.msgIds ?? options?.msgIds,
+                originTxHash: item.data.originTxHash ?? options?.originTxHash,
+                originBlockNumber: item.data.originBlockNumber ?? options?.originBlockNumber,
+                destinationTxHash: item.data.destinationTxHash ?? options?.destinationTxHash,
+              },
+            };
+          }),
+        }));
+      },
+      failUnconfirmedTransactions: () => {
+        set((state) => ({
+          transactionHistory: state.transactionHistory.map((item) => {
+            if (item.type === TransactionHistoryItemType.Bridge) {
+              if (FinalTransferStatuses.includes(item.data.status)) return item;
+              return { ...item, data: { ...item.data, status: TransferStatus.Failed } };
+            }
+            if (FinalSwapStatuses.includes(item.data.status)) return item;
+            if (item.data.originTxHash) return item;
+            return { ...item, data: { ...item.data, status: SwapStatus.Failed } };
+          }),
+        }));
+      },
+      selectedTransactionId: null,
+      setSelectedTransactionId: (selectedTransactionId) => {
+        set(() => ({ selectedTransactionId }));
       },
       knownTokens: new Map(),
       syncTokens: (newTokens) => {
@@ -393,13 +405,43 @@ export const useStore = create<AppState>()(
       partialize: (state) => ({
         // fields to persist
         chainMetadataOverrides: state.chainMetadataOverrides,
-        transfers: state.transfers, // Keep for transfers through non-indexed routes
+        transactionHistory: state.transactionHistory,
       }),
       version: PERSIST_STATE_VERSION,
+      migrate: (persistedState) => {
+        const state = persistedState as Partial<AppState> & {
+          transfers?: TransferContext[];
+          swaps?: SwapHistoryItem[];
+        };
+        if (state.transactionHistory) {
+          return {
+            chainMetadataOverrides: state.chainMetadataOverrides ?? {},
+            transactionHistory: state.transactionHistory,
+          };
+        }
+
+        const transactionHistory: TransactionHistoryItem[] = [
+          ...(state.transfers ?? []).map((data) => ({
+            id: makeTransactionId(TransactionHistoryItemType.Bridge, data.timestamp),
+            type: TransactionHistoryItemType.Bridge,
+            data,
+          })),
+          ...(state.swaps ?? []).map((data) => ({
+            id: makeTransactionId(TransactionHistoryItemType.Swap, data.timestamp),
+            type: TransactionHistoryItemType.Swap,
+            data,
+          })),
+        ];
+
+        return {
+          chainMetadataOverrides: state.chainMetadataOverrides ?? {},
+          transactionHistory,
+        };
+      },
       onRehydrateStorage: () => {
         logger.debug('Rehydrating state');
         return (state, error) => {
-          state?.failUnconfirmedTransfers();
+          state?.failUnconfirmedTransactions();
           if (error || !state) {
             logger.error('Error during hydration', error);
             return;
@@ -413,6 +455,10 @@ export const useStore = create<AppState>()(
     },
   ),
 );
+
+function makeTransactionId(type: TransactionHistoryItem['type'], timestamp: number): string {
+  return `${type}-${timestamp}-${Math.random().toString(16).slice(2)}`;
+}
 
 async function initWarpContext({
   registry,

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -128,6 +128,8 @@ export interface AppState {
   failUnconfirmedTransactions: () => void;
   selectedTransactionId: string | null;
   setSelectedTransactionId: (id: string | null) => void;
+  activeSwapTransactionId: string | null;
+  setActiveSwapTransactionId: (id: string | null) => void;
   // Accumulated engine-token catalogue. Every useTokens() result funnels
   // through syncTokens so SwapForm / SwapDetailsModal lookups go through
   // one place. Keyed by getSwapTokenKey (chainId-address). Not persisted.
@@ -335,6 +337,10 @@ export const useStore = create<AppState>()(
       selectedTransactionId: null,
       setSelectedTransactionId: (selectedTransactionId) => {
         set(() => ({ selectedTransactionId }));
+      },
+      activeSwapTransactionId: null,
+      setActiveSwapTransactionId: (activeSwapTransactionId) => {
+        set(() => ({ activeSwapTransactionId }));
       },
       knownTokens: new Map(),
       syncTokens: (newTokens) => {

--- a/src/features/swap/SwapDetailsModal.tsx
+++ b/src/features/swap/SwapDetailsModal.tsx
@@ -56,23 +56,25 @@ const STATUS_DESCRIPTION: Record<SwapStatus, string> = {
 };
 
 export function SwapDetailsModal() {
-  const activeSwapIndex = useStore((s) => s.activeSwapIndex);
-  const swaps = useStore((s) => s.swaps);
-  const setActiveSwapIndex = useStore((s) => s.setActiveSwapIndex);
-  const close = () => setActiveSwapIndex(null);
+  const selectedTransactionId = useStore((s) => s.selectedTransactionId);
+  const transactionHistory = useStore((s) => s.transactionHistory);
+  const setSelectedTransactionId = useStore((s) => s.setSelectedTransactionId);
+  const close = () => setSelectedTransactionId(null);
 
-  const isOpen = activeSwapIndex != null;
+  const isOpen = selectedTransactionId != null;
 
-  // Keep the last index alive after close so delivery polling continues in background.
-  const lastIndexRef = useRef<number | null>(null);
-  if (activeSwapIndex != null) lastIndexRef.current = activeSwapIndex;
+  // Keep the last id alive after close so delivery polling continues in background.
+  const lastIdRef = useRef<string | null>(null);
+  if (selectedTransactionId != null) lastIdRef.current = selectedTransactionId;
 
-  const renderedIndex = lastIndexRef.current;
-  const swap = renderedIndex != null ? swaps[renderedIndex] : undefined;
+  const renderedId = lastIdRef.current;
+  const item =
+    renderedId != null ? transactionHistory.find((entry) => entry.id === renderedId) : undefined;
+  const swap = item?.type === 'swap' ? item.data : undefined;
 
-  if (!swap || renderedIndex == null) return <Modal isOpen={false} close={close} />;
+  if (!swap || renderedId == null) return <Modal isOpen={false} close={close} />;
   return (
-    <SwapDetailsModalInner isOpen={isOpen} close={close} swap={swap} swapIndex={renderedIndex} />
+    <SwapDetailsModalInner isOpen={isOpen} close={close} swap={swap} transactionId={renderedId} />
   );
 }
 
@@ -80,16 +82,16 @@ function SwapDetailsModalInner({
   isOpen,
   close,
   swap,
-  swapIndex,
+  transactionId,
 }: {
   isOpen: boolean;
   close: () => void;
   swap: SwapHistoryItem;
-  swapIndex: number;
+  transactionId: string;
 }) {
   const multiProvider = useMultiProvider();
   const tokenMap = useTokenByKeyMap();
-  const updateSwapStatus = useStore((s) => s.updateSwapStatus);
+  const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
 
   const {
     status,
@@ -112,6 +114,10 @@ function SwapDetailsModalInner({
 
   const srcToken = getTokenByKeyFromMap(tokenMap, `${srcChain}-${srcTokenAddr.toLowerCase()}`);
   const dstToken = getTokenByKeyFromMap(tokenMap, `${dstChain}-${dstTokenAddr.toLowerCase()}`);
+  const srcSymbol = srcToken?.symbol ?? swap.srcTokenMeta?.symbol ?? '';
+  const dstSymbol = dstToken?.symbol ?? swap.dstTokenMeta?.symbol ?? '';
+  const srcDecimals = srcToken?.decimals ?? swap.srcTokenMeta?.decimals;
+  const dstDecimals = dstToken?.decimals ?? swap.dstTokenMeta?.decimals;
 
   const isFailed = status === SwapStatus.Failed;
   const isDestFailed = status === SwapStatus.DestSwapFailed;
@@ -141,12 +147,18 @@ function SwapDetailsModalInner({
       status !== SwapStatus.ConfirmedDestination
     ) {
       hasUpdatedDelivery.current = true;
-      updateSwapStatus(swapIndex, SwapStatus.ConfirmedDestination, {
+      updateSwapTransactionStatus(transactionId, SwapStatus.ConfirmedDestination, {
         destinationTxHash: delivery.destinationTxHash,
       });
       toast.success('Swap complete! Funds have arrived.');
     }
-  }, [delivery.isDelivered, delivery.destinationTxHash, swapIndex, status, updateSwapStatus]);
+  }, [
+    delivery.isDelivered,
+    delivery.destinationTxHash,
+    transactionId,
+    status,
+    updateSwapTransactionStatus,
+  ]);
 
   const isSent =
     status === SwapStatus.ConfirmingOrigin ||
@@ -237,11 +249,11 @@ function SwapDetailsModalInner({
         <div>
           <div className="mt-4 flex w-full items-center justify-center rounded-sm border border-gray-400/25 bg-card-gradient py-2 shadow-card">
             <div className="flex items-center font-secondary text-sm font-normal">
-              <span>{formatAmount(amountIn, srcToken?.decimals)}</span>
-              <span className="ml-1">{srcToken?.symbol ?? ''}</span>
+              <span>{formatAmount(amountIn, srcDecimals)}</span>
+              <span className="ml-1">{srcSymbol}</span>
               <Image className="mx-2" src={ArrowRightIcon} width={10} height={10} alt="" />
-              <span>{formatAmount(amountOut, dstToken?.decimals)}</span>
-              <span className="ml-1">{dstToken?.symbol ?? ''}</span>
+              <span>{formatAmount(amountOut, dstDecimals)}</span>
+              <span className="ml-1">{dstSymbol}</span>
             </div>
           </div>
 
@@ -252,9 +264,7 @@ function SwapDetailsModalInner({
               ) : (
                 <ChainLogo chainName={originChain} size={36} />
               )}
-              <span className="mt-1 text-xs font-medium tracking-wider">
-                {srcToken?.symbol ?? ''}
-              </span>
+              <span className="mt-1 text-xs font-medium tracking-wider">{srcSymbol}</span>
               <span className="text-xxs font-normal tracking-wider text-gray-500">
                 {getChainDisplayName(multiProvider, originChain, true)}
               </span>
@@ -269,9 +279,7 @@ function SwapDetailsModalInner({
               ) : (
                 <ChainLogo chainName={destChain} size={36} />
               )}
-              <span className="mt-1 text-xs font-medium tracking-wider">
-                {dstToken?.symbol ?? ''}
-              </span>
+              <span className="mt-1 text-xs font-medium tracking-wider">{dstSymbol}</span>
               <span className="text-xxs font-normal tracking-wider text-gray-500">
                 {getChainDisplayName(multiProvider, destChain, true)}
               </span>
@@ -396,20 +404,22 @@ function formatAmount(amount: string, decimals: number | undefined): string {
 //   120 s → auto-mark Failed (preserves originTxHash)
 function ConfirmingOriginHint({ swap }: { swap: SwapHistoryItem }) {
   const [showHint, setShowHint] = useState(false);
-  const updateSwapStatus = useStore((s) => s.updateSwapStatus);
-  const swapIndex = useStore((s) => s.activeSwapIndex);
+  const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
+  const transactionId = useStore((s) => s.selectedTransactionId);
 
   useEffect(() => {
     const hintTimer = setTimeout(() => setShowHint(true), 60_000);
     const failTimer = setTimeout(() => {
-      if (swapIndex == null) return;
-      updateSwapStatus(swapIndex, SwapStatus.Failed, { originTxHash: swap.originTxHash });
+      if (transactionId == null) return;
+      updateSwapTransactionStatus(transactionId, SwapStatus.Failed, {
+        originTxHash: swap.originTxHash,
+      });
     }, 120_000);
     return () => {
       clearTimeout(hintTimer);
       clearTimeout(failTimer);
     };
-  }, [swapIndex, swap.originTxHash, updateSwapStatus]);
+  }, [transactionId, swap.originTxHash, updateSwapTransactionStatus]);
 
   if (!showHint) return null;
   return (

--- a/src/features/swap/SwapDetailsModal.tsx
+++ b/src/features/swap/SwapDetailsModal.tsx
@@ -24,7 +24,7 @@ import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { getChainDisplayName } from '../chains/utils';
 import { useMessageDeliveryStatus } from '../messages/useMessageDeliveryStatus';
-import { useStore } from '../store';
+import { TransactionHistoryItemType, useStore } from '../store';
 import { formatBalance } from './balances/utils';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
 import { FinalSwapStatuses, SwapStatus, type SwapHistoryItem } from './types';
@@ -55,6 +55,9 @@ const STATUS_DESCRIPTION: Record<SwapStatus, string> = {
   [SwapStatus.Failed]: 'Swap failed',
 };
 
+const CONFIRMING_ORIGIN_HINT_DELAY_MS = 60_000;
+const CONFIRMING_ORIGIN_AUTO_FAIL_DELAY_MS = 120_000;
+
 export function SwapDetailsModal() {
   const selectedTransactionId = useStore((s) => s.selectedTransactionId);
   const transactionHistory = useStore((s) => s.transactionHistory);
@@ -70,7 +73,7 @@ export function SwapDetailsModal() {
   const renderedId = lastIdRef.current;
   const item =
     renderedId != null ? transactionHistory.find((entry) => entry.id === renderedId) : undefined;
-  const swap = item?.type === 'swap' ? item.data : undefined;
+  const swap = item?.type === TransactionHistoryItemType.Swap ? item.data : undefined;
 
   if (!swap || renderedId == null) return <Modal isOpen={false} close={close} />;
   return (
@@ -345,7 +348,9 @@ function SwapDetailsModalInner({
             <div className="mt-5 text-center text-sm text-gray-600 dark:text-foreground-muted">
               {STATUS_DESCRIPTION[status]}
             </div>
-            {status === SwapStatus.ConfirmingOrigin && <ConfirmingOriginHint swap={swap} />}
+            {status === SwapStatus.ConfirmingOrigin && (
+              <ConfirmingOriginHint swap={swap} transactionId={transactionId} />
+            )}
           </div>
         )}
       </div>
@@ -399,22 +404,23 @@ function formatAmount(amount: string, decimals: number | undefined): string {
   }
 }
 
-// Two-stage escalation while stuck in ConfirmingOrigin:
-//   60 s → soft hint ("may have failed in your wallet")
-//   120 s → auto-mark Failed (preserves originTxHash)
-function ConfirmingOriginHint({ swap }: { swap: SwapHistoryItem }) {
+function ConfirmingOriginHint({
+  swap,
+  transactionId,
+}: {
+  swap: SwapHistoryItem;
+  transactionId: string;
+}) {
   const [showHint, setShowHint] = useState(false);
   const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
-  const transactionId = useStore((s) => s.selectedTransactionId);
 
   useEffect(() => {
-    const hintTimer = setTimeout(() => setShowHint(true), 60_000);
+    const hintTimer = setTimeout(() => setShowHint(true), CONFIRMING_ORIGIN_HINT_DELAY_MS);
     const failTimer = setTimeout(() => {
-      if (transactionId == null) return;
       updateSwapTransactionStatus(transactionId, SwapStatus.Failed, {
         originTxHash: swap.originTxHash,
       });
-    }, 120_000);
+    }, CONFIRMING_ORIGIN_AUTO_FAIL_DELAY_MS);
     return () => {
       clearTimeout(hintTimer);
       clearTimeout(failTimer);

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -19,7 +19,7 @@ import { config } from '../../consts/config';
 import { updateQueryParams } from '../../utils/queryParams';
 import { useChains } from '../api/hooks';
 import { useMultiProvider } from '../chains/hooks';
-import { useStore } from '../store';
+import { TransactionHistoryItemType, useStore } from '../store';
 import { RecipientConfirmationModal } from '../wallet/RecipientConfirmationModal';
 import { WalletConnectionWarning } from '../wallet/WalletConnectionWarning';
 import { WalletDropdown } from '../wallet/WalletDropdown';
@@ -172,7 +172,8 @@ function SwapFormContent() {
       : undefined,
   );
   const isActiveSwapInFlight =
-    activeSwap?.type === 'swap' && !FinalSwapStatuses.includes(activeSwap.data.status);
+    activeSwap?.type === TransactionHistoryItemType.Swap &&
+    !FinalSwapStatuses.includes(activeSwap.data.status);
 
   const hasAmount = !!values.amount && Number(values.amount) > 0;
   const hasTokens = !!srcToken && !!dstToken;
@@ -326,7 +327,10 @@ function SwapFormContent() {
       const cur = useStore
         .getState()
         .transactionHistory.find((historyItem) => historyItem.id === transactionId);
-      if (cur?.type === 'swap' && !FinalSwapStatuses.includes(cur.data.status)) {
+      if (
+        cur?.type === TransactionHistoryItemType.Swap &&
+        !FinalSwapStatuses.includes(cur.data.status)
+      ) {
         updateSwapTransactionStatus(transactionId, SwapStatus.Failed);
       }
     } finally {

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -160,15 +160,15 @@ function SwapFormContent() {
   useToastError(swap.error, 'Swap failed');
   const addSwapTransaction = useStore((s) => s.addSwapTransaction);
   const setSelectedTransactionId = useStore((s) => s.setSelectedTransactionId);
+  const setActiveSwapTransactionId = useStore((s) => s.setActiveSwapTransactionId);
   const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
   const setSwapLoading = useStore((s) => s.setSwapLoading);
 
-  // Send-button gating: derive from the modal's active swap status, not
-  // hook isPending. Closing the modal clears selectedTransactionId so a stuck
-  // confirm() polling loop doesn't permanently lock the button.
+  // Send-button gating tracks the active execution, not the transaction selected
+  // for history/modals. Viewing an old pending swap should not disable the form.
   const activeSwap = useStore((s) =>
-    s.selectedTransactionId != null
-      ? s.transactionHistory.find((item) => item.id === s.selectedTransactionId)
+    s.activeSwapTransactionId != null
+      ? s.transactionHistory.find((item) => item.id === s.activeSwapTransactionId)
       : undefined,
   );
   const isActiveSwapInFlight =
@@ -304,6 +304,7 @@ function SwapFormContent() {
     };
     const transactionId = addSwapTransaction(item);
     setSelectedTransactionId(transactionId);
+    setActiveSwapTransactionId(transactionId);
 
     try {
       // useSwap.execute handles revoke / approve / swap sequencing
@@ -329,6 +330,7 @@ function SwapFormContent() {
         updateSwapTransactionStatus(transactionId, SwapStatus.Failed);
       }
     } finally {
+      setActiveSwapTransactionId(null);
       setSwapLoading(false);
     }
   }, [
@@ -348,6 +350,7 @@ function SwapFormContent() {
     swap,
     addSwapTransaction,
     setSelectedTransactionId,
+    setActiveSwapTransactionId,
     updateSwapTransactionStatus,
     setSwapLoading,
     setErrors,

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -158,18 +158,21 @@ function SwapFormContent() {
 
   const swap = useSwap();
   useToastError(swap.error, 'Swap failed');
-  const addSwap = useStore((s) => s.addSwap);
-  const setActiveSwapIndex = useStore((s) => s.setActiveSwapIndex);
-  const updateSwapStatus = useStore((s) => s.updateSwapStatus);
+  const addSwapTransaction = useStore((s) => s.addSwapTransaction);
+  const setSelectedTransactionId = useStore((s) => s.setSelectedTransactionId);
+  const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
   const setSwapLoading = useStore((s) => s.setSwapLoading);
 
   // Send-button gating: derive from the modal's active swap status, not
-  // hook isPending. Closing the modal clears activeSwapIndex so a stuck
+  // hook isPending. Closing the modal clears selectedTransactionId so a stuck
   // confirm() polling loop doesn't permanently lock the button.
   const activeSwap = useStore((s) =>
-    s.activeSwapIndex != null ? s.swaps[s.activeSwapIndex] : undefined,
+    s.selectedTransactionId != null
+      ? s.transactionHistory.find((item) => item.id === s.selectedTransactionId)
+      : undefined,
   );
-  const isActiveSwapInFlight = activeSwap != null && !FinalSwapStatuses.includes(activeSwap.status);
+  const isActiveSwapInFlight =
+    activeSwap?.type === 'swap' && !FinalSwapStatuses.includes(activeSwap.data.status);
 
   const hasAmount = !!values.amount && Number(values.amount) > 0;
   const hasTokens = !!srcToken && !!dstToken;
@@ -273,28 +276,40 @@ function SwapFormContent() {
 
     const initialStep = bestRoute.raw.steps[0];
     const finalStep = bestRoute.raw.steps[bestRoute.raw.steps.length - 1];
+    const timestamp = Date.now();
     const item: SwapHistoryItem = {
       status: SwapStatus.Preparing,
-      timestamp: Date.now(),
+      timestamp,
       srcChain: values.srcChain,
       dstChain: values.dstChain,
       srcToken: srcToken.address,
       dstToken: dstToken.address,
+      srcTokenMeta: {
+        symbol: srcToken.symbol,
+        decimals: srcToken.decimals,
+        chainName: srcToken.chainName,
+        logoURI: srcToken.logoURI,
+      },
+      dstTokenMeta: {
+        symbol: dstToken.symbol,
+        decimals: dstToken.decimals,
+        chainName: dstToken.chainName,
+        logoURI: dstToken.logoURI,
+      },
       amountIn:
         initialStep && 'amountIn' in initialStep ? initialStep.amountIn : bestRoute.raw.output,
       amountOut: finalStep && 'amountOut' in finalStep ? finalStep.amountOut : bestRoute.raw.output,
       sender,
       recipient: effectiveRecipient,
     };
-    addSwap(item);
-    const swapIndex = useStore.getState().swaps.length - 1;
-    setActiveSwapIndex(swapIndex);
+    const transactionId = addSwapTransaction(item);
+    setSelectedTransactionId(transactionId);
 
     try {
       // useSwap.execute handles revoke / approve / swap sequencing
       // internally based on the params below.
       await swap.execute({
-        swapIndex,
+        transactionId,
         route: bestRoute,
         srcChainId: values.srcChain,
         dstChainId: values.dstChain,
@@ -307,9 +322,11 @@ function SwapFormContent() {
         isNative,
       });
     } catch {
-      const cur = useStore.getState().swaps[swapIndex]?.status;
-      if (cur && !FinalSwapStatuses.includes(cur)) {
-        updateSwapStatus(swapIndex, SwapStatus.Failed);
+      const cur = useStore
+        .getState()
+        .transactionHistory.find((historyItem) => historyItem.id === transactionId);
+      if (cur?.type === 'swap' && !FinalSwapStatuses.includes(cur.data.status)) {
+        updateSwapTransactionStatus(transactionId, SwapStatus.Failed);
       }
     } finally {
       setSwapLoading(false);
@@ -329,9 +346,9 @@ function SwapFormContent() {
     amountAtomic,
     isNative,
     swap,
-    addSwap,
-    setActiveSwapIndex,
-    updateSwapStatus,
+    addSwapTransaction,
+    setSelectedTransactionId,
+    updateSwapTransactionStatus,
     setSwapLoading,
     setErrors,
   ]);

--- a/src/features/swap/SwapTokenCard.tsx
+++ b/src/features/swap/SwapTokenCard.tsx
@@ -1,11 +1,9 @@
-import { SwapDetailsModal } from './SwapDetailsModal';
 import { SwapForm } from './SwapForm';
 
 export function SwapTokenCard() {
   return (
     <div className="relative w-100 sm:w-[31rem]">
       <SwapForm />
-      <SwapDetailsModal />
     </div>
   );
 }

--- a/src/features/swap/types.ts
+++ b/src/features/swap/types.ts
@@ -7,6 +7,13 @@ export interface LabeledMsgId {
   label: SwapMessageLabel;
 }
 
+export interface SwapHistoryTokenMeta {
+  symbol: string;
+  decimals: number;
+  chainName: string;
+  logoURI?: string;
+}
+
 // ── Persisted/in-memory swap history ──────────────────────────────────
 
 // Status of a single submitted swap. Used by SwapDetailsModal to drive
@@ -40,6 +47,8 @@ export interface SwapHistoryItem {
   dstChain: number;
   srcToken: string;
   dstToken: string;
+  srcTokenMeta?: SwapHistoryTokenMeta;
+  dstTokenMeta?: SwapHistoryTokenMeta;
   amountIn: string;
   amountOut: string;
   sender: string;

--- a/src/features/swap/useSwap.ts
+++ b/src/features/swap/useSwap.ts
@@ -18,7 +18,7 @@ import { SwapStatus } from './types';
 import type { AugmentedRoute, LabeledMsgId } from './types';
 
 interface ExecuteArgs {
-  swapIndex: number;
+  transactionId: string;
   route: AugmentedRoute;
   srcChainId: number;
   dstChainId: number;
@@ -39,7 +39,7 @@ interface ExecuteArgs {
 export function useSwap() {
   const multiProvider = useMultiProvider();
   const transactionFns = useTransactionFns(multiProvider);
-  const updateSwapStatus = useStore((s) => s.updateSwapStatus);
+  const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
   const [error, setError] = useState<Error | null>(null);
   const [isPending, setIsPending] = useState(false);
 
@@ -48,7 +48,7 @@ export function useSwap() {
       setError(null);
       setIsPending(true);
 
-      const { swapIndex, route, srcChainId } = args;
+      const { transactionId, route, srcChainId } = args;
 
       if (!route.raw.tx) throw new Error('Route has no tx');
 
@@ -88,7 +88,7 @@ export function useSwap() {
             adapter.isRevokeApprovalRequired(args.sender, spender),
           ]);
           const doApprove = async (amount: bigint) => {
-            updateSwapStatus(swapIndex, SwapStatus.SigningApprove);
+            updateSwapTransactionStatus(transactionId, SwapStatus.SigningApprove);
             const populated = await adapter.populateApproveTx({
               weiAmountOrId: amount.toString(),
               recipient: spender,
@@ -101,7 +101,7 @@ export function useSwap() {
               } as Parameters<typeof fns.sendTransaction>[0]['tx'],
               chainName: srcChainName,
             });
-            updateSwapStatus(swapIndex, SwapStatus.ConfirmingApprove);
+            updateSwapTransactionStatus(transactionId, SwapStatus.ConfirmingApprove);
             const receipt = await confirm();
             if (isReverted(receipt)) {
               logger.error('Approve tx reverted', new Error(`tx=${hash}`));
@@ -114,11 +114,11 @@ export function useSwap() {
 
         // Order is critical: post to CCS BEFORE broadcasting.
         if (route.raw.callCommitment) {
-          updateSwapStatus(swapIndex, SwapStatus.CreatingTxs);
+          updateSwapTransactionStatus(transactionId, SwapStatus.CreatingTxs);
           await postCommitment(route.raw.callCommitment);
         }
 
-        updateSwapStatus(swapIndex, SwapStatus.SigningSwap);
+        updateSwapTransactionStatus(transactionId, SwapStatus.SigningSwap);
         const { hash, confirm } = await fns.sendTransaction({
           tx: {
             type: txType,
@@ -132,12 +132,14 @@ export function useSwap() {
           chainName: srcChainName,
         });
 
-        updateSwapStatus(swapIndex, SwapStatus.ConfirmingOrigin, { originTxHash: hash });
+        updateSwapTransactionStatus(transactionId, SwapStatus.ConfirmingOrigin, {
+          originTxHash: hash,
+        });
 
         const receipt = await confirm();
         if (isReverted(receipt)) {
           logger.error('Origin tx reverted', new Error(`tx=${hash}`));
-          updateSwapStatus(swapIndex, SwapStatus.Failed, { originTxHash: hash });
+          updateSwapTransactionStatus(transactionId, SwapStatus.Failed, { originTxHash: hash });
           const err = new Error('Origin transaction reverted on chain');
           setError(err);
           throw err;
@@ -146,7 +148,7 @@ export function useSwap() {
         const expectsBridge = route.raw.steps.some((s) => s.type === 'bridge');
         if (expectsBridge && !parsed.messages.length) {
           logger.error('Origin tx confirmed but no Dispatch log emitted', new Error(`tx=${hash}`));
-          updateSwapStatus(swapIndex, SwapStatus.Failed, {
+          updateSwapTransactionStatus(transactionId, SwapStatus.Failed, {
             originTxHash: hash,
             originBlockNumber: parsed.originBlockNumber,
           });
@@ -158,7 +160,7 @@ export function useSwap() {
         }
         // Same-chain swap (no bridge step): finalize on origin confirm.
         if (!expectsBridge) {
-          updateSwapStatus(swapIndex, SwapStatus.ConfirmedDestination, {
+          updateSwapTransactionStatus(transactionId, SwapStatus.ConfirmedDestination, {
             originTxHash: hash,
             destinationTxHash: hash,
             originBlockNumber: parsed.originBlockNumber,
@@ -167,7 +169,7 @@ export function useSwap() {
         }
         submitToRelayApi(srcChainName, hash, protocol as ProtocolType, receipt);
 
-        updateSwapStatus(swapIndex, SwapStatus.Bridging, {
+        updateSwapTransactionStatus(transactionId, SwapStatus.Bridging, {
           msgIds: labelMessages(parsed.messages, route),
           originBlockNumber: parsed.originBlockNumber,
         });
@@ -175,14 +177,14 @@ export function useSwap() {
         return hash;
       } catch (err) {
         logger.error('Swap broadcast failed', err);
-        updateSwapStatus(swapIndex, SwapStatus.Failed);
+        updateSwapTransactionStatus(transactionId, SwapStatus.Failed);
         setError(err as Error);
         throw err;
       } finally {
         setIsPending(false);
       }
     },
-    [transactionFns, multiProvider, updateSwapStatus],
+    [transactionFns, multiProvider, updateSwapTransactionStatus],
   );
 
   return { execute, isPending, error };

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -48,8 +48,7 @@ import { useChainDisplayName, useMultiProvider } from '../chains/hooks';
 import { getChainDisplayName } from '../chains/utils';
 import { isMultiCollateralLimitExceeded } from '../limits/utils';
 import { useIsAccountSanctioned } from '../sanctions/hooks/useIsAccountSanctioned';
-import { useStore } from '../store';
-import { TransactionHistoryItemType } from '../store';
+import { TransactionHistoryItemType, useStore } from '../store';
 import { useIsApproveRequired } from '../tokens/approval';
 import {
   getInitialTokenKeys,
@@ -397,9 +396,8 @@ function DestinationTokenCard({ isReview }: { isReview: boolean }) {
     }
     return undefined;
   });
-  // Use the hash string as the dep, not the transfer object: Zustand mutates transfer
-  // objects in place on status transitions, so an object-reference dep would fire on
-  // every status tick rather than only when a new originTxHash appears.
+  // Use the hash string as the dep so this only reacts when a new origin tx appears,
+  // not when the latest transaction object is replaced during status updates.
   const latestTxHash = latestTransfer?.originTxHash;
 
   // For same-chain CCR swaps the delivery is atomic — refetch the balance immediately

--- a/src/features/transfer/TransferTokenForm.tsx
+++ b/src/features/transfer/TransferTokenForm.tsx
@@ -49,6 +49,7 @@ import { getChainDisplayName } from '../chains/utils';
 import { isMultiCollateralLimitExceeded } from '../limits/utils';
 import { useIsAccountSanctioned } from '../sanctions/hooks/useIsAccountSanctioned';
 import { useStore } from '../store';
+import { TransactionHistoryItemType } from '../store';
 import { useIsApproveRequired } from '../tokens/approval';
 import {
   getInitialTokenKeys,
@@ -389,8 +390,13 @@ function DestinationTokenCard({ isReview }: { isReview: boolean }) {
 
   const { balance, refetch: refetchBalance } = useDestinationBalance(recipient, destinationToken);
 
-  const transfers = useStore((s) => s.transfers);
-  const latestTransfer = transfers[transfers.length - 1];
+  const latestTransfer = useStore((s) => {
+    for (let i = s.transactionHistory.length - 1; i >= 0; i--) {
+      const item = s.transactionHistory[i];
+      if (item.type === TransactionHistoryItemType.Bridge) return item.data;
+    }
+    return undefined;
+  });
   // Use the hash string as the dep, not the transfer object: Zustand mutates transfer
   // objects in place on status transitions, so an object-reference dep would fire on
   // every status tick rather than only when a new originTxHash appears.

--- a/src/features/transfer/TransfersDetailsModal.tsx
+++ b/src/features/transfer/TransfersDetailsModal.tsx
@@ -30,7 +30,7 @@ import { useMultiProvider } from '../chains/hooks';
 import { getChainDisplayName, hasPermissionlessChain } from '../chains/utils';
 import { useMessageDeliveryStatus } from '../messages/useMessageDeliveryStatus';
 import { useOriginFinality } from '../messages/useOriginFinality';
-import { useStore } from '../store';
+import { TransactionHistoryItemType, useStore } from '../store';
 import { tryFindToken, useWarpCore } from '../tokens/hooks';
 import { computeDestAmount } from './scaleUtils';
 import { TransferContext, TransferStatus } from './types';
@@ -64,6 +64,13 @@ export function TransfersDetailsModal({
   const [toUrl, setToUrl] = useState<string>('');
   const [originTxUrl, setOriginTxUrl] = useState<string>('');
   const [destTxUrl, setDestTxUrl] = useState<string>('');
+  const liveTransfer = useStore((s): TransferContext | undefined => {
+    if (!transactionId) return undefined;
+    const item = s.transactionHistory.find((entry) => entry.id === transactionId);
+    if (item?.type !== TransactionHistoryItemType.Bridge) return undefined;
+    return item.data;
+  });
+  const tx = liveTransfer ?? transfer;
 
   const {
     status,
@@ -78,7 +85,7 @@ export function TransfersDetailsModal({
     msgId,
     timestamp,
     destinationTxHash: storedDestTxHash,
-  } = transfer || {};
+  } = tx || {};
 
   const multiProvider = useMultiProvider();
   const warpCore = useWarpCore();
@@ -89,8 +96,8 @@ export function TransfersDetailsModal({
   const walletDetails = useWalletDetails()[account?.protocol || ProtocolType.Ethereum];
 
   // Query delivery status from GraphQL when modal is open for sent transfers
-  const isSent = isTransferSent(transfer?.status);
-  const isFailed = isTransferFailed(transfer?.status);
+  const isSent = isTransferSent(tx?.status);
+  const isFailed = isTransferFailed(tx?.status);
   const shouldTrackDelivery = isSent && !isFailed && !!msgId;
 
   const delivery = useMessageDeliveryStatus(
@@ -103,7 +110,7 @@ export function TransfersDetailsModal({
   const isDelivered = status === TransferStatus.Delivered || delivery.isDelivered;
 
   // Origin block number: prefer store (hot path), fall back to GraphQL (cold path after refresh)
-  const originBlockNumber = transfer?.originBlockNumber ?? delivery.originBlockHeight;
+  const originBlockNumber = tx?.originBlockNumber ?? delivery.originBlockHeight;
 
   const isFinalized = useOriginFinality(
     origin,
@@ -114,9 +121,9 @@ export function TransfersDetailsModal({
   const stage = useMemo((): MessageStage => {
     if (isDelivered) return MessageStage.Relayed;
     if (isFinalized) return MessageStage.Finalized;
-    if (isTransferSent(transfer?.status) && transfer?.originTxHash) return MessageStage.Sent;
+    if (isTransferSent(tx?.status) && tx?.originTxHash) return MessageStage.Sent;
     return MessageStage.Preparing;
-  }, [isDelivered, isFinalized, transfer]);
+  }, [isDelivered, isFinalized, tx]);
 
   // Resolve the destination tx hash from either store or live query
   const destinationTxHash = storedDestTxHash || delivery.destinationTxHash;
@@ -188,7 +195,7 @@ export function TransfersDetailsModal({
 
   // Fetch explorer URLs for addresses and transactions
   useEffect(() => {
-    if (!transfer) return;
+    if (!tx) return;
     let cancelled = false;
 
     const fetchUrls = async () => {
@@ -223,16 +230,7 @@ export function TransfersDetailsModal({
     return () => {
       cancelled = true;
     };
-  }, [
-    transfer,
-    multiProvider,
-    origin,
-    destination,
-    originTxHash,
-    destinationTxHash,
-    sender,
-    recipient,
-  ]);
+  }, [tx, multiProvider, origin, destination, originTxHash, destinationTxHash, sender, recipient]);
 
   return (
     <Modal isOpen={isOpen} close={onClose} panelClassname="transfer-details-modal max-w-sm">

--- a/src/features/transfer/TransfersDetailsModal.tsx
+++ b/src/features/transfer/TransfersDetailsModal.tsx
@@ -53,10 +53,12 @@ export function TransfersDetailsModal({
   isOpen,
   onClose,
   transfer,
+  transactionId,
 }: {
   isOpen: boolean;
   onClose: () => void;
   transfer: TransferContext;
+  transactionId?: string;
 }) {
   const [fromUrl, setFromUrl] = useState<string>('');
   const [toUrl, setToUrl] = useState<string>('');
@@ -80,14 +82,7 @@ export function TransfersDetailsModal({
 
   const multiProvider = useMultiProvider();
   const warpCore = useWarpCore();
-  const transfers = useStore((s) => s.transfers);
-  const updateTransferStatus = useStore((s) => s.updateTransferStatus);
-
-  // Find the index of this transfer in the store (for updating status)
-  const transferIndex = useMemo(
-    () => transfers.findIndex((t) => t === transfer || (t.msgId && t.msgId === transfer?.msgId)),
-    [transfers, transfer],
-  );
+  const updateBridgeTransactionStatus = useStore((s) => s.updateBridgeTransactionStatus);
 
   const isChainKnown = multiProvider.hasChain(origin);
   const account = useAccountForChain(multiProvider, isChainKnown ? origin : undefined);
@@ -176,19 +171,19 @@ export function TransfersDetailsModal({
       delivery.isDelivered &&
       !hasUpdatedDelivery.current &&
       status !== TransferStatus.Delivered &&
-      transferIndex >= 0
+      transactionId
     ) {
       hasUpdatedDelivery.current = true;
-      updateTransferStatus(transferIndex, TransferStatus.Delivered, {
+      updateBridgeTransactionStatus(transactionId, TransferStatus.Delivered, {
         destinationTxHash: delivery.destinationTxHash,
       });
     }
   }, [
     delivery.isDelivered,
     delivery.destinationTxHash,
-    transferIndex,
+    transactionId,
     status,
-    updateTransferStatus,
+    updateBridgeTransactionStatus,
   ]);
 
   // Fetch explorer URLs for addresses and transactions

--- a/src/features/transfer/useTokenTransfer.ts
+++ b/src/features/transfer/useTokenTransfer.ts
@@ -36,12 +36,10 @@ const TRANSFER_TIMEOUT_ERROR1 = 'block height exceeded';
 const TRANSFER_TIMEOUT_ERROR2 = 'timeout';
 
 export function useTokenTransfer(onDone?: () => void) {
-  const { transfers, addTransfer, updateTransferStatus } = useStore((s) => ({
-    transfers: s.transfers,
-    addTransfer: s.addTransfer,
-    updateTransferStatus: s.updateTransferStatus,
+  const { addBridgeTransaction, updateBridgeTransactionStatus } = useStore((s) => ({
+    addBridgeTransaction: s.addBridgeTransaction,
+    updateBridgeTransactionStatus: s.updateBridgeTransactionStatus,
   }));
-  const transferIndex = transfers.length;
 
   const multiProvider = useMultiProvider();
   const warpCore = useWarpCore();
@@ -62,12 +60,11 @@ export function useTokenTransfer(onDone?: () => void) {
       executeTransfer({
         warpCore,
         values,
-        transferIndex,
         activeAccounts,
         activeChains,
         transactionFns,
-        addTransfer,
-        updateTransferStatus,
+        addBridgeTransaction,
+        updateBridgeTransactionStatus,
         setIsLoading,
         onDone,
         routeOverrideToken,
@@ -75,13 +72,12 @@ export function useTokenTransfer(onDone?: () => void) {
       }),
     [
       warpCore,
-      transferIndex,
       activeAccounts,
       activeChains,
       transactionFns,
       setIsLoading,
-      addTransfer,
-      updateTransferStatus,
+      addBridgeTransaction,
+      updateBridgeTransactionStatus,
       onDone,
     ],
   );
@@ -95,12 +91,11 @@ export function useTokenTransfer(onDone?: () => void) {
 async function executeTransfer({
   warpCore,
   values,
-  transferIndex,
   activeAccounts,
   activeChains,
   transactionFns,
-  addTransfer,
-  updateTransferStatus,
+  addBridgeTransaction,
+  updateBridgeTransactionStatus,
   setIsLoading,
   onDone,
   routeOverrideToken,
@@ -108,12 +103,11 @@ async function executeTransfer({
 }: {
   warpCore: WarpCore;
   values: TransferFormValues;
-  transferIndex: number;
   activeAccounts: ReturnType<typeof useAccounts>;
   activeChains: ReturnType<typeof useActiveChains>;
   transactionFns: ReturnType<typeof useTransactionFns>;
-  addTransfer: (t: TransferContext) => void;
-  updateTransferStatus: AppState['updateTransferStatus'];
+  addBridgeTransaction: (t: TransferContext) => string;
+  updateBridgeTransactionStatus: AppState['updateBridgeTransactionStatus'];
   setIsLoading: (b: boolean) => void;
   onDone?: () => void;
   routeOverrideToken: Token | null;
@@ -122,7 +116,7 @@ async function executeTransfer({
   logger.debug('Preparing transfer transaction(s)');
   setIsLoading(true);
   let transferStatus: TransferStatus = TransferStatus.Preparing;
-  updateTransferStatus(transferIndex, transferStatus);
+  let transactionId: string | undefined;
 
   const { originTokenKey, destinationTokenKey, amount, recipient: formRecipient } = values;
   const multiProvider = warpCore.multiProvider;
@@ -172,7 +166,7 @@ async function executeTransfer({
       throw new Error('Insufficient destination collateral');
     }
 
-    addTransfer({
+    transactionId = addBridgeTransaction({
       timestamp: new Date().getTime(),
       status: TransferStatus.Preparing,
       origin,
@@ -184,13 +178,16 @@ async function executeTransfer({
       amount,
     });
 
-    updateTransferStatus(transferIndex, (transferStatus = TransferStatus.CreatingTxs));
+    updateBridgeTransactionStatus(transactionId, (transferStatus = TransferStatus.CreatingTxs));
 
     // Check if Predicate attestation is needed
     let attestationResult: PredicateAttestationResult | undefined;
 
     try {
-      updateTransferStatus(transferIndex, (transferStatus = TransferStatus.FetchingAttestation));
+      updateBridgeTransactionStatus(
+        transactionId,
+        (transferStatus = TransferStatus.FetchingAttestation),
+      );
       attestationResult = await fetchPredicateAttestation({
         warpCore,
         token: originToken,
@@ -206,7 +203,7 @@ async function executeTransfer({
       throw new Error(`Predicate attestation failed: ${message}`);
     }
 
-    updateTransferStatus(transferIndex, (transferStatus = TransferStatus.CreatingTxs));
+    updateBridgeTransactionStatus(transactionId, (transferStatus = TransferStatus.CreatingTxs));
 
     const txs = await warpCore.getTransferRemoteTxs({
       originTokenAmount,
@@ -228,8 +225,8 @@ async function executeTransfer({
     let txReceipt: TypedTransactionReceipt | undefined = undefined;
 
     if (txs.length > 1 && txs.every((tx) => tx.type === ProviderType.Starknet)) {
-      updateTransferStatus(
-        transferIndex,
+      updateBridgeTransactionStatus(
+        transactionId,
         (transferStatus = txCategoryToStatuses[WarpTxCategory.Transfer][0]),
       );
       const { hash, confirm } = await sendMultiTransaction({
@@ -237,8 +234,8 @@ async function executeTransfer({
         chainName: origin,
         activeChainName: activeChain.chainName,
       });
-      updateTransferStatus(
-        transferIndex,
+      updateBridgeTransactionStatus(
+        transactionId,
         (transferStatus = txCategoryToStatuses[WarpTxCategory.Transfer][1]),
       );
       txReceipt = await confirm();
@@ -249,8 +246,8 @@ async function executeTransfer({
       hashes.push(hash);
     } else {
       for (const tx of txs) {
-        updateTransferStatus(
-          transferIndex,
+        updateBridgeTransactionStatus(
+          transactionId,
           (transferStatus = txCategoryToStatuses[tx.category][0]),
         );
         const { hash, confirm } = await sendTransaction({
@@ -258,8 +255,8 @@ async function executeTransfer({
           chainName: origin,
           activeChainName: activeChain.chainName,
         });
-        updateTransferStatus(
-          transferIndex,
+        updateBridgeTransactionStatus(
+          transactionId,
           (transferStatus = txCategoryToStatuses[tx.category][1]),
         );
         txReceipt = await confirm();
@@ -292,18 +289,22 @@ async function executeTransfer({
         : undefined;
     // Same-chain CCR swaps are atomic: delivery happens in the same tx, no relay needed.
     if (isSameChainCcr) {
-      updateTransferStatus(transferIndex, (transferStatus = TransferStatus.Delivered), {
+      updateBridgeTransactionStatus(transactionId, (transferStatus = TransferStatus.Delivered), {
         originTxHash,
         originBlockNumber,
         msgId,
         destinationTxHash: originTxHash,
       });
     } else {
-      updateTransferStatus(transferIndex, (transferStatus = TransferStatus.ConfirmedTransfer), {
-        originTxHash,
-        originBlockNumber,
-        msgId,
-      });
+      updateBridgeTransactionStatus(
+        transactionId,
+        (transferStatus = TransferStatus.ConfirmedTransfer),
+        {
+          originTxHash,
+          originBlockNumber,
+          msgId,
+        },
+      );
     }
 
     if (originTxHash && !isSameChainCcr)
@@ -331,7 +332,7 @@ async function executeTransfer({
   } catch (error: any) {
     logger.error(`Error at stage ${transferStatus}`, error);
     const errorDetails = error.message || error.toString();
-    updateTransferStatus(transferIndex, TransferStatus.Failed);
+    if (transactionId) updateBridgeTransactionStatus(transactionId, TransferStatus.Failed);
     if (errorDetails.includes(CHAIN_MISMATCH_ERROR)) {
       // Wagmi switchNetwork call helps prevent this but isn't foolproof
       toast.error('Wallet must be connected to origin chain');

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -31,7 +31,7 @@ import {
 } from '../store';
 import { formatBalance as formatSwapBalance } from '../swap/balances/utils';
 import { getTokenByKeyFromMap } from '../swap/tokens/hooks';
-import { SwapHistoryItem, SwapStatus } from '../swap/types';
+import { FinalSwapStatuses, SwapHistoryItem, SwapStatus } from '../swap/types';
 import { tryFindToken, useWarpCore } from '../tokens/hooks';
 import { computeDestAmount, formatMessageAmount } from '../transfer/scaleUtils';
 import { TransfersDetailsModal } from '../transfer/TransfersDetailsModal';
@@ -131,6 +131,7 @@ export function SideBarMenu({
     const ids = new Set<string>();
     for (const item of transactionHistory) {
       if (item.type !== TransactionHistoryItemType.Swap) continue;
+      if (!FinalSwapStatuses.includes(item.data.status)) continue;
       for (const msg of item.data.msgIds ?? []) ids.add(msg.msgId.toLowerCase());
     }
     return ids;
@@ -173,8 +174,12 @@ export function SideBarMenu({
     });
     const swapItems: HistoryItem[] = transactionHistory
       .filter(
-        (item): item is Extract<TransactionHistoryItem, { type: 'swap' }> =>
-          item.type === TransactionHistoryItemType.Swap,
+        (
+          item,
+        ): item is Extract<
+          TransactionHistoryItem,
+          { type: typeof TransactionHistoryItemType.Swap }
+        > => item.type === TransactionHistoryItemType.Swap,
       )
       .map((item) => ({
         type: HistoryItemType.Swap,
@@ -212,9 +217,8 @@ export function SideBarMenu({
     setIsModalOpen(true);
   };
 
-  // Open modal when a new transfer is added (avoids showing stale data from the
-  // previous transfer, which would happen if we triggered on transferLoading
-  // because addTransfer is called after setTransferLoading(true)).
+  // Open modal when a new bridge transaction is added. Triggering from loading
+  // state can show stale data because addBridgeTransaction runs after loading starts.
   useEffect(() => {
     const prev = prevBridgeTransactionsLengthRef.current;
     prevBridgeTransactionsLengthRef.current = bridgeTransactions.length;
@@ -225,7 +229,7 @@ export function SideBarMenu({
         setIsModalOpen(true);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- transfers.length increasing guarantees a new transfers ref; listing transfers would re-run on status updates
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bridgeTransactions.length increasing guarantees a new bridgeTransactions ref; listing bridgeTransactions would re-run on status updates
   }, [bridgeTransactions.length]);
 
   useEffect(() => {

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -41,11 +41,12 @@ import { startRelativeTimeTicker } from './relativeTimeTicker';
 
 const HistoryItemType = {
   ...TransferItemType,
-  Swap: 'swap',
+  Swap: TransactionHistoryItemType.Swap,
 } as const;
 
 type HistoryItem =
-  | TransferItem
+  | (Extract<TransferItem, { type: typeof TransferItemType.Local }> & { transactionId?: string })
+  | Extract<TransferItem, { type: typeof TransferItemType.Api }>
   | { type: typeof HistoryItemType.Swap; data: SwapHistoryItem; transactionId: string };
 
 export function SideBarMenu({
@@ -85,6 +86,10 @@ export function SideBarMenu({
           item.type === TransactionHistoryItemType.Bridge,
       ),
     [transactionHistory],
+  );
+  const bridgeTransferData = useMemo(
+    () => bridgeTransactions.map((item) => item.data),
+    [bridgeTransactions],
   );
   const prevBridgeTransactionsLengthRef = useRef(bridgeTransactions.length);
 
@@ -126,22 +131,19 @@ export function SideBarMenu({
     const ids = new Set<string>();
     for (const item of transactionHistory) {
       if (item.type !== TransactionHistoryItemType.Swap) continue;
-      for (const msg of item.data.msgIds ?? []) ids.add(msg.msgId);
+      for (const msg of item.data.msgIds ?? []) ids.add(msg.msgId.toLowerCase());
     }
     return ids;
   }, [transactionHistory]);
 
   const visibleMessages = useMemo(
-    () => messages.filter((message) => !swapMessageIds.has(message.msgId)),
+    () => messages.filter((message) => !swapMessageIds.has(message.msgId.toLowerCase())),
     [messages, swapMessageIds],
   );
 
   // Merge local bridge transactions with API messages
   const warpCore = useWarpCore();
-  const allMergedTransfers = useMergedTransferHistory(
-    bridgeTransactions.map((item) => item.data),
-    visibleMessages,
-  );
+  const allMergedTransfers = useMergedTransferHistory(bridgeTransferData, visibleMessages);
 
   // Filter out API messages with unknown tokens
   const mergedTransfers = useMemo(
@@ -155,7 +157,20 @@ export function SideBarMenu({
     [allMergedTransfers, multiProvider, warpCore],
   );
 
+  const bridgeTransactionIdsByData = useMemo(() => {
+    const ids = new Map<TransferContext, string>();
+    for (const item of bridgeTransactions) ids.set(item.data, item.id);
+    return ids;
+  }, [bridgeTransactions]);
+
   const historyItems = useMemo<HistoryItem[]>(() => {
+    const bridgeItems = mergedTransfers.map((item): HistoryItem => {
+      if (item.type !== TransferItemType.Local) return item;
+      return {
+        ...item,
+        transactionId: bridgeTransactionIdsByData.get(item.data),
+      };
+    });
     const swapItems: HistoryItem[] = transactionHistory
       .filter(
         (item): item is Extract<TransactionHistoryItem, { type: 'swap' }> =>
@@ -166,10 +181,8 @@ export function SideBarMenu({
         data: item.data,
         transactionId: item.id,
       }));
-    return [...mergedTransfers, ...swapItems].sort(
-      (a, b) => getItemTimestamp(b) - getItemTimestamp(a),
-    );
-  }, [mergedTransfers, transactionHistory]);
+    return [...bridgeItems, ...swapItems].sort((a, b) => getItemTimestamp(b) - getItemTimestamp(a));
+  }, [bridgeTransactionIdsByData, mergedTransfers, transactionHistory]);
 
   // Infinite scroll handler
   const handleScroll = useCallback(() => {
@@ -192,8 +205,7 @@ export function SideBarMenu({
       return;
     }
     if (item.type === HistoryItemType.Local) {
-      const transactionId = bridgeTransactions.find((entry) => entry.data === item.data)?.id;
-      setSelectedTransfer({ transactionId, data: item.data });
+      setSelectedTransfer({ transactionId: item.transactionId, data: item.data });
     } else {
       setSelectedTransfer({ data: messageToTransferContext(item.data, multiProvider, warpCore) });
     }

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -23,13 +23,30 @@ import {
   useMergedTransferHistory,
 } from '../messages/useMergedTransferHistory';
 import { useMessageHistory } from '../messages/useMessageHistory';
-import { useStore } from '../store';
+import {
+  type AppState,
+  type TransactionHistoryItem,
+  TransactionHistoryItemType,
+  useStore,
+} from '../store';
+import { formatBalance as formatSwapBalance } from '../swap/balances/utils';
+import { getTokenByKeyFromMap } from '../swap/tokens/hooks';
+import { SwapHistoryItem, SwapStatus } from '../swap/types';
 import { tryFindToken, useWarpCore } from '../tokens/hooks';
 import { computeDestAmount, formatMessageAmount } from '../transfer/scaleUtils';
 import { TransfersDetailsModal } from '../transfer/TransfersDetailsModal';
 import { TransferContext, TransferStatus } from '../transfer/types';
 import { getIconByTransferStatus, STATUSES_WITH_ICON } from '../transfer/utils';
 import { startRelativeTimeTicker } from './relativeTimeTicker';
+
+const HistoryItemType = {
+  ...TransferItemType,
+  Swap: 'swap',
+} as const;
+
+type HistoryItem =
+  | TransferItem
+  | { type: typeof HistoryItemType.Swap; data: SwapHistoryItem; transactionId: string };
 
 export function SideBarMenu({
   onClickConnectWallet,
@@ -43,18 +60,33 @@ export function SideBarMenu({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedTransfer, setSelectedTransfer] = useState<TransferContext | null>(null);
+  const [selectedTransfer, setSelectedTransfer] = useState<{
+    transactionId?: string;
+    data: TransferContext;
+  } | null>(null);
   const [nowMs, setNowMs] = useState(() => Date.now());
 
   const multiProvider = useMultiProvider();
 
-  const { transfers, originChainName, routerAddressesByChainMap } = useStore((s) => ({
-    transfers: s.transfers,
-    originChainName: s.originChainName,
-    routerAddressesByChainMap: s.routerAddressesByChainMap,
-  }));
+  const { transactionHistory, originChainName, routerAddressesByChainMap, knownTokens } = useStore(
+    (s) => ({
+      transactionHistory: s.transactionHistory,
+      originChainName: s.originChainName,
+      routerAddressesByChainMap: s.routerAddressesByChainMap,
+      knownTokens: s.knownTokens,
+    }),
+  );
+  const setSelectedTransactionId = useStore((s) => s.setSelectedTransactionId);
 
-  const prevTransfersLengthRef = useRef(transfers.length);
+  const bridgeTransactions = useMemo(
+    () =>
+      transactionHistory.filter(
+        (item): item is Extract<TransactionHistoryItem, { type: 'bridge' }> =>
+          item.type === TransactionHistoryItemType.Bridge,
+      ),
+    [transactionHistory],
+  );
+  const prevBridgeTransactionsLengthRef = useRef(bridgeTransactions.length);
 
   // Get all connected wallet addresses (normalized for consistent matching)
   const { accounts } = useAccounts(multiProvider, config.addressBlacklist);
@@ -90,9 +122,26 @@ export function SideBarMenu({
     multiProvider,
   );
 
-  // Merge local transfers with API messages
+  const swapMessageIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const item of transactionHistory) {
+      if (item.type !== TransactionHistoryItemType.Swap) continue;
+      for (const msg of item.data.msgIds ?? []) ids.add(msg.msgId);
+    }
+    return ids;
+  }, [transactionHistory]);
+
+  const visibleMessages = useMemo(
+    () => messages.filter((message) => !swapMessageIds.has(message.msgId)),
+    [messages, swapMessageIds],
+  );
+
+  // Merge local bridge transactions with API messages
   const warpCore = useWarpCore();
-  const allMergedTransfers = useMergedTransferHistory(transfers, messages);
+  const allMergedTransfers = useMergedTransferHistory(
+    bridgeTransactions.map((item) => item.data),
+    visibleMessages,
+  );
 
   // Filter out API messages with unknown tokens
   const mergedTransfers = useMemo(
@@ -105,6 +154,22 @@ export function SideBarMenu({
       }),
     [allMergedTransfers, multiProvider, warpCore],
   );
+
+  const historyItems = useMemo<HistoryItem[]>(() => {
+    const swapItems: HistoryItem[] = transactionHistory
+      .filter(
+        (item): item is Extract<TransactionHistoryItem, { type: 'swap' }> =>
+          item.type === TransactionHistoryItemType.Swap,
+      )
+      .map((item) => ({
+        type: HistoryItemType.Swap,
+        data: item.data,
+        transactionId: item.id,
+      }));
+    return [...mergedTransfers, ...swapItems].sort(
+      (a, b) => getItemTimestamp(b) - getItemTimestamp(a),
+    );
+  }, [mergedTransfers, transactionHistory]);
 
   // Infinite scroll handler
   const handleScroll = useCallback(() => {
@@ -121,11 +186,16 @@ export function SideBarMenu({
     toast.success('Address copied to clipboard', { autoClose: 2000 });
   };
 
-  const handleItemClick = (item: TransferItem) => {
-    if (item.type === TransferItemType.Local) {
-      setSelectedTransfer(item.data);
+  const handleItemClick = (item: HistoryItem) => {
+    if (item.type === HistoryItemType.Swap) {
+      setSelectedTransactionId(item.transactionId);
+      return;
+    }
+    if (item.type === HistoryItemType.Local) {
+      const transactionId = bridgeTransactions.find((entry) => entry.data === item.data)?.id;
+      setSelectedTransfer({ transactionId, data: item.data });
     } else {
-      setSelectedTransfer(messageToTransferContext(item.data, multiProvider, warpCore));
+      setSelectedTransfer({ data: messageToTransferContext(item.data, multiProvider, warpCore) });
     }
     setIsModalOpen(true);
   };
@@ -134,14 +204,17 @@ export function SideBarMenu({
   // previous transfer, which would happen if we triggered on transferLoading
   // because addTransfer is called after setTransferLoading(true)).
   useEffect(() => {
-    const prev = prevTransfersLengthRef.current;
-    prevTransfersLengthRef.current = transfers.length;
-    if (transfers.length > prev) {
-      setSelectedTransfer(transfers[transfers.length - 1]);
-      setIsModalOpen(true);
+    const prev = prevBridgeTransactionsLengthRef.current;
+    prevBridgeTransactionsLengthRef.current = bridgeTransactions.length;
+    if (bridgeTransactions.length > prev) {
+      const latest = bridgeTransactions[bridgeTransactions.length - 1];
+      if (latest) {
+        setSelectedTransfer({ transactionId: latest.id, data: latest.data });
+        setIsModalOpen(true);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- transfers.length increasing guarantees a new transfers ref; listing transfers would re-run on status updates
-  }, [transfers.length]);
+  }, [bridgeTransactions.length]);
 
   useEffect(() => {
     setIsMenuOpen(isOpen);
@@ -194,7 +267,7 @@ export function SideBarMenu({
           />
           <div className="sidebar-menu-header flex w-full items-center justify-between bg-accent-gradient px-3.5 py-2 shadow-accent-glow dark:!shadow-none">
             <span className="text-base font-normal tracking-wider text-white">
-              Transfer History
+              Transaction History
             </span>
             <button
               onClick={refresh}
@@ -218,22 +291,19 @@ export function SideBarMenu({
             ) : (
               <>
                 <div className="sidebar-menu-list flex w-full grow flex-col divide-y">
-                  {mergedTransfers.length === 0 && !isLoading && (
+                  {historyItems.length === 0 && !isLoading && (
                     <div className="sidebar-menu-empty px-3.5 py-6 text-center text-sm text-gray-500 dark:text-foreground-primary">
-                      No transfers yet
+                      No transactions yet
                     </div>
                   )}
-                  {mergedTransfers.map((item) => (
+                  {historyItems.map((item) => (
                     <TransferSummary
-                      key={
-                        item.type === TransferItemType.Local
-                          ? `local-${item.data.timestamp}-${item.data.originTxHash || item.data.msgId || ''}`
-                          : `api-${item.data.msgId}`
-                      }
+                      key={getItemKey(item)}
                       item={item}
                       onClick={() => handleItemClick(item)}
                       multiProvider={multiProvider}
                       warpCore={warpCore}
+                      knownTokens={knownTokens}
                       nowMs={nowMs}
                     />
                   ))}
@@ -243,9 +313,9 @@ export function SideBarMenu({
                     <SpinnerIcon className="h-5 w-5" />
                   </div>
                 )}
-                {!hasMore && mergedTransfers.length > 0 && (
+                {!hasMore && historyItems.length > 0 && (
                   <div className="sidebar-menu-end px-3.5 py-3 text-center text-xs text-gray-400 dark:text-foreground-primary">
-                    No more transfers
+                    No more transactions
                   </div>
                 )}
               </>
@@ -260,7 +330,8 @@ export function SideBarMenu({
             setIsModalOpen(false);
             setSelectedTransfer(null);
           }}
-          transfer={selectedTransfer}
+          transfer={selectedTransfer.data}
+          transactionId={selectedTransfer.transactionId}
         />
       )}
     </>
@@ -272,61 +343,108 @@ function TransferSummary({
   onClick,
   multiProvider,
   warpCore,
+  knownTokens,
   nowMs,
 }: {
-  item: TransferItem;
+  item: HistoryItem;
   onClick: () => void;
   multiProvider: ReturnType<typeof useMultiProvider>;
   warpCore: ReturnType<typeof useWarpCore>;
+  knownTokens: AppState['knownTokens'];
   nowMs: number;
 }) {
-  const { originChain, destChain, amount, destAmount, status, token, destToken, timestamp } =
-    useMemo(() => {
-      if (item.type === TransferItemType.Local) {
-        const t = item.data;
-        const originToken = tryFindToken(warpCore, t.origin, t.originTokenAddressOrDenom);
-        const destinationToken = tryFindToken(warpCore, t.destination, t.destTokenAddressOrDenom);
-        return {
-          originChain: t.origin,
-          destChain: t.destination,
-          amount: t.amount,
-          destAmount: computeDestAmount(t.amount, originToken, destinationToken),
-          status: t.status,
-          token: originToken,
-          destToken: destinationToken,
-          timestamp: t.timestamp,
-        };
-      }
-      const msg = item.data;
-      const originChain = multiProvider.tryGetChainName(msg.originDomainId) || '';
-      const destChain = multiProvider.tryGetChainName(msg.destinationDomainId) || '';
-      const token = tryFindToken(warpCore, originChain, msg.sender);
-
-      let amount = '';
-      if (msg.warpTransfer?.amount && token) {
-        try {
-          amount = formatMessageAmount(msg.warpTransfer.amount, token);
-        } catch (err) {
-          logger.error('Failed to format warp transfer amount', err);
-        }
-      }
-
-      const destToken = tryFindToken(warpCore, destChain, msg.recipient);
-
+  const {
+    originChain,
+    destChain,
+    amount,
+    destAmount,
+    status,
+    token,
+    destToken,
+    tokenSymbol,
+    destTokenSymbol,
+    timestamp,
+  } = useMemo(() => {
+    if (item.type === HistoryItemType.Swap) {
+      const swap = item.data;
+      const srcToken = getTokenByKeyFromMap(
+        knownTokens,
+        `${swap.srcChain}-${swap.srcToken.toLowerCase()}`,
+      );
+      const dstToken = getTokenByKeyFromMap(
+        knownTokens,
+        `${swap.dstChain}-${swap.dstToken.toLowerCase()}`,
+      );
+      const originChain =
+        srcToken?.chainName ??
+        swap.srcTokenMeta?.chainName ??
+        multiProvider.tryGetChainName(swap.srcChain) ??
+        '';
+      const destChain =
+        dstToken?.chainName ??
+        swap.dstTokenMeta?.chainName ??
+        multiProvider.tryGetChainName(swap.dstChain) ??
+        '';
+      const srcDecimals = srcToken?.decimals ?? swap.srcTokenMeta?.decimals;
+      const dstDecimals = dstToken?.decimals ?? swap.dstTokenMeta?.decimals;
       return {
         originChain,
         destChain,
-        amount,
-        destAmount: computeDestAmount(amount, token, destToken),
-        status:
-          msg.status === MessageStatus.Delivered
-            ? TransferStatus.Delivered
-            : TransferStatus.ConfirmedTransfer,
-        token,
-        destToken,
-        timestamp: msg.origin.timestamp,
+        amount: formatSwapHistoryAmount(swap.amountIn, srcDecimals),
+        destAmount: formatSwapHistoryAmount(swap.amountOut, dstDecimals),
+        status: swapStatusToTransferStatus(swap.status),
+        token: srcToken,
+        destToken: dstToken,
+        tokenSymbol: srcToken?.symbol ?? swap.srcTokenMeta?.symbol,
+        destTokenSymbol: dstToken?.symbol ?? swap.dstTokenMeta?.symbol,
+        timestamp: swap.timestamp,
       };
-    }, [item.type, item.data, multiProvider, warpCore]);
+    }
+    if (item.type === TransferItemType.Local) {
+      const t = item.data;
+      const originToken = tryFindToken(warpCore, t.origin, t.originTokenAddressOrDenom);
+      const destinationToken = tryFindToken(warpCore, t.destination, t.destTokenAddressOrDenom);
+      return {
+        originChain: t.origin,
+        destChain: t.destination,
+        amount: t.amount,
+        destAmount: computeDestAmount(t.amount, originToken, destinationToken),
+        status: t.status,
+        token: originToken,
+        destToken: destinationToken,
+        timestamp: t.timestamp,
+      };
+    }
+    const msg = item.data;
+    const originChain = multiProvider.tryGetChainName(msg.originDomainId) || '';
+    const destChain = multiProvider.tryGetChainName(msg.destinationDomainId) || '';
+    const token = tryFindToken(warpCore, originChain, msg.sender);
+
+    let amount = '';
+    if (msg.warpTransfer?.amount && token) {
+      try {
+        amount = formatMessageAmount(msg.warpTransfer.amount, token);
+      } catch (err) {
+        logger.error('Failed to format warp transfer amount', err);
+      }
+    }
+
+    const destToken = tryFindToken(warpCore, destChain, msg.recipient);
+
+    return {
+      originChain,
+      destChain,
+      amount,
+      destAmount: computeDestAmount(amount, token, destToken),
+      status:
+        msg.status === MessageStatus.Delivered
+          ? TransferStatus.Delivered
+          : TransferStatus.ConfirmedTransfer,
+      token,
+      destToken,
+      timestamp: msg.origin.timestamp,
+    };
+  }, [item.type, item.data, multiProvider, warpCore, knownTokens]);
 
   return (
     <button onClick={onClick} className={`${styles.btn} justify-between py-3`}>
@@ -348,9 +466,9 @@ function TransferSummary({
             <span
               className={`sidebar-menu-token-text text-sm font-normal text-gray-800 dark:text-foreground-primary ${amount ? 'ml-1' : ''}`}
             >
-              {token?.symbol || 'Unknown token'}
+              {token?.symbol || tokenSymbol || 'Unknown token'}
             </span>
-            {destToken && (
+            {(destToken || destTokenSymbol) && (
               <>
                 <Image
                   className="sidebar-menu-arrow mx-1 dark:opacity-85 dark:brightness-0 dark:invert"
@@ -365,7 +483,7 @@ function TransferSummary({
                   </span>
                 )}
                 <span className="sidebar-menu-token-text ml-1 text-sm font-normal text-gray-800 dark:text-foreground-primary">
-                  {destToken.symbol}
+                  {destToken?.symbol || destTokenSymbol}
                 </span>
               </>
             )}
@@ -399,6 +517,44 @@ function TransferSummary({
       </div>
     </button>
   );
+}
+
+function getItemTimestamp(item: HistoryItem): number {
+  if (item.type === HistoryItemType.Swap || item.type === HistoryItemType.Local)
+    return item.data.timestamp;
+  return item.data.origin.timestamp;
+}
+
+function getItemKey(item: HistoryItem): string {
+  if (item.type === HistoryItemType.Swap) {
+    return `swap-${item.transactionId}`;
+  }
+  if (item.type === TransferItemType.Local) {
+    return `local-${item.data.timestamp}-${item.data.originTxHash || item.data.msgId || ''}`;
+  }
+  return `api-${item.data.msgId}`;
+}
+
+function formatSwapHistoryAmount(amount: string, decimals: number | undefined): string {
+  if (decimals == null) return '';
+  try {
+    return formatSwapBalance(BigInt(amount), decimals);
+  } catch {
+    return '';
+  }
+}
+
+function swapStatusToTransferStatus(status: SwapStatus): TransferStatus {
+  if (status === SwapStatus.ConfirmedDestination) return TransferStatus.Delivered;
+  if (status === SwapStatus.Failed || status === SwapStatus.DestSwapFailed)
+    return TransferStatus.Failed;
+  if (
+    status === SwapStatus.Bridging ||
+    status === SwapStatus.ConfirmingDestination ||
+    status === SwapStatus.ConfirmingOrigin
+  )
+    return TransferStatus.ConfirmedTransfer;
+  return TransferStatus.ConfirmingTransfer;
 }
 
 const styles = {

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -461,6 +461,7 @@ function TransferSummary({
       timestamp: msg.origin.timestamp,
     };
   }, [item.type, item.data, multiProvider, warpCore, knownTokens]);
+  const badgeType = item.type === HistoryItemType.Swap ? 'swap' : 'bridge';
 
   return (
     <button onClick={onClick} className={`${styles.btn} justify-between py-3`}>
@@ -504,8 +505,8 @@ function TransferSummary({
               </>
             )}
           </div>
-          <div className="mt-1 flex items-center">
-            <span className="sidebar-menu-route-text text-xxs font-normal tracking-wide text-gray-900 dark:text-foreground-primary">
+          <div className="mt-1 flex h-4 items-center">
+            <span className="sidebar-menu-route-text text-xxs font-normal leading-4 tracking-wide text-gray-900 dark:text-foreground-primary">
               {getChainDisplayName(multiProvider, originChain, true)}
             </span>
             <Image
@@ -515,23 +516,41 @@ function TransferSummary({
               height={10}
               alt=""
             />
-            <span className="sidebar-menu-route-text text-xxs font-normal tracking-wide text-gray-900 dark:text-foreground-primary">
+            <span className="sidebar-menu-route-text text-xxs font-normal leading-4 tracking-wide text-gray-900 dark:text-foreground-primary">
               {getChainDisplayName(multiProvider, destChain, true)}
             </span>
+            <HistoryTypeBadge type={badgeType} />
           </div>
           <div className="sidebar-menu-time mt-1 w-full text-left text-xxs font-normal text-gray-500 dark:text-foreground-primary">
             {formatTransferHistoryTimestamp(timestamp, nowMs)}
           </div>
         </div>
       </div>
-      <div className="flex h-5 w-5">
-        {STATUSES_WITH_ICON.includes(status) ? (
-          <Image src={getIconByTransferStatus(status)} width={25} height={25} alt="" />
-        ) : (
-          <SpinnerIcon className="-ml-1 mr-3 h-5 w-5" />
-        )}
+      <div className="ml-2 flex shrink-0 items-center">
+        <div className="flex h-5 w-5">
+          {STATUSES_WITH_ICON.includes(status) ? (
+            <Image src={getIconByTransferStatus(status)} width={25} height={25} alt="" />
+          ) : (
+            <SpinnerIcon className="-ml-1 mr-3 h-5 w-5" />
+          )}
+        </div>
       </div>
     </button>
+  );
+}
+
+function HistoryTypeBadge({ type }: { type: 'bridge' | 'swap' }) {
+  const isSwap = type === 'swap';
+  return (
+    <span
+      className={`sidebar-menu-type-badge ml-1.5 inline-flex h-3.5 shrink-0 items-center rounded border px-1.5 text-[0.55rem] font-medium leading-none dark:text-foreground-primary ${
+        isSwap
+          ? 'border-accent-500/35 bg-accent-50/25 text-accent-500 dark:border-primary-300/45 dark:bg-primary-300/15'
+          : 'border-blue-500/35 bg-blue-50/70 text-blue-600 dark:border-blue-300/40 dark:bg-blue-400/10'
+      }`}
+    >
+      {isSwap ? 'Swap' : 'Bridge'}
+    </span>
   );
 }
 

--- a/src/pages/embed.tsx
+++ b/src/pages/embed.tsx
@@ -4,7 +4,7 @@ import Head from 'next/head';
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 
 import { APP_NAME } from '../consts/app';
-import { useStore } from '../features/store';
+import { TransactionHistoryItemType, useStore } from '../features/store';
 import { TransfersDetailsModal } from '../features/transfer/TransfersDetailsModal';
 import { TransferTokenCard } from '../features/transfer/TransferTokenCard';
 import { TransferContext } from '../features/transfer/types';
@@ -47,8 +47,13 @@ function usePostMessageBridge() {
 
 /** Auto-opens TransfersDetailsModal when a new transfer starts. */
 function useAutoTransferModal() {
-  const transfers = useStore((s) => s.transfers);
-  const [selectedTransfer, setSelectedTransfer] = useState<TransferContext | null>(null);
+  const transfers = useStore((s) =>
+    s.transactionHistory.filter((item) => item.type === TransactionHistoryItemType.Bridge),
+  );
+  const [selectedTransfer, setSelectedTransfer] = useState<{
+    id: string;
+    data: TransferContext;
+  } | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const prevTransfersLengthRef = useRef(transfers.length);
 
@@ -64,7 +69,7 @@ function useAutoTransferModal() {
         );
         return;
       }
-      setSelectedTransfer(latestTransfer);
+      setSelectedTransfer({ id: latestTransfer.id, data: latestTransfer.data });
       setIsOpen(true);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- transfers.length increasing guarantees a new transfers ref; listing transfers would re-run on status updates
@@ -106,7 +111,8 @@ const EmbedPage: NextPage = () => {
         <TransfersDetailsModal
           isOpen={isModalOpen}
           onClose={closeModal}
-          transfer={selectedTransfer}
+          transfer={selectedTransfer.data}
+          transactionId={selectedTransfer.id}
         />
       )}
     </>

--- a/src/pages/embed.tsx
+++ b/src/pages/embed.tsx
@@ -47,8 +47,10 @@ function usePostMessageBridge() {
 
 /** Auto-opens TransfersDetailsModal when a new transfer starts. */
 function useAutoTransferModal() {
-  const transfers = useStore((s) =>
-    s.transactionHistory.filter((item) => item.type === TransactionHistoryItemType.Bridge),
+  const transactionHistory = useStore((s) => s.transactionHistory);
+  const transfers = useMemo(
+    () => transactionHistory.filter((item) => item.type === TransactionHistoryItemType.Bridge),
+    [transactionHistory],
   );
   const [selectedTransfer, setSelectedTransfer] = useState<{
     id: string;


### PR DESCRIPTION
## Summary
- unify bridge and swap history in a single typed transaction store
- open bridge or swap detail modals from the shared sidebar history
- hide GraphQL bridge legs that are already represented by local swap history