### PR TITLE
fix: remove compromised H/humanity route from Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -279,9 +279,6 @@ export const warpRouteWhitelist: Array<string> | null = [
   'FLT/fluence',
   'wpFLT/fluence',
 
-  // H
-  'H/humanity',
-
   // RCADE route
   'RCADE/arbitrum-bsc',
 


### PR DESCRIPTION
## Summary
- Removes the `H/humanity` warp route from the Nexus warp UI whitelist (`src/consts/warpRouteWhitelist.ts`), disabling it in the bridging UI.

## Context
The H/humanity warp route was compromised in the **2026-06-09 Humanity Protocol exploit**:
- The Ethereum collateral router (`0x44F161aE29361E332dEA039DFA2F404E0bC5B5Cc`) was upgraded to a malicious implementation via a compromised ProxyAdmin and drained (~141M H).
- The BSC synthetic leg remains minted but **unbacked**.
- The relayer denylist for this route is being applied separately on the mainnet3 hyperlane + fastpath relayers.

Pulling it from the Nexus whitelist prevents users from interacting with the broken/unsafe route in the UI.

## Test plan
- [ ] CI: `warpRouteWhitelist` test passes (it only asserts each remaining ID exists in the registry).
- [ ] Confirm `H/humanity` no longer appears in the Nexus warp UI route list after deploy.