### PR TITLE
feat: hyperswaps recovery status

### DIFF
--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -121,6 +121,7 @@ function DeliveryTargetWatcher({
     multiProvider,
     enabled: target.type === TransactionHistoryItemType.Swap && !graphQlDelivery.isDelivered,
   });
+  // Swap recovery status is centralized here so the modal stays display-only.
   useSwapStatus(swap, target.type === TransactionHistoryItemType.Swap ? target.id : null);
   const hasToasted = useRef(false);
   const hasUpdatedFromGraphQl = useRef(false);

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -25,6 +25,7 @@ import { assembleChainMetadata } from './chains/metadata';
 import type { UiToken } from './swap/tokens/types';
 import { getTokenKey as getSwapTokenKey } from './swap/tokens/utils';
 import { FinalSwapStatuses, LabeledMsgId, SwapHistoryItem, SwapStatus } from './swap/types';
+import type { RouteResponse } from './api/types';
 import {
   buildTokensArray,
   getTokenKey,
@@ -123,8 +124,13 @@ export interface AppState {
       originTxHash?: string;
       originBlockNumber?: number;
       destinationTxHash?: string;
+      originTxTimestamp?: number;
     },
   ) => void;
+  // Non-persisted: routes for active swap transactions, keyed by transactionId.
+  // Cleared on page reload. Used by useSwapStatus.
+  swapRouteByTransactionId: Map<string, RouteResponse>;
+  setSwapRoute: (transactionId: string, route: RouteResponse) => void;
   failUnconfirmedTransactions: () => void;
   selectedTransactionId: string | null;
   setSelectedTransactionId: (id: string | null) => void;
@@ -316,10 +322,19 @@ export const useStore = create<AppState>()(
                 originTxHash: item.data.originTxHash ?? options?.originTxHash,
                 originBlockNumber: item.data.originBlockNumber ?? options?.originBlockNumber,
                 destinationTxHash: item.data.destinationTxHash ?? options?.destinationTxHash,
+                originTxTimestamp: item.data.originTxTimestamp ?? options?.originTxTimestamp,
               },
             };
           }),
         }));
+      },
+      swapRouteByTransactionId: new Map(),
+      setSwapRoute: (transactionId, route) => {
+        set((state) => {
+          const next = new Map(state.swapRouteByTransactionId);
+          next.set(transactionId, route);
+          return { swapRouteByTransactionId: next };
+        });
       },
       failUnconfirmedTransactions: () => {
         set((state) => ({

--- a/src/features/swap/SwapDetailsModal.tsx
+++ b/src/features/swap/SwapDetailsModal.tsx
@@ -28,6 +28,7 @@ import { TransactionHistoryItemType, useStore } from '../store';
 import { formatBalance } from './balances/utils';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
 import { FinalSwapStatuses, SwapStatus, type SwapHistoryItem } from './types';
+import { useSwapStatus } from './useSwapStatus';
 
 const DEFAULT_TIMINGS: StageTimings = {
   [MessageStage.Finalized]: null,
@@ -52,6 +53,8 @@ const STATUS_DESCRIPTION: Record<SwapStatus, string> = {
   [SwapStatus.ConfirmingDestination]: 'Confirming on destination chain…',
   [SwapStatus.ConfirmedDestination]: 'Delivered',
   [SwapStatus.DestSwapFailed]: 'Destination swap reverted',
+  [SwapStatus.FailedRecovered]: 'Swap reverted — bridge token returned',
+  [SwapStatus.DestFailed]: 'Destination execution failed — funds stranded in ICA',
   [SwapStatus.Failed]: 'Swap failed',
 };
 
@@ -95,6 +98,9 @@ function SwapDetailsModalInner({
   const multiProvider = useMultiProvider();
   const tokenMap = useTokenByKeyMap();
   const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
+  const isIcaRoute = useStore(
+    (s) => !!s.swapRouteByTransactionId.get(transactionId)?.callCommitment,
+  );
 
   const {
     status,
@@ -122,20 +128,27 @@ function SwapDetailsModalInner({
   const srcDecimals = srcToken?.decimals ?? swap.srcTokenMeta?.decimals;
   const dstDecimals = dstToken?.decimals ?? swap.dstTokenMeta?.decimals;
 
+  // Reads the REVEAL tx receipt once it lands; drives transitions to ConfirmedDestination,
+  // FailedRecovered, and DestFailed by checking Transfer events client-side.
+  useSwapStatus(swap, transactionId);
+
   const isFailed = status === SwapStatus.Failed;
   const isDestFailed = status === SwapStatus.DestSwapFailed;
   const isDelivered = status === SwapStatus.ConfirmedDestination;
+  const isFailedRecovered = status === SwapStatus.FailedRecovered;
+  const isRevealFailed = status === SwapStatus.DestFailed;
   const isFinal = FinalSwapStatuses.includes(status);
 
-  // Poll the reveal message when present — its delivery tx IS the ICA
-  // execution on the destination chain, which is what actually completes
-  // the swap. Pure-bridge routes (no destination swap) have no reveal,
-  // so fall back to the warp message. Same-chain swaps have no msgIds.
+  // For ICA routes, only the reveal message delivery tx is the actual ICA execution.
+  // The warp/bridge message delivery tx is a CCTP bundle — wrong tx for swap detection.
+  // Track reveal separately so we never submit the bridge tx as destinationTxHash.
+  const revealMsgId = msgIds?.find((m) => m.label === 'reveal')?.msgId;
+  // pollingMsgId drives the timeline display — falls back to warp for pure-bridge routes.
   const pollingMsgId = (
-    msgIds?.find((m) => m.label === 'reveal') ??
-    msgIds?.find((m) => m.label === 'warp') ??
-    msgIds?.[0]
-  )?.msgId;
+    revealMsgId ??
+    msgIds?.find((m) => m.label === 'warp')?.msgId ??
+    msgIds?.[0]?.msgId
+  );
   const delivery = useMessageDeliveryStatus(pollingMsgId, !isFinal, multiProvider);
 
   const hasUpdatedDelivery = useRef(false);
@@ -144,12 +157,18 @@ function SwapDetailsModalInner({
   }, [pollingMsgId]);
 
   useEffect(() => {
-    if (
-      delivery.isDelivered &&
-      !hasUpdatedDelivery.current &&
-      status !== SwapStatus.ConfirmedDestination
-    ) {
-      hasUpdatedDelivery.current = true;
+    if (!delivery.isDelivered || hasUpdatedDelivery.current) return;
+    hasUpdatedDelivery.current = true;
+
+    if (isIcaRoute) {
+      // Only pass destinationTxHash when the reveal message delivered — that tx IS
+      // the ICA execution. If we fell back to polling the warp message, the delivery
+      // tx is the CCTP bridge bundle, which is useless for swap outcome detection.
+      const isRevealDelivery = pollingMsgId === revealMsgId;
+      updateSwapTransactionStatus(transactionId, status, {
+        ...(isRevealDelivery ? { destinationTxHash: delivery.destinationTxHash } : {}),
+      });
+    } else {
       updateSwapTransactionStatus(transactionId, SwapStatus.ConfirmedDestination, {
         destinationTxHash: delivery.destinationTxHash,
       });
@@ -160,6 +179,9 @@ function SwapDetailsModalInner({
     delivery.destinationTxHash,
     transactionId,
     status,
+    isIcaRoute,
+    pollingMsgId,
+    revealMsgId,
     updateSwapTransactionStatus,
   ]);
 
@@ -168,7 +190,9 @@ function SwapDetailsModalInner({
     status === SwapStatus.Bridging ||
     status === SwapStatus.ConfirmingDestination ||
     status === SwapStatus.ConfirmedDestination ||
-    isDestFailed;
+    isDestFailed ||
+    isFailedRecovered ||
+    isRevealFailed;
 
   const stage = useMemo<MessageStage>(() => {
     if (isDelivered) return MessageStage.Relayed;
@@ -240,7 +264,9 @@ function SwapDetailsModalInner({
             <div className="flex items-center text-xs font-normal">
               {isDelivered ? (
                 <h3 className="text-green-50">Delivered</h3>
-              ) : isDestFailed ? (
+              ) : isFailedRecovered ? (
+                <h3 className="text-blue-400">Recovered</h3>
+              ) : isDestFailed || isRevealFailed ? (
                 <h3 className="text-amber-600">Stranded</h3>
               ) : (
                 <h3 className="text-red-500">Failed</h3>
@@ -313,8 +339,20 @@ function SwapDetailsModalInner({
           <div className="mt-5 flex flex-col space-y-4">
             {isDestFailed && (
               <div className="rounded border border-amber-300 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
-                Origin succeeded and the bridge delivered, but the destination swap reverted. Funds
-                are sitting in your ICA — recovery is not yet wired in.
+                Origin succeeded and the bridge delivered, but the destination swap reverted. The
+                fallback swept the bridge token back to your wallet on the destination chain.
+              </div>
+            )}
+            {isFailedRecovered && (
+              <div className="rounded border border-blue-300 bg-blue-50 p-3 text-xs text-blue-800 dark:border-blue-500/40 dark:bg-blue-500/10 dark:text-blue-200">
+                The destination swap reverted and the bridge token was automatically returned to
+                your wallet on the destination chain.
+              </div>
+            )}
+            {isRevealFailed && (
+              <div className="rounded border border-amber-300 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+                The destination execution ran but both the swap and fallback failed. Bridge token
+                remains in your ICA. Please contact support.
               </div>
             )}
             <TransferProperty name="Sender Address" value={sender} url={fromUrl} />

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -278,7 +278,8 @@ function SwapFormContent() {
     const initialStep = bestRoute.raw.steps[0];
     const finalStep = bestRoute.raw.steps[bestRoute.raw.steps.length - 1];
     const destinationSwapStep = bestRoute.raw.steps.find(
-      (step) => step.type === 'swap' && step.chain === values.dstChain,
+      (step): step is Extract<(typeof bestRoute.raw.steps)[number], { type: 'swap' }> =>
+        step.type === 'swap' && step.chain === values.dstChain,
     );
     const timestamp = Date.now();
     const item: SwapHistoryItem = {
@@ -306,7 +307,7 @@ function SwapFormContent() {
       sender,
       recipient: effectiveRecipient,
       destinationOutcome:
-        bestRoute.raw.callCommitment && destinationSwapStep?.type === 'swap'
+        bestRoute.raw.callCommitment && destinationSwapStep
           ? {
               bridgeToken: destinationSwapStep.tokenIn,
               dstToken: destinationSwapStep.tokenOut,

--- a/src/features/swap/types.ts
+++ b/src/features/swap/types.ts
@@ -31,12 +31,18 @@ export enum SwapStatus {
   // Origin tx confirmed and bridge delivered, but the dest swap step
   // reverted — funds are sitting in the user's ICA on the dest chain.
   DestSwapFailed = 'dest-swap-failed',
+  // Fallback sub-plan swept bridge token to recipient automatically.
+  FailedRecovered = 'failed-recovered',
+  // REVEAL delivered but both swap and fallback sub-plans reverted — funds stranded in ICA.
+  DestFailed = 'dest-failed',
   Failed = 'failed',
 }
 
 export const FinalSwapStatuses = [
   SwapStatus.ConfirmedDestination,
   SwapStatus.DestSwapFailed,
+  SwapStatus.FailedRecovered,
+  SwapStatus.DestFailed,
   SwapStatus.Failed,
 ];
 
@@ -57,6 +63,8 @@ export interface SwapHistoryItem {
   destinationTxHash?: string;
   msgIds?: LabeledMsgId[];
   originBlockNumber?: number;
+  /** Unix seconds when the origin tx was broadcast. */
+  originTxTimestamp?: number;
 }
 
 // ── Form values ──────────────────────────────────────────────────────

--- a/src/features/swap/useSwap.ts
+++ b/src/features/swap/useSwap.ts
@@ -279,7 +279,9 @@ function labelMessages(messages: ParsedMessage[], route: AugmentedRoute): Labele
     }
 
     const ccsLabel = getCcsMessageLabel(msg.body);
-    if (msg === revealMsg) return { msgId: msg.msgId, label: 'reveal' as const };
+    if (ccsLabel === 'reveal' || msg === revealMsg) {
+      return { msgId: msg.msgId, label: 'reveal' as const };
+    }
     if (ccsLabel === 'commit') return { msgId: msg.msgId, label: ccsLabel };
 
     logger.warn('Unexpected swap message shape; labeling as commit', {

--- a/src/features/swap/useSwap.ts
+++ b/src/features/swap/useSwap.ts
@@ -279,10 +279,8 @@ function labelMessages(messages: ParsedMessage[], route: AugmentedRoute): Labele
     }
 
     const ccsLabel = getCcsMessageLabel(msg.body);
-    if (ccsLabel === 'reveal' || msg === revealMsg) {
-      return { msgId: msg.msgId, label: 'reveal' as const };
-    }
-    if (ccsLabel === 'commit') return { msgId: msg.msgId, label: ccsLabel };
+    if (ccsLabel) return { msgId: msg.msgId, label: ccsLabel };
+    if (msg === revealMsg) return { msgId: msg.msgId, label: 'reveal' as const };
 
     logger.warn('Unexpected swap message shape; labeling as commit', {
       msgId: msg.msgId,

--- a/src/features/swap/useSwap.ts
+++ b/src/features/swap/useSwap.ts
@@ -40,6 +40,7 @@ export function useSwap() {
   const multiProvider = useMultiProvider();
   const transactionFns = useTransactionFns(multiProvider);
   const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
+  const setSwapRoute = useStore((s) => s.setSwapRoute);
   const [error, setError] = useState<Error | null>(null);
   const [isPending, setIsPending] = useState(false);
 
@@ -51,6 +52,9 @@ export function useSwap() {
       const { transactionId, route, srcChainId } = args;
 
       if (!route.raw.tx) throw new Error('Route has no tx');
+
+      // Store route for status polling and recovery (non-persisted, session only).
+      setSwapRoute(transactionId, route.raw);
 
       const srcChainName = multiProvider.tryGetChainName(srcChainId);
       const protocol = multiProvider.tryGetProtocol(srcChainId);
@@ -115,7 +119,17 @@ export function useSwap() {
         // Order is critical: post to CCS BEFORE broadcasting.
         if (route.raw.callCommitment) {
           updateSwapTransactionStatus(transactionId, SwapStatus.CreatingTxs);
-          await postCommitment(route.raw.callCommitment);
+          try {
+            await postCommitment(route.raw.callCommitment);
+          } catch (ccsErr) {
+            logger.error('CCS post failed — aborting swap', ccsErr);
+            updateSwapTransactionStatus(transactionId, SwapStatus.Failed);
+            const err = new Error(
+              'Could not register swap with the coordination service. Your funds are safe — please try again.',
+            );
+            setError(err);
+            throw err;
+          }
         }
 
         updateSwapTransactionStatus(transactionId, SwapStatus.SigningSwap);
@@ -172,6 +186,7 @@ export function useSwap() {
         updateSwapTransactionStatus(transactionId, SwapStatus.Bridging, {
           msgIds: labelMessages(parsed.messages, route),
           originBlockNumber: parsed.originBlockNumber,
+          originTxTimestamp: Math.floor(Date.now() / 1000),
         });
 
         return hash;
@@ -184,7 +199,7 @@ export function useSwap() {
         setIsPending(false);
       }
     },
-    [transactionFns, multiProvider, updateSwapTransactionStatus],
+    [transactionFns, multiProvider, updateSwapTransactionStatus, setSwapRoute],
   );
 
   return { execute, isPending, error };
@@ -250,20 +265,16 @@ function labelMessages(messages: ParsedMessage[], route: AugmentedRoute): Labele
       .map((s) => s.router.toLowerCase()),
   );
 
-  let nonWarpCount = 0;
+  const nonWarp = messages.filter((m) => !bridgeRouters.has(m.sender.toLowerCase()));
+  // callRemoteCommitReveal dispatches COMMIT first, REVEAL last. CCTP aggregation
+  // routes prepend an extra internal message, so identify REVEAL as the last
+  // non-warp message rather than counting from the front.
+  const revealMsg = nonWarp.at(-1);
+
   return messages.map((msg) => {
     if (bridgeRouters.has(msg.sender.toLowerCase())) {
       return { msgId: msg.msgId, label: 'warp' as const };
     }
-    // Commit precedes reveal in the CCS protocol; >2 non-warp messages is unexpected.
-    if (nonWarpCount >= 2) {
-      logger.warn('Unexpected non-warp message count in swap receipt', {
-        nonWarpCount,
-        msgId: msg.msgId,
-      });
-    }
-    const label = nonWarpCount === 0 ? ('commit' as const) : ('reveal' as const);
-    nonWarpCount++;
-    return { msgId: msg.msgId, label };
+    return { msgId: msg.msgId, label: msg === revealMsg ? 'reveal' : 'commit' };
   });
 }

--- a/src/features/swap/useSwapStatus.ts
+++ b/src/features/swap/useSwapStatus.ts
@@ -1,0 +1,130 @@
+import { useEffect, useRef } from 'react';
+import { toast } from 'react-toastify';
+
+import { isZeroishAddress } from '@hyperlane-xyz/utils';
+import { useMultiProvider } from '../chains/hooks';
+import { useStore } from '../store';
+import { FinalSwapStatuses, SwapStatus, type SwapHistoryItem } from './types';
+
+// ERC20 Transfer(address indexed from, address indexed to, uint256 value)
+const TRANSFER_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+
+type ReceiptProvider = {
+  getTransactionReceipt(
+    hash: string,
+  ): Promise<{ logs: Array<{ topics: string[]; address: string }> } | null>;
+};
+
+async function detectSwapOutcome(
+  provider: ReceiptProvider,
+  destinationTxHash: string,
+  recipient: string,
+  bridgeToken: string,
+  dstToken: string,
+): Promise<'success' | 'failed_recovered' | 'dest_failed'> {
+  const receipt = await provider.getTransactionReceipt(destinationTxHash);
+  if (!receipt) return 'dest_failed';
+
+  const recipientLower = recipient.toLowerCase();
+  const bridgeTokenLower = bridgeToken.toLowerCase();
+  const dstTokenLower = dstToken.toLowerCase();
+
+  let destSwapSucceeded = false;
+  let fallbackDelivered = false;
+
+  for (const log of receipt.logs) {
+    if (log.topics[0] !== TRANSFER_TOPIC) continue;
+    if (log.topics.length < 3) continue;
+
+    // topics are 32-byte hex strings; last 40 chars are the address
+    const to = `0x${log.topics[2]!.slice(26)}`.toLowerCase();
+    const addr = log.address.toLowerCase();
+
+    if (addr === dstTokenLower && to === recipientLower) destSwapSucceeded = true;
+    if (addr === bridgeTokenLower && to === recipientLower) fallbackDelivered = true;
+  }
+
+  if (destSwapSucceeded) return 'success';
+  if (fallbackDelivered) return 'failed_recovered';
+  return 'dest_failed';
+}
+
+// Fires once when the REVEAL tx hash lands on a swap. Reads the receipt directly
+// from the destination chain RPC to determine swap outcome without polling the engine.
+export function useSwapStatus(swap: SwapHistoryItem | undefined, transactionId: string | null) {
+  const route = useStore((s) =>
+    transactionId ? s.swapRouteByTransactionId.get(transactionId) : undefined,
+  );
+  const updateStatus = useStore((s) => s.updateSwapTransactionStatus);
+  const multiProvider = useMultiProvider();
+  const lastProcessedTxRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const { destinationTxHash, status, dstChain, recipient } = swap ?? {};
+    if (!destinationTxHash || !transactionId || !route?.callCommitment) return;
+    if (status && FinalSwapStatuses.includes(status)) return;
+    if (lastProcessedTxRef.current === destinationTxHash) return;
+    lastProcessedTxRef.current = destinationTxHash;
+
+    const destSwapStep = route.steps.find((s) => s.type === 'swap' && s.chain === dstChain);
+
+    // No dest swap on this ICA route — bridge delivered, that's a success.
+    if (!destSwapStep || destSwapStep.type !== 'swap') {
+      updateStatus(transactionId, SwapStatus.ConfirmedDestination);
+      toast.success('Swap complete! Funds have arrived.');
+      return;
+    }
+
+    const bridgeToken = destSwapStep.tokenIn;
+    const dstToken = destSwapStep.tokenOut;
+
+    // Native output — Transfer events won't show ETH, optimistically assume success.
+    if (isZeroishAddress(dstToken)) {
+      updateStatus(transactionId, SwapStatus.ConfirmedDestination);
+      toast.success('Swap complete! Funds have arrived.');
+      return;
+    }
+
+    let provider: ReceiptProvider | null = null;
+    try {
+      const chainName = multiProvider.tryGetChainName(dstChain!);
+      if (chainName) provider = multiProvider.getEthersV5Provider(chainName);
+    } catch {
+      // chain not registered — fall through to optimistic success below
+    }
+
+    if (!provider) {
+      updateStatus(transactionId, SwapStatus.ConfirmedDestination);
+      toast.success('Swap complete! Funds have arrived.');
+      return;
+    }
+
+    detectSwapOutcome(provider, destinationTxHash, recipient!, bridgeToken, dstToken)
+      .then((outcome) => {
+        if (outcome === 'success') {
+          updateStatus(transactionId, SwapStatus.ConfirmedDestination);
+          toast.success('Swap complete! Funds have arrived.');
+        } else if (outcome === 'failed_recovered') {
+          updateStatus(transactionId, SwapStatus.FailedRecovered);
+          toast.success('Swap failed — bridge token returned to your wallet.');
+        } else {
+          updateStatus(transactionId, SwapStatus.DestFailed);
+          toast.error('Swap failed — please contact support, your funds may be in your ICA.');
+        }
+      })
+      .catch(() => {
+        // Receipt read failed — optimistically show success to avoid false negatives.
+        updateStatus(transactionId, SwapStatus.ConfirmedDestination);
+        toast.success('Swap complete! Funds have arrived.');
+      });
+  }, [
+    swap?.destinationTxHash,
+    swap?.status,
+    swap?.dstChain,
+    swap?.recipient,
+    transactionId,
+    route,
+    multiProvider,
+    updateStatus,
+  ]);
+}

--- a/src/features/swap/useSwapStatus.ts
+++ b/src/features/swap/useSwapStatus.ts
@@ -37,7 +37,7 @@ async function detectSwapOutcome(
     if (log.topics[0] !== TRANSFER_TOPIC) continue;
     if (log.topics.length < 3) continue;
 
-    // topics are 32-byte hex strings; last 40 chars are the address
+    // Indexed addresses are 0x + 24 leading-zero chars + 40 address chars.
     const to = `0x${log.topics[2]!.slice(26)}`.toLowerCase();
     const addr = log.address.toLowerCase();
 
@@ -93,12 +93,11 @@ export function useSwapStatus(swap: SwapHistoryItem | undefined, transactionId: 
       const chainName = multiProvider.tryGetChainName(dstChain!);
       if (chainName) provider = multiProvider.getEthersV5Provider(chainName);
     } catch {
-      // chain not registered — fall through to optimistic success below
+      // chain not registered — keep confirming so a later render can retry
     }
 
     if (!provider) {
-      updateStatus(transactionId, SwapStatus.ConfirmedDestination);
-      toast.success('Swap complete! Funds have arrived.');
+      lastProcessedTxRef.current = null;
       return;
     }
 
@@ -116,9 +115,7 @@ export function useSwapStatus(swap: SwapHistoryItem | undefined, transactionId: 
         }
       })
       .catch(() => {
-        // Receipt read failed — optimistically show success to avoid false negatives.
-        updateStatus(transactionId, SwapStatus.ConfirmedDestination);
-        toast.success('Swap complete! Funds have arrived.');
+        lastProcessedTxRef.current = null;
       });
   }, [
     swap?.destinationTxHash,

--- a/src/features/wallet/SideBarMenu.tsx
+++ b/src/features/wallet/SideBarMenu.tsx
@@ -580,9 +580,15 @@ function formatSwapHistoryAmount(amount: string, decimals: number | undefined): 
 }
 
 function swapStatusToTransferStatus(status: SwapStatus): TransferStatus {
+  const failedSwapStatuses = [
+    SwapStatus.Failed,
+    SwapStatus.DestSwapFailed,
+    SwapStatus.FailedRecovered,
+    SwapStatus.DestFailed,
+  ];
+
   if (status === SwapStatus.ConfirmedDestination) return TransferStatus.Delivered;
-  if (status === SwapStatus.Failed || status === SwapStatus.DestSwapFailed)
-    return TransferStatus.Failed;
+  if (failedSwapStatuses.includes(status)) return TransferStatus.Failed;
   if (
     status === SwapStatus.Bridging ||
     status === SwapStatus.ConfirmingDestination ||


### PR DESCRIPTION
## Summary

Adds destination outcome handling for Hyperswap/ICA routes so swaps do not get marked complete just because the Hyperlane message delivered.

- Tracks swap route metadata during the active session and persists the minimal destination outcome fields needed after reload.
- Adds destination receipt inspection for REVEAL transactions to distinguish successful destination swaps, automatic bridge-token recovery, and stranded ICA funds.
- Adds `FailedRecovered` and `DestFailed` terminal swap states with modal/sidebar UI copy for recovered vs stranded outcomes.
- Keeps destination-outcome swaps in `ConfirmingDestination` until receipt inspection completes, and retries instead of finalizing success on RPC/provider uncertainty.
- Improves CCS message labeling by trusting body-derived commit/reveal labels before falling back to positional reveal detection.
- Handles CCS registration failures before broadcasting so users do not sign swaps that were not registered with the coordination service.