### PR TITLE
fix: watch transaction delivery in background

### DIFF
--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -4,6 +4,13 @@ import { ProtocolType } from '@hyperlane-xyz/utils';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef } from 'react';
 import { toast } from 'react-toastify';
+import {
+  decodeFunctionResult,
+  encodeFunctionData,
+  parseAbi,
+  toEventSelector,
+  type Hex,
+} from 'viem';
 
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
@@ -13,10 +20,13 @@ import { TransferStatus } from '../transfer/types';
 import { useMessageDeliveryStatus } from './useMessageDeliveryStatus';
 
 const MAILBOX_DELIVERY_POLL_INTERVAL_MS = 3_000;
-const MAILBOX_DELIVERED_SELECTOR = '0xe495f1d4';
-const MAILBOX_PROCESSED_AT_SELECTOR = '0x07a2fda1';
-const MAILBOX_PROCESS_ID_TOPIC =
-  '0x1cae38cdd3d3919489272725a5ae62a4f48b2989b0dae843d3c279fee18073a9';
+const MAILBOX_ABI = parseAbi([
+  // Mirrors the stable Hyperlane Mailbox delivery surface used by the SDK.
+  'function delivered(bytes32) view returns (bool)',
+  'function processedAt(bytes32) view returns (uint256)',
+  'event ProcessId(bytes32 indexed messageId)',
+]);
+const MAILBOX_PROCESS_ID_TOPIC = toEventSelector('ProcessId(bytes32)');
 
 type BridgeDeliveryTarget = {
   id: string;
@@ -221,20 +231,10 @@ async function getMailboxDeliveryStatus({
       return { isDelivered: false, destinationTxHash: undefined };
     }
     const provider = typedProvider.provider as EthersLikeProvider;
-    const delivered = await callMailboxBoolean(
-      provider,
-      mailbox,
-      MAILBOX_DELIVERED_SELECTOR,
-      msgId,
-    );
+    const delivered = await callMailboxBoolean(provider, mailbox, 'delivered', msgId);
     if (!delivered) return { isDelivered: false, destinationTxHash: undefined };
 
-    const processedAt = await callMailboxUint(
-      provider,
-      mailbox,
-      MAILBOX_PROCESSED_AT_SELECTOR,
-      msgId,
-    );
+    const processedAt = await callMailboxUint(provider, mailbox, 'processedAt', msgId);
     const destinationTxHash =
       processedAt > 0n
         ? await findProcessTxHash(provider, mailbox, msgId, Number(processedAt))
@@ -250,21 +250,35 @@ async function getMailboxDeliveryStatus({
 async function callMailboxBoolean(
   provider: EthersLikeProvider,
   mailbox: string,
-  selector: string,
+  functionName: 'delivered',
   msgId: string,
 ) {
-  const raw = await provider.call({ to: mailbox, data: encodeMailboxCall(selector, msgId) });
-  return BigInt(raw) === 1n;
+  const raw = await provider.call({
+    to: mailbox,
+    data: encodeMailboxCall(functionName, msgId),
+  });
+  return decodeFunctionResult({
+    abi: MAILBOX_ABI,
+    functionName,
+    data: raw as Hex,
+  });
 }
 
 async function callMailboxUint(
   provider: EthersLikeProvider,
   mailbox: string,
-  selector: string,
+  functionName: 'processedAt',
   msgId: string,
 ) {
-  const raw = await provider.call({ to: mailbox, data: encodeMailboxCall(selector, msgId) });
-  return BigInt(raw);
+  const raw = await provider.call({
+    to: mailbox,
+    data: encodeMailboxCall(functionName, msgId),
+  });
+  return decodeFunctionResult({
+    abi: MAILBOX_ABI,
+    functionName,
+    data: raw as Hex,
+  });
 }
 
 async function findProcessTxHash(
@@ -282,8 +296,12 @@ async function findProcessTxHash(
   return log?.transactionHash;
 }
 
-function encodeMailboxCall(selector: string, msgId: string) {
-  return `${selector}${msgId.replace(/^0x/, '')}`;
+function encodeMailboxCall(functionName: 'delivered' | 'processedAt', msgId: string) {
+  return encodeFunctionData({
+    abi: MAILBOX_ABI,
+    functionName,
+    args: [msgId as Hex],
+  });
 }
 
 function getSwapDeliveryMsgId(msgIds: LabeledMsgId[]) {

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -234,11 +234,16 @@ async function getMailboxDeliveryStatus({
     const delivered = await callMailboxBoolean(provider, mailbox, 'delivered', msgId);
     if (!delivered) return { isDelivered: false, destinationTxHash: undefined };
 
-    const processedAt = await callMailboxUint(provider, mailbox, 'processedAt', msgId);
-    const destinationTxHash =
-      processedAt > 0n
-        ? await findProcessTxHash(provider, mailbox, msgId, Number(processedAt))
-        : undefined;
+    let destinationTxHash: string | undefined;
+    try {
+      const processedAt = await callMailboxUint(provider, mailbox, 'processedAt', msgId);
+      destinationTxHash =
+        processedAt > 0n
+          ? await findProcessTxHash(provider, mailbox, msgId, Number(processedAt))
+          : undefined;
+    } catch (err) {
+      logger.warn('Mailbox delivered but process transaction lookup failed', err as Error);
+    }
 
     return { isDelivered: true, destinationTxHash };
   } catch (err) {

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { toast } from 'react-toastify';
+
+import { useMultiProvider } from '../chains/hooks';
+import { TransactionHistoryItemType, useStore } from '../store';
+import { FinalSwapStatuses, SwapStatus, type LabeledMsgId } from '../swap/types';
+import { TransferStatus } from '../transfer/types';
+import { useMessageDeliveryStatus } from './useMessageDeliveryStatus';
+
+type DeliveryTarget = {
+  id: string;
+  type: typeof TransactionHistoryItemType.Bridge | typeof TransactionHistoryItemType.Swap;
+  msgId: string;
+};
+
+export function TransactionDeliveryWatcher() {
+  const transactionHistory = useStore((s) => s.transactionHistory);
+
+  const targets = useMemo(
+    () =>
+      transactionHistory.flatMap((item): DeliveryTarget[] => {
+        if (item.type === TransactionHistoryItemType.Bridge) {
+          if (
+            item.data.status !== TransferStatus.ConfirmedTransfer ||
+            !item.data.msgId ||
+            item.data.destinationTxHash
+          ) {
+            return [];
+          }
+          return [{ id: item.id, type: item.type, msgId: item.data.msgId }];
+        }
+
+        if (
+          FinalSwapStatuses.includes(item.data.status) ||
+          !item.data.msgIds?.length ||
+          item.data.destinationTxHash
+        ) {
+          return [];
+        }
+
+        const msgId = getSwapDeliveryMsgId(item.data.msgIds);
+        return msgId ? [{ id: item.id, type: item.type, msgId }] : [];
+      }),
+    [transactionHistory],
+  );
+
+  return (
+    <>
+      {targets.map((target) => (
+        <DeliveryTargetWatcher key={`${target.type}-${target.id}-${target.msgId}`} {...target} />
+      ))}
+    </>
+  );
+}
+
+function DeliveryTargetWatcher({ id, type, msgId }: DeliveryTarget) {
+  const multiProvider = useMultiProvider();
+  const updateBridgeTransactionStatus = useStore((s) => s.updateBridgeTransactionStatus);
+  const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
+  const delivery = useMessageDeliveryStatus(msgId, true, multiProvider);
+  const hasUpdated = useRef(false);
+
+  useEffect(() => {
+    hasUpdated.current = false;
+  }, [msgId]);
+
+  useEffect(() => {
+    if (!delivery.isDelivered || hasUpdated.current) return;
+    hasUpdated.current = true;
+
+    if (type === TransactionHistoryItemType.Bridge) {
+      updateBridgeTransactionStatus(id, TransferStatus.Delivered, {
+        destinationTxHash: delivery.destinationTxHash,
+      });
+      return;
+    }
+
+    updateSwapTransactionStatus(id, SwapStatus.ConfirmedDestination, {
+      destinationTxHash: delivery.destinationTxHash,
+    });
+    toast.success('Swap complete! Funds have arrived.');
+  }, [
+    delivery.isDelivered,
+    delivery.destinationTxHash,
+    id,
+    type,
+    updateBridgeTransactionStatus,
+    updateSwapTransactionStatus,
+  ]);
+
+  return null;
+}
+
+function getSwapDeliveryMsgId(msgIds: LabeledMsgId[]) {
+  const normalized = normalizePersistedMsgLabels(msgIds);
+  return (
+    normalized.find((m) => m.label === 'reveal') ??
+    normalized.find((m) => m.label === 'warp') ??
+    normalized[0]
+  )?.msgId;
+}
+
+function normalizePersistedMsgLabels(msgIds: LabeledMsgId[]) {
+  if (
+    msgIds.length === 3 &&
+    msgIds[0]?.label === 'commit' &&
+    msgIds[1]?.label === 'reveal' &&
+    msgIds[2]?.label === 'reveal'
+  ) {
+    return [{ ...msgIds[0], label: 'warp' }, { ...msgIds[1], label: 'commit' }, msgIds[2]];
+  }
+  return msgIds;
+}

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -5,10 +5,11 @@ import { toast } from 'react-toastify';
 
 import { useMultiProvider } from '../chains/hooks';
 import { TransactionHistoryItemType, useStore } from '../store';
-import { FinalSwapStatuses, SwapStatus, type LabeledMsgId } from '../swap/types';
+import { FinalSwapStatuses, SwapStatus } from '../swap/types';
 import { TransferStatus } from '../transfer/types';
 import { useEvmMailboxDeliveryStatus } from './useEvmMailboxDeliveryStatus';
 import { useMessageDeliveryStatus } from './useMessageDeliveryStatus';
+import { getSwapDeliveryMsgId } from './utils';
 
 type BridgeDeliveryTarget = {
   id: string;
@@ -26,6 +27,8 @@ type SwapDeliveryTarget = {
 
 type DeliveryTarget = BridgeDeliveryTarget | SwapDeliveryTarget;
 
+const MAX_BACKGROUND_DELIVERY_TARGETS = 5;
+
 export function TransactionDeliveryWatcher() {
   const multiProvider = useMultiProvider();
   const chainAddresses = useStore((s) => s.chainAddresses);
@@ -33,28 +36,39 @@ export function TransactionDeliveryWatcher() {
 
   const targets = useMemo(
     () =>
-      transactionHistory.flatMap((item): DeliveryTarget[] => {
-        if (item.type === TransactionHistoryItemType.Bridge) {
-          if (
-            item.data.status !== TransferStatus.ConfirmedTransfer ||
-            !item.data.msgId ||
-            item.data.destinationTxHash
-          ) {
-            return [];
+      transactionHistory
+        .flatMap((item): DeliveryTarget[] => {
+          if (item.type === TransactionHistoryItemType.Bridge) {
+            if (
+              item.data.status !== TransferStatus.ConfirmedTransfer ||
+              !item.data.msgId ||
+              item.data.destinationTxHash
+            ) {
+              return [];
+            }
+            return [{ id: item.id, type: item.type, msgId: item.data.msgId }];
           }
-          return [{ id: item.id, type: item.type, msgId: item.data.msgId }];
-        }
 
-        if (!item.data.msgIds?.length) return [];
-        if (FinalSwapStatuses.includes(item.data.status) && item.data.destinationTxHash) return [];
+          if (item.type !== TransactionHistoryItemType.Swap) return [];
 
-        const destinationChain = multiProvider.tryGetChainName(item.data.dstChain);
-        if (!destinationChain) return [];
-        const msgId = getSwapDeliveryMsgId(item.data.msgIds);
-        return msgId
-          ? [{ id: item.id, type: item.type, msgId, destinationChain, status: item.data.status }]
-          : [];
-      }),
+          if (!item.data.msgIds?.length) return [];
+          if (FinalSwapStatuses.includes(item.data.status)) {
+            if (
+              item.data.status !== SwapStatus.ConfirmedDestination ||
+              item.data.destinationTxHash
+            ) {
+              return [];
+            }
+          }
+
+          const destinationChain = multiProvider.tryGetChainName(item.data.dstChain);
+          if (!destinationChain) return [];
+          const msgId = getSwapDeliveryMsgId(item.data.msgIds);
+          return msgId
+            ? [{ id: item.id, type: item.type, msgId, destinationChain, status: item.data.status }]
+            : [];
+        })
+        .slice(-MAX_BACKGROUND_DELIVERY_TARGETS),
     [multiProvider, transactionHistory],
   );
 
@@ -143,12 +157,4 @@ function DeliveryTargetWatcher({
   ]);
 
   return null;
-}
-
-function getSwapDeliveryMsgId(msgIds: LabeledMsgId[]) {
-  return (
-    msgIds.find((m) => m.label === 'reveal') ??
-    msgIds.find((m) => m.label === 'warp') ??
-    msgIds[0]
-  )?.msgId;
 }

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -142,7 +142,7 @@ function DeliveryTargetWatcher({
       });
       if (target.status !== SwapStatus.ConfirmedDestination && !hasToasted.current) {
         hasToasted.current = true;
-        toast.success('Swap complete! Finalizing details...');
+        toast.success('Swap complete! Funds have arrived.');
       }
     }
   }, [

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -1,5 +1,6 @@
 import type { ChainAddresses } from '@hyperlane-xyz/registry';
 import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
+import type { MutableRefObject } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
 import { toast } from 'react-toastify';
 
@@ -32,44 +33,42 @@ const MAX_BACKGROUND_DELIVERY_TARGETS = 5;
 export function TransactionDeliveryWatcher() {
   const multiProvider = useMultiProvider();
   const chainAddresses = useStore((s) => s.chainAddresses);
+  const selectedTransactionId = useStore((s) => s.selectedTransactionId);
   const transactionHistory = useStore((s) => s.transactionHistory);
 
-  const targets = useMemo(
-    () =>
-      transactionHistory
-        .flatMap((item): DeliveryTarget[] => {
-          if (item.type === TransactionHistoryItemType.Bridge) {
-            const shouldWatchBridge =
-              item.data.status === TransferStatus.ConfirmedTransfer ||
-              item.data.status === TransferStatus.Delivered;
-            if (!shouldWatchBridge || !item.data.msgId || item.data.destinationTxHash) {
-              return [];
-            }
-            return [{ id: item.id, type: item.type, msgId: item.data.msgId }];
-          }
+  const targets = useMemo(() => {
+    const deliveryTargets = transactionHistory.flatMap((item): DeliveryTarget[] => {
+      if (item.type === TransactionHistoryItemType.Bridge) {
+        const shouldWatchBridge =
+          item.data.status === TransferStatus.ConfirmedTransfer ||
+          item.data.status === TransferStatus.Delivered;
+        if (!shouldWatchBridge || !item.data.msgId || item.data.destinationTxHash) {
+          return [];
+        }
+        return [{ id: item.id, type: item.type, msgId: item.data.msgId }];
+      }
 
-          if (item.type !== TransactionHistoryItemType.Swap) return [];
+      if (item.type !== TransactionHistoryItemType.Swap) return [];
 
-          if (!item.data.msgIds?.length) return [];
-          if (FinalSwapStatuses.includes(item.data.status)) {
-            if (
-              item.data.status !== SwapStatus.ConfirmedDestination ||
-              item.data.destinationTxHash
-            ) {
-              return [];
-            }
-          }
+      if (!item.data.msgIds?.length) return [];
+      if (FinalSwapStatuses.includes(item.data.status)) {
+        if (item.data.status !== SwapStatus.ConfirmedDestination || item.data.destinationTxHash) {
+          return [];
+        }
+      }
 
-          const destinationChain = multiProvider.tryGetChainName(item.data.dstChain);
-          if (!destinationChain) return [];
-          const msgId = getSwapDeliveryMsgId(item.data.msgIds);
-          return msgId
-            ? [{ id: item.id, type: item.type, msgId, destinationChain, status: item.data.status }]
-            : [];
-        })
-        .slice(-MAX_BACKGROUND_DELIVERY_TARGETS),
-    [multiProvider, transactionHistory],
-  );
+      const destinationChain = multiProvider.tryGetChainName(item.data.dstChain);
+      if (!destinationChain) return [];
+      const msgId = getSwapDeliveryMsgId(item.data.msgIds);
+      return msgId
+        ? [{ id: item.id, type: item.type, msgId, destinationChain, status: item.data.status }]
+        : [];
+    });
+
+    return prioritizeSelectedTarget(deliveryTargets, selectedTransactionId).slice(
+      -MAX_BACKGROUND_DELIVERY_TARGETS,
+    );
+  }, [multiProvider, selectedTransactionId, transactionHistory]);
 
   return (
     <>
@@ -105,26 +104,46 @@ function DeliveryTargetWatcher({
   });
   const hasToasted = useRef(false);
   const hasUpdatedFromGraphQl = useRef(false);
+  const hasBackfilledGraphQlHash = useRef(false);
   const hasUpdatedFromMailbox = useRef(false);
 
   useEffect(() => {
     hasToasted.current = false;
     hasUpdatedFromGraphQl.current = false;
+    hasBackfilledGraphQlHash.current = false;
     hasUpdatedFromMailbox.current = false;
   }, [target.id, target.msgId]);
 
   useEffect(() => {
     if (target.type === TransactionHistoryItemType.Bridge) {
-      if (!graphQlDelivery.isDelivered || hasUpdatedFromGraphQl.current) return;
+      if (
+        !graphQlDelivery.isDelivered ||
+        !shouldUpdateFromDelivery(
+          hasUpdatedFromGraphQl,
+          hasBackfilledGraphQlHash,
+          graphQlDelivery.destinationTxHash,
+        )
+      ) {
+        return;
+      }
       hasUpdatedFromGraphQl.current = true;
+      if (graphQlDelivery.destinationTxHash) hasBackfilledGraphQlHash.current = true;
       updateBridgeTransactionStatus(target.id, TransferStatus.Delivered, {
         destinationTxHash: graphQlDelivery.destinationTxHash,
       });
       return;
     }
 
-    if (graphQlDelivery.isDelivered && !hasUpdatedFromGraphQl.current) {
+    if (
+      graphQlDelivery.isDelivered &&
+      shouldUpdateFromDelivery(
+        hasUpdatedFromGraphQl,
+        hasBackfilledGraphQlHash,
+        graphQlDelivery.destinationTxHash,
+      )
+    ) {
       hasUpdatedFromGraphQl.current = true;
+      if (graphQlDelivery.destinationTxHash) hasBackfilledGraphQlHash.current = true;
       updateSwapTransactionStatus(target.id, SwapStatus.ConfirmedDestination, {
         destinationTxHash: graphQlDelivery.destinationTxHash,
       });
@@ -156,4 +175,29 @@ function DeliveryTargetWatcher({
   ]);
 
   return null;
+}
+
+function shouldUpdateFromDelivery(
+  hasUpdated: MutableRefObject<boolean>,
+  hasBackfilledHash: MutableRefObject<boolean>,
+  destinationTxHash: string | undefined,
+) {
+  if (!hasUpdated.current) return true;
+  return !!destinationTxHash && !hasBackfilledHash.current;
+}
+
+function prioritizeSelectedTarget<T extends { id: string }>(
+  targets: T[],
+  selectedTransactionId: string | null | undefined,
+) {
+  if (!selectedTransactionId) return targets;
+
+  const selectedIndex = targets.findIndex((target) => target.id === selectedTransactionId);
+  if (selectedIndex === -1) return targets;
+
+  return [
+    ...targets.slice(0, selectedIndex),
+    ...targets.slice(selectedIndex + 1),
+    targets[selectedIndex],
+  ];
 }

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -39,11 +39,10 @@ export function TransactionDeliveryWatcher() {
       transactionHistory
         .flatMap((item): DeliveryTarget[] => {
           if (item.type === TransactionHistoryItemType.Bridge) {
-            if (
-              item.data.status !== TransferStatus.ConfirmedTransfer ||
-              !item.data.msgId ||
-              item.data.destinationTxHash
-            ) {
+            const shouldWatchBridge =
+              item.data.status === TransferStatus.ConfirmedTransfer ||
+              item.data.status === TransferStatus.Delivered;
+            if (!shouldWatchBridge || !item.data.msgId || item.data.destinationTxHash) {
               return [];
             }
             return [{ id: item.id, type: item.type, msgId: item.data.msgId }];
@@ -129,7 +128,7 @@ function DeliveryTargetWatcher({
       updateSwapTransactionStatus(target.id, SwapStatus.ConfirmedDestination, {
         destinationTxHash: graphQlDelivery.destinationTxHash,
       });
-      if (!hasToasted.current) {
+      if (target.status !== SwapStatus.ConfirmedDestination && !hasToasted.current) {
         hasToasted.current = true;
         toast.success('Swap complete! Funds have arrived.');
       }
@@ -141,7 +140,7 @@ function DeliveryTargetWatcher({
       updateSwapTransactionStatus(target.id, SwapStatus.ConfirmedDestination, {
         destinationTxHash: mailboxDelivery.destinationTxHash,
       });
-      if (!hasToasted.current) {
+      if (target.status !== SwapStatus.ConfirmedDestination && !hasToasted.current) {
         hasToasted.current = true;
         toast.success('Swap complete! Finalizing details...');
       }

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -1,19 +1,52 @@
+import type { ChainAddresses } from '@hyperlane-xyz/registry';
+import type { ChainMap, ChainName, MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef } from 'react';
 import { toast } from 'react-toastify';
 
+import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { TransactionHistoryItemType, useStore } from '../store';
 import { FinalSwapStatuses, SwapStatus, type LabeledMsgId } from '../swap/types';
 import { TransferStatus } from '../transfer/types';
 import { useMessageDeliveryStatus } from './useMessageDeliveryStatus';
 
-type DeliveryTarget = {
+const MAILBOX_DELIVERY_POLL_INTERVAL_MS = 3_000;
+const MAILBOX_DELIVERED_SELECTOR = '0xe495f1d4';
+const MAILBOX_PROCESSED_AT_SELECTOR = '0x07a2fda1';
+const MAILBOX_PROCESS_ID_TOPIC =
+  '0x1cae38cdd3d3919489272725a5ae62a4f48b2989b0dae843d3c279fee18073a9';
+
+type BridgeDeliveryTarget = {
   id: string;
-  type: typeof TransactionHistoryItemType.Bridge | typeof TransactionHistoryItemType.Swap;
+  type: typeof TransactionHistoryItemType.Bridge;
   msgId: string;
 };
 
+type SwapDeliveryTarget = {
+  id: string;
+  type: typeof TransactionHistoryItemType.Swap;
+  msgId: string;
+  destinationChain: ChainName;
+  status: SwapStatus;
+};
+
+type DeliveryTarget = BridgeDeliveryTarget | SwapDeliveryTarget;
+
+type EthersLikeProvider = {
+  call: (tx: { to: string; data: string }) => Promise<string>;
+  getLogs: (filter: {
+    address: string;
+    fromBlock: number;
+    toBlock: number;
+    topics: string[];
+  }) => Promise<Array<{ transactionHash?: string }>>;
+};
+
 export function TransactionDeliveryWatcher() {
+  const multiProvider = useMultiProvider();
+  const chainAddresses = useStore((s) => s.chainAddresses);
   const transactionHistory = useStore((s) => s.transactionHistory);
 
   const targets = useMemo(
@@ -30,65 +63,227 @@ export function TransactionDeliveryWatcher() {
           return [{ id: item.id, type: item.type, msgId: item.data.msgId }];
         }
 
-        if (
-          FinalSwapStatuses.includes(item.data.status) ||
-          !item.data.msgIds?.length ||
-          item.data.destinationTxHash
-        ) {
-          return [];
-        }
+        if (!item.data.msgIds?.length) return [];
+        if (FinalSwapStatuses.includes(item.data.status) && item.data.destinationTxHash) return [];
 
+        const destinationChain = multiProvider.tryGetChainName(item.data.dstChain);
+        if (!destinationChain) return [];
         const msgId = getSwapDeliveryMsgId(item.data.msgIds);
-        return msgId ? [{ id: item.id, type: item.type, msgId }] : [];
+        return msgId
+          ? [{ id: item.id, type: item.type, msgId, destinationChain, status: item.data.status }]
+          : [];
       }),
-    [transactionHistory],
+    [multiProvider, transactionHistory],
   );
 
   return (
     <>
       {targets.map((target) => (
-        <DeliveryTargetWatcher key={`${target.type}-${target.id}-${target.msgId}`} {...target} />
+        <DeliveryTargetWatcher
+          key={`${target.type}-${target.id}-${target.msgId}`}
+          target={target}
+          chainAddresses={chainAddresses}
+        />
       ))}
     </>
   );
 }
 
-function DeliveryTargetWatcher({ id, type, msgId }: DeliveryTarget) {
+function DeliveryTargetWatcher({
+  target,
+  chainAddresses,
+}: {
+  target: DeliveryTarget;
+  chainAddresses: ChainMap<ChainAddresses>;
+}) {
   const multiProvider = useMultiProvider();
   const updateBridgeTransactionStatus = useStore((s) => s.updateBridgeTransactionStatus);
   const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
-  const delivery = useMessageDeliveryStatus(msgId, true, multiProvider);
-  const hasUpdated = useRef(false);
+  const graphQlDelivery = useMessageDeliveryStatus(target.msgId, true, multiProvider);
+  const mailboxDelivery = useEvmMailboxDeliveryStatus({
+    msgId: target.msgId,
+    destinationChain:
+      target.type === TransactionHistoryItemType.Swap ? target.destinationChain : undefined,
+    chainAddresses,
+    multiProvider,
+    enabled: target.type === TransactionHistoryItemType.Swap && !graphQlDelivery.isDelivered,
+  });
+  const hasToasted = useRef(false);
+  const hasUpdatedFromGraphQl = useRef(false);
+  const hasUpdatedFromMailbox = useRef(false);
 
   useEffect(() => {
-    hasUpdated.current = false;
-  }, [msgId]);
+    hasToasted.current = false;
+    hasUpdatedFromGraphQl.current = false;
+    hasUpdatedFromMailbox.current = false;
+  }, [target.id, target.msgId]);
 
   useEffect(() => {
-    if (!delivery.isDelivered || hasUpdated.current) return;
-    hasUpdated.current = true;
-
-    if (type === TransactionHistoryItemType.Bridge) {
-      updateBridgeTransactionStatus(id, TransferStatus.Delivered, {
-        destinationTxHash: delivery.destinationTxHash,
+    if (target.type === TransactionHistoryItemType.Bridge) {
+      if (!graphQlDelivery.isDelivered || hasUpdatedFromGraphQl.current) return;
+      hasUpdatedFromGraphQl.current = true;
+      updateBridgeTransactionStatus(target.id, TransferStatus.Delivered, {
+        destinationTxHash: graphQlDelivery.destinationTxHash,
       });
       return;
     }
 
-    updateSwapTransactionStatus(id, SwapStatus.ConfirmedDestination, {
-      destinationTxHash: delivery.destinationTxHash,
-    });
-    toast.success('Swap complete! Funds have arrived.');
+    if (graphQlDelivery.isDelivered && !hasUpdatedFromGraphQl.current) {
+      hasUpdatedFromGraphQl.current = true;
+      updateSwapTransactionStatus(target.id, SwapStatus.ConfirmedDestination, {
+        destinationTxHash: graphQlDelivery.destinationTxHash,
+      });
+      if (!hasToasted.current) {
+        hasToasted.current = true;
+        toast.success('Swap complete! Funds have arrived.');
+      }
+      return;
+    }
+
+    if (mailboxDelivery.isDelivered && !hasUpdatedFromMailbox.current) {
+      hasUpdatedFromMailbox.current = true;
+      updateSwapTransactionStatus(target.id, SwapStatus.ConfirmedDestination, {
+        destinationTxHash: mailboxDelivery.destinationTxHash,
+      });
+      if (!hasToasted.current) {
+        hasToasted.current = true;
+        toast.success('Swap complete! Finalizing details...');
+      }
+    }
   }, [
-    delivery.isDelivered,
-    delivery.destinationTxHash,
-    id,
-    type,
+    graphQlDelivery.destinationTxHash,
+    graphQlDelivery.isDelivered,
+    mailboxDelivery.destinationTxHash,
+    mailboxDelivery.isDelivered,
+    target,
     updateBridgeTransactionStatus,
     updateSwapTransactionStatus,
   ]);
 
   return null;
+}
+
+function useEvmMailboxDeliveryStatus({
+  msgId,
+  destinationChain,
+  chainAddresses,
+  multiProvider,
+  enabled,
+}: {
+  msgId: string;
+  destinationChain: ChainName | undefined;
+  chainAddresses: ChainMap<ChainAddresses>;
+  multiProvider: MultiProtocolProvider;
+  enabled: boolean;
+}) {
+  const { data } = useQuery({
+    queryKey: ['evmMailboxDelivery', destinationChain, msgId],
+    queryFn: async () => {
+      if (!destinationChain) return { isDelivered: false, destinationTxHash: undefined };
+      return getMailboxDeliveryStatus({ msgId, destinationChain, chainAddresses, multiProvider });
+    },
+    enabled: enabled && !!destinationChain,
+    refetchInterval: (query) => {
+      if (query.state.data?.isDelivered) return false;
+      return MAILBOX_DELIVERY_POLL_INTERVAL_MS;
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    isDelivered: data?.isDelivered ?? false,
+    destinationTxHash: data?.destinationTxHash,
+  };
+}
+
+async function getMailboxDeliveryStatus({
+  msgId,
+  destinationChain,
+  chainAddresses,
+  multiProvider,
+}: {
+  msgId: string;
+  destinationChain: ChainName;
+  chainAddresses: ChainMap<ChainAddresses>;
+  multiProvider: MultiProtocolProvider;
+}) {
+  try {
+    const protocol = multiProvider.tryGetProtocol(destinationChain);
+    if (protocol !== ProtocolType.Ethereum && protocol !== ProtocolType.Tron) {
+      return { isDelivered: false, destinationTxHash: undefined };
+    }
+
+    const mailbox = chainAddresses[destinationChain]?.mailbox;
+    if (!mailbox) return { isDelivered: false, destinationTxHash: undefined };
+
+    const typedProvider = multiProvider.getProvider(destinationChain);
+    if (typedProvider.type !== 'ethers-v5' && typedProvider.type !== 'tron') {
+      return { isDelivered: false, destinationTxHash: undefined };
+    }
+    const provider = typedProvider.provider as EthersLikeProvider;
+    const delivered = await callMailboxBoolean(
+      provider,
+      mailbox,
+      MAILBOX_DELIVERED_SELECTOR,
+      msgId,
+    );
+    if (!delivered) return { isDelivered: false, destinationTxHash: undefined };
+
+    const processedAt = await callMailboxUint(
+      provider,
+      mailbox,
+      MAILBOX_PROCESSED_AT_SELECTOR,
+      msgId,
+    );
+    const destinationTxHash =
+      processedAt > 0n
+        ? await findProcessTxHash(provider, mailbox, msgId, Number(processedAt))
+        : undefined;
+
+    return { isDelivered: true, destinationTxHash };
+  } catch (err) {
+    logger.warn('Fast mailbox delivery check failed', err as Error);
+    return { isDelivered: false, destinationTxHash: undefined };
+  }
+}
+
+async function callMailboxBoolean(
+  provider: EthersLikeProvider,
+  mailbox: string,
+  selector: string,
+  msgId: string,
+) {
+  const raw = await provider.call({ to: mailbox, data: encodeMailboxCall(selector, msgId) });
+  return BigInt(raw) === 1n;
+}
+
+async function callMailboxUint(
+  provider: EthersLikeProvider,
+  mailbox: string,
+  selector: string,
+  msgId: string,
+) {
+  const raw = await provider.call({ to: mailbox, data: encodeMailboxCall(selector, msgId) });
+  return BigInt(raw);
+}
+
+async function findProcessTxHash(
+  provider: EthersLikeProvider,
+  mailbox: string,
+  msgId: string,
+  blockNumber: number,
+) {
+  const [log] = await provider.getLogs({
+    address: mailbox,
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
+    topics: [MAILBOX_PROCESS_ID_TOPIC, msgId],
+  });
+  return log?.transactionHash;
+}
+
+function encodeMailboxCall(selector: string, msgId: string) {
+  return `${selector}${msgId.replace(/^0x/, '')}`;
 }
 
 function getSwapDeliveryMsgId(msgIds: LabeledMsgId[]) {

--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -1,32 +1,14 @@
 import type { ChainAddresses } from '@hyperlane-xyz/registry';
-import type { ChainMap, ChainName, MultiProtocolProvider } from '@hyperlane-xyz/sdk';
-import { ProtocolType } from '@hyperlane-xyz/utils';
-import { useQuery } from '@tanstack/react-query';
+import type { ChainMap, ChainName } from '@hyperlane-xyz/sdk';
 import { useEffect, useMemo, useRef } from 'react';
 import { toast } from 'react-toastify';
-import {
-  decodeFunctionResult,
-  encodeFunctionData,
-  parseAbi,
-  toEventSelector,
-  type Hex,
-} from 'viem';
 
-import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { TransactionHistoryItemType, useStore } from '../store';
 import { FinalSwapStatuses, SwapStatus, type LabeledMsgId } from '../swap/types';
 import { TransferStatus } from '../transfer/types';
+import { useEvmMailboxDeliveryStatus } from './useEvmMailboxDeliveryStatus';
 import { useMessageDeliveryStatus } from './useMessageDeliveryStatus';
-
-const MAILBOX_DELIVERY_POLL_INTERVAL_MS = 3_000;
-const MAILBOX_ABI = parseAbi([
-  // Mirrors the stable Hyperlane Mailbox delivery surface used by the SDK.
-  'function delivered(bytes32) view returns (bool)',
-  'function processedAt(bytes32) view returns (uint256)',
-  'event ProcessId(bytes32 indexed messageId)',
-]);
-const MAILBOX_PROCESS_ID_TOPIC = toEventSelector('ProcessId(bytes32)');
 
 type BridgeDeliveryTarget = {
   id: string;
@@ -43,16 +25,6 @@ type SwapDeliveryTarget = {
 };
 
 type DeliveryTarget = BridgeDeliveryTarget | SwapDeliveryTarget;
-
-type EthersLikeProvider = {
-  call: (tx: { to: string; data: string }) => Promise<string>;
-  getLogs: (filter: {
-    address: string;
-    fromBlock: number;
-    toBlock: number;
-    topics: string[];
-  }) => Promise<Array<{ transactionHash?: string }>>;
-};
 
 export function TransactionDeliveryWatcher() {
   const multiProvider = useMultiProvider();
@@ -173,159 +145,10 @@ function DeliveryTargetWatcher({
   return null;
 }
 
-function useEvmMailboxDeliveryStatus({
-  msgId,
-  destinationChain,
-  chainAddresses,
-  multiProvider,
-  enabled,
-}: {
-  msgId: string;
-  destinationChain: ChainName | undefined;
-  chainAddresses: ChainMap<ChainAddresses>;
-  multiProvider: MultiProtocolProvider;
-  enabled: boolean;
-}) {
-  const { data } = useQuery({
-    queryKey: ['evmMailboxDelivery', destinationChain, msgId],
-    queryFn: async () => {
-      if (!destinationChain) return { isDelivered: false, destinationTxHash: undefined };
-      return getMailboxDeliveryStatus({ msgId, destinationChain, chainAddresses, multiProvider });
-    },
-    enabled: enabled && !!destinationChain,
-    refetchInterval: (query) => {
-      if (query.state.data?.isDelivered) return false;
-      return MAILBOX_DELIVERY_POLL_INTERVAL_MS;
-    },
-    refetchOnWindowFocus: false,
-  });
-
-  return {
-    isDelivered: data?.isDelivered ?? false,
-    destinationTxHash: data?.destinationTxHash,
-  };
-}
-
-async function getMailboxDeliveryStatus({
-  msgId,
-  destinationChain,
-  chainAddresses,
-  multiProvider,
-}: {
-  msgId: string;
-  destinationChain: ChainName;
-  chainAddresses: ChainMap<ChainAddresses>;
-  multiProvider: MultiProtocolProvider;
-}) {
-  try {
-    const protocol = multiProvider.tryGetProtocol(destinationChain);
-    if (protocol !== ProtocolType.Ethereum && protocol !== ProtocolType.Tron) {
-      return { isDelivered: false, destinationTxHash: undefined };
-    }
-
-    const mailbox = chainAddresses[destinationChain]?.mailbox;
-    if (!mailbox) return { isDelivered: false, destinationTxHash: undefined };
-
-    const typedProvider = multiProvider.getProvider(destinationChain);
-    if (typedProvider.type !== 'ethers-v5' && typedProvider.type !== 'tron') {
-      return { isDelivered: false, destinationTxHash: undefined };
-    }
-    const provider = typedProvider.provider as EthersLikeProvider;
-    const delivered = await callMailboxBoolean(provider, mailbox, 'delivered', msgId);
-    if (!delivered) return { isDelivered: false, destinationTxHash: undefined };
-
-    let destinationTxHash: string | undefined;
-    try {
-      const processedAt = await callMailboxUint(provider, mailbox, 'processedAt', msgId);
-      destinationTxHash =
-        processedAt > 0n
-          ? await findProcessTxHash(provider, mailbox, msgId, Number(processedAt))
-          : undefined;
-    } catch (err) {
-      logger.warn('Mailbox delivered but process transaction lookup failed', err as Error);
-    }
-
-    return { isDelivered: true, destinationTxHash };
-  } catch (err) {
-    logger.warn('Fast mailbox delivery check failed', err as Error);
-    return { isDelivered: false, destinationTxHash: undefined };
-  }
-}
-
-async function callMailboxBoolean(
-  provider: EthersLikeProvider,
-  mailbox: string,
-  functionName: 'delivered',
-  msgId: string,
-) {
-  const raw = await provider.call({
-    to: mailbox,
-    data: encodeMailboxCall(functionName, msgId),
-  });
-  return decodeFunctionResult({
-    abi: MAILBOX_ABI,
-    functionName,
-    data: raw as Hex,
-  });
-}
-
-async function callMailboxUint(
-  provider: EthersLikeProvider,
-  mailbox: string,
-  functionName: 'processedAt',
-  msgId: string,
-) {
-  const raw = await provider.call({
-    to: mailbox,
-    data: encodeMailboxCall(functionName, msgId),
-  });
-  return decodeFunctionResult({
-    abi: MAILBOX_ABI,
-    functionName,
-    data: raw as Hex,
-  });
-}
-
-async function findProcessTxHash(
-  provider: EthersLikeProvider,
-  mailbox: string,
-  msgId: string,
-  blockNumber: number,
-) {
-  const [log] = await provider.getLogs({
-    address: mailbox,
-    fromBlock: blockNumber,
-    toBlock: blockNumber,
-    topics: [MAILBOX_PROCESS_ID_TOPIC, msgId],
-  });
-  return log?.transactionHash;
-}
-
-function encodeMailboxCall(functionName: 'delivered' | 'processedAt', msgId: string) {
-  return encodeFunctionData({
-    abi: MAILBOX_ABI,
-    functionName,
-    args: [msgId as Hex],
-  });
-}
-
 function getSwapDeliveryMsgId(msgIds: LabeledMsgId[]) {
-  const normalized = normalizePersistedMsgLabels(msgIds);
   return (
-    normalized.find((m) => m.label === 'reveal') ??
-    normalized.find((m) => m.label === 'warp') ??
-    normalized[0]
+    msgIds.find((m) => m.label === 'reveal') ??
+    msgIds.find((m) => m.label === 'warp') ??
+    msgIds[0]
   )?.msgId;
-}
-
-function normalizePersistedMsgLabels(msgIds: LabeledMsgId[]) {
-  if (
-    msgIds.length === 3 &&
-    msgIds[0]?.label === 'commit' &&
-    msgIds[1]?.label === 'reveal' &&
-    msgIds[2]?.label === 'reveal'
-  ) {
-    return [{ ...msgIds[0], label: 'warp' }, { ...msgIds[1], label: 'commit' }, msgIds[2]];
-  }
-  return msgIds;
 }

--- a/src/features/messages/mailboxDelivery.test.ts
+++ b/src/features/messages/mailboxDelivery.test.ts
@@ -1,0 +1,154 @@
+import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { encodeFunctionResult, parseAbi, toEventSelector } from 'viem';
+import { describe, expect, test, vi } from 'vitest';
+
+import { getMailboxDeliveryStatus } from './mailboxDelivery';
+
+const MAILBOX = '0x0000000000000000000000000000000000000001';
+const MSG_ID = `0x${'01'.repeat(32)}`;
+const TX_HASH = `0x${'02'.repeat(32)}`;
+const CHAIN = 'ethereum';
+const MAILBOX_ABI = parseAbi([
+  'function delivered(bytes32) view returns (bool)',
+  'function processedAt(bytes32) view returns (uint256)',
+]);
+
+function encodeMailboxResult(functionName: 'delivered', value: boolean): string;
+function encodeMailboxResult(functionName: 'processedAt', value: bigint): string;
+function encodeMailboxResult(functionName: 'delivered' | 'processedAt', value: boolean | bigint) {
+  return encodeFunctionResult({
+    abi: MAILBOX_ABI,
+    functionName,
+    result: value,
+  });
+}
+
+function createMultiProvider({
+  protocol = ProtocolType.Ethereum,
+  providerType = 'ethers-v5',
+  call = vi.fn(),
+  getLogs = vi.fn(),
+}: {
+  protocol?: ProtocolType;
+  providerType?: string;
+  call?: ReturnType<typeof vi.fn>;
+  getLogs?: ReturnType<typeof vi.fn>;
+}) {
+  return {
+    tryGetProtocol: vi.fn().mockReturnValue(protocol),
+    getProvider: vi.fn().mockReturnValue({
+      type: providerType,
+      provider: { call, getLogs },
+    }),
+  } as unknown as MultiProtocolProvider;
+}
+
+describe('getMailboxDeliveryStatus', () => {
+  test('skips unsupported protocols before reading provider', async () => {
+    const multiProvider = createMultiProvider({ protocol: ProtocolType.Cosmos });
+
+    const result = await getMailboxDeliveryStatus({
+      msgId: MSG_ID,
+      destinationChain: CHAIN,
+      chainAddresses: { [CHAIN]: { mailbox: MAILBOX } },
+      multiProvider,
+    });
+
+    expect(result).toEqual({ isDelivered: false, destinationTxHash: undefined });
+    expect(multiProvider.getProvider).not.toHaveBeenCalled();
+  });
+
+  test('skips unsupported provider types', async () => {
+    const multiProvider = createMultiProvider({ providerType: 'viem' });
+
+    const result = await getMailboxDeliveryStatus({
+      msgId: MSG_ID,
+      destinationChain: CHAIN,
+      chainAddresses: { [CHAIN]: { mailbox: MAILBOX } },
+      multiProvider,
+    });
+
+    expect(result).toEqual({ isDelivered: false, destinationTxHash: undefined });
+  });
+
+  test('returns not delivered when mailbox delivered is false', async () => {
+    const call = vi.fn().mockResolvedValue(encodeMailboxResult('delivered', false));
+    const getLogs = vi.fn();
+    const multiProvider = createMultiProvider({ call, getLogs });
+
+    const result = await getMailboxDeliveryStatus({
+      msgId: MSG_ID,
+      destinationChain: CHAIN,
+      chainAddresses: { [CHAIN]: { mailbox: MAILBOX } },
+      multiProvider,
+    });
+
+    expect(result).toEqual({ isDelivered: false, destinationTxHash: undefined });
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(getLogs).not.toHaveBeenCalled();
+  });
+
+  test('returns delivered without tx hash when processedAt is outside safe block range', async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce(encodeMailboxResult('delivered', true))
+      .mockResolvedValueOnce(
+        encodeMailboxResult('processedAt', BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+      );
+    const getLogs = vi.fn();
+    const multiProvider = createMultiProvider({ call, getLogs });
+
+    const result = await getMailboxDeliveryStatus({
+      msgId: MSG_ID,
+      destinationChain: CHAIN,
+      chainAddresses: { [CHAIN]: { mailbox: MAILBOX } },
+      multiProvider,
+    });
+
+    expect(result).toEqual({ isDelivered: true, destinationTxHash: undefined });
+    expect(getLogs).not.toHaveBeenCalled();
+  });
+
+  test('returns ProcessId transaction hash when log lookup finds one', async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce(encodeMailboxResult('delivered', true))
+      .mockResolvedValueOnce(encodeMailboxResult('processedAt', 123n));
+    const getLogs = vi.fn().mockResolvedValue([{ transactionHash: TX_HASH }]);
+    const multiProvider = createMultiProvider({ call, getLogs });
+
+    const result = await getMailboxDeliveryStatus({
+      msgId: MSG_ID,
+      destinationChain: CHAIN,
+      chainAddresses: { [CHAIN]: { mailbox: MAILBOX } },
+      multiProvider,
+    });
+
+    expect(result).toEqual({ isDelivered: true, destinationTxHash: TX_HASH });
+    expect(getLogs).toHaveBeenCalledWith({
+      address: MAILBOX,
+      fromBlock: 123,
+      toBlock: 123,
+      topics: [toEventSelector('ProcessId(bytes32)'), MSG_ID],
+    });
+  });
+
+  test('returns delivered without tx hash when ProcessId log lookup is empty', async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce(encodeMailboxResult('delivered', true))
+      .mockResolvedValueOnce(encodeMailboxResult('processedAt', 123n));
+    const getLogs = vi.fn().mockResolvedValue([]);
+    const multiProvider = createMultiProvider({ call, getLogs });
+
+    const result = await getMailboxDeliveryStatus({
+      msgId: MSG_ID,
+      destinationChain: CHAIN,
+      chainAddresses: { [CHAIN]: { mailbox: MAILBOX } },
+      multiProvider,
+    });
+
+    expect(result).toEqual({ isDelivered: true, destinationTxHash: undefined });
+  });
+});

--- a/src/features/messages/mailboxDelivery.ts
+++ b/src/features/messages/mailboxDelivery.ts
@@ -1,0 +1,133 @@
+import type { ChainAddresses } from '@hyperlane-xyz/registry';
+import type { ChainMap, ChainName, MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import {
+  decodeFunctionResult,
+  encodeFunctionData,
+  parseAbi,
+  toEventSelector,
+  type Hex,
+} from 'viem';
+
+import { logger } from '../../utils/logger';
+
+const MAILBOX_ABI = parseAbi([
+  // Mirrors the stable Hyperlane Mailbox delivery surface used by the SDK.
+  'function delivered(bytes32) view returns (bool)',
+  'function processedAt(bytes32) view returns (uint256)',
+  'event ProcessId(bytes32 indexed messageId)',
+]);
+const MAILBOX_PROCESS_ID_TOPIC = toEventSelector('ProcessId(bytes32)');
+
+type EthersLikeProvider = {
+  call: (tx: { to: string; data: string }) => Promise<string>;
+  getLogs: (filter: {
+    address: string;
+    fromBlock: number;
+    toBlock: number;
+    topics: string[];
+  }) => Promise<Array<{ transactionHash?: string }>>;
+};
+
+export async function getMailboxDeliveryStatus({
+  msgId,
+  destinationChain,
+  chainAddresses,
+  multiProvider,
+}: {
+  msgId: string;
+  destinationChain: ChainName;
+  chainAddresses: ChainMap<ChainAddresses>;
+  multiProvider: MultiProtocolProvider;
+}) {
+  try {
+    const protocol = multiProvider.tryGetProtocol(destinationChain);
+    if (protocol !== ProtocolType.Ethereum && protocol !== ProtocolType.Tron) {
+      return { isDelivered: false, destinationTxHash: undefined };
+    }
+
+    const mailbox = chainAddresses[destinationChain]?.mailbox;
+    if (!mailbox) return { isDelivered: false, destinationTxHash: undefined };
+
+    const typedProvider = multiProvider.getProvider(destinationChain);
+    if (typedProvider.type !== 'ethers-v5' && typedProvider.type !== 'tron') {
+      return { isDelivered: false, destinationTxHash: undefined };
+    }
+    const provider = typedProvider.provider as EthersLikeProvider;
+    const delivered = await callMailboxBoolean(provider, mailbox, 'delivered', msgId);
+    if (!delivered) return { isDelivered: false, destinationTxHash: undefined };
+
+    let destinationTxHash: string | undefined;
+    try {
+      const processedAt = await callMailboxUint(provider, mailbox, 'processedAt', msgId);
+      destinationTxHash =
+        processedAt > 0n
+          ? await findProcessTxHash(provider, mailbox, msgId, Number(processedAt))
+          : undefined;
+    } catch (err) {
+      logger.warn('Mailbox delivered but process transaction lookup failed', err as Error);
+    }
+
+    return { isDelivered: true, destinationTxHash };
+  } catch (err) {
+    logger.warn('Fast mailbox delivery check failed', err as Error);
+    return { isDelivered: false, destinationTxHash: undefined };
+  }
+}
+
+async function callMailboxBoolean(
+  provider: EthersLikeProvider,
+  mailbox: string,
+  functionName: 'delivered',
+  msgId: string,
+) {
+  const raw = await provider.call({
+    to: mailbox,
+    data: encodeMailboxCall(functionName, msgId),
+  });
+  return decodeFunctionResult({
+    abi: MAILBOX_ABI,
+    functionName,
+    data: raw as Hex,
+  });
+}
+
+async function callMailboxUint(
+  provider: EthersLikeProvider,
+  mailbox: string,
+  functionName: 'processedAt',
+  msgId: string,
+) {
+  const raw = await provider.call({
+    to: mailbox,
+    data: encodeMailboxCall(functionName, msgId),
+  });
+  return decodeFunctionResult({
+    abi: MAILBOX_ABI,
+    functionName,
+    data: raw as Hex,
+  });
+}
+
+async function findProcessTxHash(
+  provider: EthersLikeProvider,
+  mailbox: string,
+  msgId: string,
+  blockNumber: number,
+) {
+  const [log] = await provider.getLogs({
+    address: mailbox,
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
+    topics: [MAILBOX_PROCESS_ID_TOPIC, msgId],
+  });
+  return log?.transactionHash;
+}
+
+function encodeMailboxCall(functionName: 'delivered' | 'processedAt', msgId: string) {
+  return encodeFunctionData({
+    abi: MAILBOX_ABI,
+    functionName,
+    args: [msgId as Hex],
+  });
+}

--- a/src/features/messages/mailboxDelivery.ts
+++ b/src/features/messages/mailboxDelivery.ts
@@ -60,10 +60,10 @@ export async function getMailboxDeliveryStatus({
     let destinationTxHash: string | undefined;
     try {
       const processedAt = await callMailboxUint(provider, mailbox, 'processedAt', msgId);
-      destinationTxHash =
-        processedAt > 0n
-          ? await findProcessTxHash(provider, mailbox, msgId, Number(processedAt))
-          : undefined;
+      const processedBlock = mailboxProcessedBlockToNumber(processedAt);
+      destinationTxHash = processedBlock
+        ? await findProcessTxHash(provider, mailbox, msgId, processedBlock)
+        : undefined;
     } catch (err) {
       logger.warn('Mailbox delivered but process transaction lookup failed', err as Error);
     }
@@ -130,4 +130,9 @@ function encodeMailboxCall(functionName: 'delivered' | 'processedAt', msgId: str
     functionName,
     args: [msgId as Hex],
   });
+}
+
+function mailboxProcessedBlockToNumber(processedAt: bigint) {
+  if (processedAt <= 0n || processedAt > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
+  return Number(processedAt);
 }

--- a/src/features/messages/mailboxDelivery.ts
+++ b/src/features/messages/mailboxDelivery.ts
@@ -132,7 +132,8 @@ function encodeMailboxCall(functionName: 'delivered' | 'processedAt', msgId: str
   });
 }
 
-function mailboxProcessedBlockToNumber(processedAt: bigint) {
-  if (processedAt <= 0n || processedAt > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
-  return Number(processedAt);
+function mailboxProcessedBlockToNumber(processedAt: bigint | number) {
+  const processedBlock = BigInt(processedAt);
+  if (processedBlock <= 0n || processedBlock > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
+  return Number(processedBlock);
 }

--- a/src/features/messages/useEvmMailboxDeliveryStatus.ts
+++ b/src/features/messages/useEvmMailboxDeliveryStatus.ts
@@ -1,0 +1,40 @@
+import type { ChainAddresses } from '@hyperlane-xyz/registry';
+import type { ChainMap, ChainName, MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getMailboxDeliveryStatus } from './mailboxDelivery';
+
+const MAILBOX_DELIVERY_POLL_INTERVAL_MS = 3_000;
+
+export function useEvmMailboxDeliveryStatus({
+  msgId,
+  destinationChain,
+  chainAddresses,
+  multiProvider,
+  enabled,
+}: {
+  msgId: string;
+  destinationChain: ChainName | undefined;
+  chainAddresses: ChainMap<ChainAddresses>;
+  multiProvider: MultiProtocolProvider;
+  enabled: boolean;
+}) {
+  const { data } = useQuery({
+    queryKey: ['evmMailboxDelivery', destinationChain, msgId],
+    queryFn: async () => {
+      if (!destinationChain) return { isDelivered: false, destinationTxHash: undefined };
+      return getMailboxDeliveryStatus({ msgId, destinationChain, chainAddresses, multiProvider });
+    },
+    enabled: enabled && !!destinationChain,
+    refetchInterval: (query) => {
+      if (query.state.data?.isDelivered) return false;
+      return MAILBOX_DELIVERY_POLL_INTERVAL_MS;
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    isDelivered: data?.isDelivered ?? false,
+    destinationTxHash: data?.destinationTxHash,
+  };
+}

--- a/src/features/messages/useEvmMailboxDeliveryStatus.ts
+++ b/src/features/messages/useEvmMailboxDeliveryStatus.ts
@@ -19,13 +19,14 @@ export function useEvmMailboxDeliveryStatus({
   multiProvider: MultiProtocolProvider;
   enabled: boolean;
 }) {
+  const mailbox = destinationChain ? chainAddresses[destinationChain]?.mailbox : undefined;
   const { data } = useQuery({
-    queryKey: ['evmMailboxDelivery', destinationChain, msgId],
+    queryKey: ['evmMailboxDelivery', destinationChain, mailbox, msgId],
     queryFn: async () => {
       if (!destinationChain) return { isDelivered: false, destinationTxHash: undefined };
       return getMailboxDeliveryStatus({ msgId, destinationChain, chainAddresses, multiProvider });
     },
-    enabled: enabled && !!destinationChain,
+    enabled: enabled && !!destinationChain && !!mailbox,
     refetchInterval: (query) => {
       if (query.state.data?.isDelivered) return false;
       return MAILBOX_DELIVERY_POLL_INTERVAL_MS;

--- a/src/features/messages/useMessageDeliveryStatus.ts
+++ b/src/features/messages/useMessageDeliveryStatus.ts
@@ -1,5 +1,6 @@
 import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
 
 import { logger } from '../../utils/logger';
 import { executeGraphQLQuery } from './graphqlClient';
@@ -8,6 +9,7 @@ import { parseTimestamp, postgresByteaToTxHash } from './queries/encoding';
 import type { MessageStubEntry } from './queries/fragments';
 
 const POLL_INTERVAL_MS = 10_000;
+const DELIVERED_HASH_BACKFILL_WINDOW_MS = 2 * 60 * 1_000;
 
 export interface MessageDeliveryResult {
   /** Whether the message has been delivered on destination */
@@ -31,6 +33,12 @@ export function useMessageDeliveryStatus(
   isOpen: boolean,
   multiProvider: MultiProtocolProvider,
 ): MessageDeliveryResult {
+  const deliveredWithoutHashFirstSeenAt = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    deliveredWithoutHashFirstSeenAt.current = undefined;
+  }, [msgId]);
+
   const { data, isLoading } = useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps -- multiProvider is stable, adding it causes unnecessary refetches
     queryKey: ['messageDelivery', msgId],
@@ -52,8 +60,17 @@ export function useMessageDeliveryStatus(
     enabled: !!msgId && isOpen,
     staleTime: 30_000,
     refetchInterval: (query) => {
-      // Stop polling once delivered
-      if (query.state.data?.isDelivered) return false;
+      const result = query.state.data;
+      if (!result?.isDelivered) {
+        deliveredWithoutHashFirstSeenAt.current = undefined;
+        return POLL_INTERVAL_MS;
+      }
+      if (result.destinationTxHash) return false;
+
+      deliveredWithoutHashFirstSeenAt.current ??= Date.now();
+      const backfillElapsedMs = Date.now() - deliveredWithoutHashFirstSeenAt.current;
+      if (backfillElapsedMs >= DELIVERED_HASH_BACKFILL_WINDOW_MS) return false;
+
       return POLL_INTERVAL_MS;
     },
     refetchOnWindowFocus: false,

--- a/src/features/messages/useMessageDeliveryStatus.ts
+++ b/src/features/messages/useMessageDeliveryStatus.ts
@@ -34,6 +34,7 @@ export function useMessageDeliveryStatus(
   multiProvider: MultiProtocolProvider,
 ): MessageDeliveryResult {
   const deliveredWithoutHashFirstSeenAt = useRef<number | undefined>(undefined);
+  const isMultiProviderReady = multiProvider.getKnownChainNames().length > 0;
 
   useEffect(() => {
     deliveredWithoutHashFirstSeenAt.current = undefined;
@@ -41,7 +42,7 @@ export function useMessageDeliveryStatus(
 
   const { data, isLoading } = useQuery({
     // eslint-disable-next-line @tanstack/query/exhaustive-deps -- multiProvider is stable, adding it causes unnecessary refetches
-    queryKey: ['messageDelivery', msgId],
+    queryKey: ['messageDelivery', msgId, isMultiProviderReady],
     queryFn: async () => {
       if (!msgId) return null;
       const queryData = buildMessageByIdQuery(msgId);
@@ -57,7 +58,7 @@ export function useMessageDeliveryStatus(
       if (!entry) return null;
       return parseDeliveryResult(entry, multiProvider);
     },
-    enabled: !!msgId && isOpen,
+    enabled: !!msgId && isOpen && isMultiProviderReady,
     staleTime: 30_000,
     refetchInterval: (query) => {
       const result = query.state.data;

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -1,0 +1,9 @@
+import type { LabeledMsgId } from '../swap/types';
+
+export function getSwapDeliveryMsgId(msgIds: LabeledMsgId[] | undefined) {
+  return (
+    msgIds?.find((m) => m.label === 'reveal') ??
+    msgIds?.find((m) => m.label === 'warp') ??
+    msgIds?.[0]
+  )?.msgId;
+}

--- a/src/features/swap/SwapDetailsModal.tsx
+++ b/src/features/swap/SwapDetailsModal.tsx
@@ -10,7 +10,6 @@ import {
 } from '@hyperlane-xyz/widgets';
 import Image from 'next/image';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { toast } from 'react-toastify';
 
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import { TokenChainIcon } from '../../components/icons/TokenChainIcon';
@@ -23,7 +22,6 @@ import { getHypExplorerMessageLink } from '../../utils/links';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { getChainDisplayName } from '../chains/utils';
-import { useMessageDeliveryStatus } from '../messages/useMessageDeliveryStatus';
 import { TransactionHistoryItemType, useStore } from '../store';
 import { formatBalance } from './balances/utils';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
@@ -94,8 +92,6 @@ function SwapDetailsModalInner({
 }) {
   const multiProvider = useMultiProvider();
   const tokenMap = useTokenByKeyMap();
-  const updateSwapTransactionStatus = useStore((s) => s.updateSwapTransactionStatus);
-
   const {
     status,
     srcChain,
@@ -137,32 +133,6 @@ function SwapDetailsModalInner({
     msgIds?.find((m) => m.label === 'warp') ??
     msgIds?.[0]
   )?.msgId;
-  const delivery = useMessageDeliveryStatus(pollingMsgId, !isFinal, multiProvider);
-
-  const hasUpdatedDelivery = useRef(false);
-  useEffect(() => {
-    hasUpdatedDelivery.current = false;
-  }, [pollingMsgId]);
-
-  useEffect(() => {
-    if (
-      delivery.isDelivered &&
-      !hasUpdatedDelivery.current &&
-      status !== SwapStatus.ConfirmedDestination
-    ) {
-      hasUpdatedDelivery.current = true;
-      updateSwapTransactionStatus(transactionId, SwapStatus.ConfirmedDestination, {
-        destinationTxHash: delivery.destinationTxHash,
-      });
-      toast.success('Swap complete! Funds have arrived.');
-    }
-  }, [
-    delivery.isDelivered,
-    delivery.destinationTxHash,
-    transactionId,
-    status,
-    updateSwapTransactionStatus,
-  ]);
 
   const isSent =
     status === SwapStatus.ConfirmingOrigin ||

--- a/src/features/swap/SwapDetailsModal.tsx
+++ b/src/features/swap/SwapDetailsModal.tsx
@@ -22,6 +22,7 @@ import { getHypExplorerLink } from '../../utils/links';
 import { logger } from '../../utils/logger';
 import { useMultiProvider } from '../chains/hooks';
 import { getChainDisplayName } from '../chains/utils';
+import { getSwapDeliveryMsgId } from '../messages/utils';
 import { TransactionHistoryItemType, useStore } from '../store';
 import { formatBalance } from './balances/utils';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
@@ -127,11 +128,7 @@ function SwapDetailsModalInner({
   // execution on the destination chain, which is what actually completes
   // the swap. Pure-bridge routes (no destination swap) have no reveal,
   // so fall back to the warp message. Same-chain swaps have no msgIds.
-  const pollingMsgId = (
-    msgIds?.find((m) => m.label === 'reveal') ??
-    msgIds?.find((m) => m.label === 'warp') ??
-    msgIds?.[0]
-  )?.msgId;
+  const pollingMsgId = getSwapDeliveryMsgId(msgIds);
 
   const isSent =
     status === SwapStatus.ConfirmingOrigin ||

--- a/src/features/transfer/TransfersDetailsModal.tsx
+++ b/src/features/transfer/TransfersDetailsModal.tsx
@@ -15,7 +15,7 @@ import {
   useWalletDetails,
 } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import Image from 'next/image';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ChainLogo } from '../../components/icons/ChainLogo';
 import { TokenChainIcon } from '../../components/icons/TokenChainIcon';
@@ -89,7 +89,6 @@ export function TransfersDetailsModal({
 
   const multiProvider = useMultiProvider();
   const warpCore = useWarpCore();
-  const updateBridgeTransactionStatus = useStore((s) => s.updateBridgeTransactionStatus);
 
   const isChainKnown = multiProvider.hasChain(origin);
   const account = useAccountForChain(multiProvider, isChainKnown ? origin : undefined);
@@ -165,33 +164,6 @@ export function TransfersDetailsModal({
     : isFailed
       ? MessageStatus.Failing
       : MessageStatus.Pending;
-
-  // Reset delivery tracking when viewing a different transfer
-  const hasUpdatedDelivery = useRef(false);
-  useEffect(() => {
-    hasUpdatedDelivery.current = false;
-  }, [msgId]);
-
-  // Update store when delivery is confirmed
-  useEffect(() => {
-    if (
-      delivery.isDelivered &&
-      !hasUpdatedDelivery.current &&
-      status !== TransferStatus.Delivered &&
-      transactionId
-    ) {
-      hasUpdatedDelivery.current = true;
-      updateBridgeTransactionStatus(transactionId, TransferStatus.Delivered, {
-        destinationTxHash: delivery.destinationTxHash,
-      });
-    }
-  }, [
-    delivery.isDelivered,
-    delivery.destinationTxHash,
-    transactionId,
-    status,
-    updateBridgeTransactionStatus,
-  ]);
 
   // Fetch explorer URLs for addresses and transactions
   useEffect(() => {

--- a/src/features/transfer/TransfersDetailsModal.tsx
+++ b/src/features/transfer/TransfersDetailsModal.tsx
@@ -89,6 +89,7 @@ export function TransfersDetailsModal({
 
   const multiProvider = useMultiProvider();
   const warpCore = useWarpCore();
+  const updateBridgeTransactionStatus = useStore((s) => s.updateBridgeTransactionStatus);
 
   const isChainKnown = multiProvider.hasChain(origin);
   const account = useAccountForChain(multiProvider, isChainKnown ? origin : undefined);
@@ -126,6 +127,24 @@ export function TransfersDetailsModal({
 
   // Resolve the destination tx hash from either store or live query
   const destinationTxHash = storedDestTxHash || delivery.destinationTxHash;
+
+  useEffect(() => {
+    if (!transactionId || !delivery.isDelivered) return;
+    if (status === TransferStatus.Delivered && (!delivery.destinationTxHash || storedDestTxHash)) {
+      return;
+    }
+
+    updateBridgeTransactionStatus(transactionId, TransferStatus.Delivered, {
+      destinationTxHash: delivery.destinationTxHash,
+    });
+  }, [
+    delivery.destinationTxHash,
+    delivery.isDelivered,
+    status,
+    storedDestTxHash,
+    transactionId,
+    updateBridgeTransactionStatus,
+  ]);
 
   const isAccountReady = !!account?.isReady;
   const connectorName = walletDetails.name || 'wallet';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import '../../sentry.client.config';
 import { ErrorBoundary } from '../components/errors/ErrorBoundary';
 import { AppLayout } from '../components/layout/AppLayout';
+import { TransactionDeliveryWatcher } from '../features/messages/TransactionDeliveryWatcher';
 import { ThemeProvider } from '../features/theme/ThemeContext';
 import { initE2EStateIfEnabled } from '../features/wallet/_e2e/windowState';
 import { AleoWalletContext } from '../features/wallet/context/AleoWalletContext';
@@ -98,7 +99,10 @@ export default function App({ Component, pageProps }: AppProps) {
                     <RadixWalletContext>
                       <AleoWalletContext>
                         <TronWalletContext>
-                          <ThemeProvider>{content}</ThemeProvider>
+                          <ThemeProvider>
+                            <TransactionDeliveryWatcher />
+                            {content}
+                          </ThemeProvider>
                         </TronWalletContext>
                       </AleoWalletContext>
                     </RadixWalletContext>


### PR DESCRIPTION
## Summary
- Add a shared background watcher for pending bridge and swap deliveries.
- Update delivered statuses and destination transaction hashes outside the details modals.
- Keep the existing GraphQL delivery query path for multi-VM support.
- Add an EVM/Tron mailbox fast path for swap reveal messages so swaps can complete in the UI before GraphQL catches up.
- Bound background polling to the newest pending targets and avoid rewriting terminal failed swaps as delivered.