### PR TITLE
fix(swap): poll origin + destination balances

### DIFF
--- a/src/features/swap/balances/hooks.ts
+++ b/src/features/swap/balances/hooks.ts
@@ -161,6 +161,7 @@ export function useTokenBalance(token: UiToken | undefined, addressOverride?: st
       !!protocol &&
       (protocol !== ProtocolType.Ethereum || !!publicClient),
     staleTime: STALE_BALANCE_MS,
+    refetchInterval: STALE_BALANCE_MS,
   });
 }
 


### PR DESCRIPTION
Adds `refetchInterval: STALE_BALANCE_MS` to `useTokenBalance` so the origin + destination cards refresh on the same 30s cadence as the bridge form. Without this, balances stayed stale until the user switched chain/token.

Picker queries (`useTokenBalances`) left polling-free — they're only mounted while the picker is open and re-mount fresh each time, so the cost isn't worth the noise.