### PR TITLE
chore: truncate swap amount display

### DIFF
--- a/src/features/swap/SwapDetailsModal.tsx
+++ b/src/features/swap/SwapDetailsModal.tsx
@@ -24,7 +24,7 @@ import { useMultiProvider } from '../chains/hooks';
 import { getChainDisplayName } from '../chains/utils';
 import { getSwapDeliveryMsgId } from '../messages/utils';
 import { TransactionHistoryItemType, useStore } from '../store';
-import { formatBalance } from './balances/utils';
+import { formatDisplayAmount } from './balances/utils';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from './tokens/hooks';
 import { FinalSwapStatuses, SwapStatus, type SwapHistoryItem } from './types';
 
@@ -365,7 +365,7 @@ function fixDoubleSlash(url: string) {
 function formatAmount(amount: string, decimals: number | undefined): string {
   if (decimals == null) return `${amount} (atomic)`;
   try {
-    return formatBalance(BigInt(amount), decimals);
+    return formatDisplayAmount(BigInt(amount), decimals);
   } catch {
     return amount;
   }

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -4,7 +4,7 @@ import { useAccounts } from '@hyperlane-xyz/widgets/walletIntegrations/accounts'
 import { useAccountAddressForChain } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import { Form, Formik, useFormikContext } from 'formik';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { Address } from 'viem';
+import { formatUnits, type Address } from 'viem';
 
 import { FormWarningBanner } from '../../components/banner/FormWarningBanner';
 import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareSubmitButton';
@@ -608,6 +608,14 @@ function DestinationTokenCard({
   const { values, setFieldValue } = useFormikContext<SwapFormValues>();
   const { data: balance } = useTokenBalance(dstToken, recipient);
 
+  const outputExact = useMemo(() => {
+    if (!bestRoute || !dstToken) return '';
+    try {
+      return formatUnits(BigInt(bestRoute.raw.output), dstToken.decimals);
+    } catch {
+      return '';
+    }
+  }, [bestRoute, dstToken]);
   const outputDisplay = useMemo(() => {
     if (!bestRoute || !dstToken) return '';
     try {
@@ -616,7 +624,7 @@ function DestinationTokenCard({
       return '';
     }
   }, [bestRoute, dstToken]);
-  const outputUsd = useTokenUsdValue(dstToken, outputDisplay);
+  const outputUsd = useTokenUsdValue(dstToken, outputExact);
   // Price impact = how much value the swap loses to fees + slippage + spread.
   // Only meaningful when both sides have USD prices.
   const priceImpactPct = useMemo(() => {

--- a/src/features/swap/SwapForm.tsx
+++ b/src/features/swap/SwapForm.tsx
@@ -4,7 +4,7 @@ import { useAccounts } from '@hyperlane-xyz/widgets/walletIntegrations/accounts'
 import { useAccountAddressForChain } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import { Form, Formik, useFormikContext } from 'formik';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { formatUnits, type Address } from 'viem';
+import type { Address } from 'viem';
 
 import { FormWarningBanner } from '../../components/banner/FormWarningBanner';
 import { ConnectAwareSubmitButton } from '../../components/buttons/ConnectAwareSubmitButton';
@@ -25,7 +25,7 @@ import { WalletConnectionWarning } from '../wallet/WalletConnectionWarning';
 import { WalletDropdown } from '../wallet/WalletDropdown';
 import { ApprovalPhase, useApprovalStatus } from './approval';
 import { useTokenBalance } from './balances/hooks';
-import { formatBalance, formatFeeAmount, formatUsd } from './balances/utils';
+import { formatDisplayAmount, formatFeeAmount, formatUsd } from './balances/utils';
 import { FeeSectionButton } from './FeeSectionButton';
 import { MaxButton } from './MaxButton';
 import { RouteSelectionModal } from './routeSelection/RouteSelectionModal';
@@ -611,7 +611,7 @@ function DestinationTokenCard({
   const outputDisplay = useMemo(() => {
     if (!bestRoute || !dstToken) return '';
     try {
-      return formatUnits(BigInt(bestRoute.raw.output), dstToken.decimals);
+      return formatDisplayAmount(BigInt(bestRoute.raw.output), dstToken.decimals);
     } catch {
       return '';
     }
@@ -802,12 +802,12 @@ function ReviewTransactions({
           )}
           <p className="flex">
             <span className="min-w-[7.5rem]">Expected Output</span>
-            <span>{`${formatBalance(BigInt(route.raw.output), dstDecimals)} ${dstSymbol}`}</span>
+            <span>{`${formatDisplayAmount(BigInt(route.raw.output), dstDecimals)} ${dstSymbol}`}</span>
           </p>
           {!route.isBridgeOnly && (
             <p className="flex">
               <span className="min-w-[7.5rem]">Min Output</span>
-              <span>{`${formatBalance(BigInt(route.raw.outputMin), dstDecimals)} ${dstSymbol}`}</span>
+              <span>{`${formatDisplayAmount(BigInt(route.raw.outputMin), dstDecimals)} ${dstSymbol}`}</span>
             </p>
           )}
           {route.feeBreakdown.components

--- a/src/features/swap/balances/utils.ts
+++ b/src/features/swap/balances/utils.ts
@@ -4,7 +4,7 @@ import type { UiToken } from '../tokens/types';
 import { getTokenKey } from '../tokens/utils';
 import type { FeeComponent } from '../types';
 
-export { formatBalance, formatUsd } from '../../../utils/amount';
+export { formatBalance, formatDisplayAmount, formatUsd } from '../../../utils/amount';
 
 // Fee amounts need more precision than balances — gas fees can be ~1e-5
 // native units which formatBalance's 4-decimal rounding renders as "0.0000".

--- a/src/features/swap/routeSelection/RouteSelectionModal.tsx
+++ b/src/features/swap/routeSelection/RouteSelectionModal.tsx
@@ -7,7 +7,7 @@ import { TokenIcon } from '../../../components/icons/TokenIcon';
 import { HoverTooltip } from '../../../components/tooltip/HoverTooltip';
 import type { QuoteBridgeStep, QuoteStep, QuoteSwapStep } from '../../api/types';
 import { useMultiProvider } from '../../chains/hooks';
-import { formatBalance, formatFeeAmount } from '../balances/utils';
+import { formatDisplayAmount, formatFeeAmount } from '../balances/utils';
 import { getDexMeta } from '../dexMeta';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from '../tokens/hooks';
 import type { UiToken } from '../tokens/types';
@@ -101,7 +101,7 @@ interface RouteCardProps {
 function RouteCard({ route, index, isSelected, isBest, onSelect, dstToken }: RouteCardProps) {
   const decimals = dstToken?.decimals ?? 18;
   const symbol = dstToken?.symbol ?? '';
-  const outputFormatted = formatBalance(BigInt(route.raw.output), decimals);
+  const outputFormatted = formatDisplayAmount(BigInt(route.raw.output), decimals);
 
   return (
     <button

--- a/src/utils/amount.test.ts
+++ b/src/utils/amount.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatDisplayAmount } from './amount';
+
+describe('formatDisplayAmount', () => {
+  test('converts atomic units with token decimals before truncating', () => {
+    expect(formatDisplayAmount(1234567n, 6)).toBe('1.2345');
+    expect(formatDisplayAmount(123456789123456000000n, 18)).toBe('123.4567');
+  });
+
+  test('caps normal fractional values at four decimals', () => {
+    expect(formatDisplayAmount(123456789123456000000n, 18)).toBe('123.4567');
+  });
+
+  test('trims trailing zeros', () => {
+    expect(formatDisplayAmount(1000000000000000001n, 18)).toBe('1');
+  });
+
+  test('keeps enough precision for tiny non-zero values', () => {
+    expect(formatDisplayAmount(12345678900000n, 18)).toBe('0.00001234');
+    expect(formatDisplayAmount(123456789n, 18)).toBe('0.0000000001234');
+    expect(formatDisplayAmount(1n, 18)).toBe('0.000000000000000001');
+  });
+});

--- a/src/utils/amount.test.ts
+++ b/src/utils/amount.test.ts
@@ -8,12 +8,17 @@ describe('formatDisplayAmount', () => {
     expect(formatDisplayAmount(123456789123456000000n, 18)).toBe('123.4567');
   });
 
-  test('caps normal fractional values at four decimals', () => {
-    expect(formatDisplayAmount(123456789123456000000n, 18)).toBe('123.4567');
+  test('caps normal fractional values at available token decimals', () => {
+    expect(formatDisplayAmount(12345n, 2)).toBe('123.45');
+    expect(formatDisplayAmount(123456n, 3)).toBe('123.456');
   });
 
-  test('trims trailing zeros', () => {
+  test('drops sub-display dust for non-zero integer amounts', () => {
     expect(formatDisplayAmount(1000000000000000001n, 18)).toBe('1');
+  });
+
+  test('formats zero amounts', () => {
+    expect(formatDisplayAmount(0n, 18)).toBe('0');
   });
 
   test('keeps enough precision for tiny non-zero values', () => {

--- a/src/utils/amount.ts
+++ b/src/utils/amount.ts
@@ -7,6 +7,19 @@ export function formatBalance(balance: bigint, decimals: number): string {
   return fromWeiRounded(balance.toString(), decimals, 4);
 }
 
+export function formatDisplayAmount(atomicAmount: bigint, decimals: number): string {
+  const formatted = fromWeiRounded(atomicAmount.toString(), decimals, decimals);
+  const [integerPart, fractionalPart = ''] = formatted.split('.');
+  if (!fractionalPart) return integerPart;
+
+  const firstNonZeroIndex = fractionalPart.search(/[1-9]/);
+  if (firstNonZeroIndex === -1) return integerPart;
+
+  const decimalPlaces = integerPart === '0' && firstNonZeroIndex >= 4 ? firstNonZeroIndex + 4 : 4;
+  const visibleFraction = fractionalPart.slice(0, decimalPlaces).replace(/0+$/, '');
+  return visibleFraction ? `${integerPart}.${visibleFraction}` : integerPart;
+}
+
 export function formatUsd(value: number, approximate = false): string {
   if (value < 0.01) return '<$0.01';
   const prefix = approximate ? '≈$' : '$';


### PR DESCRIPTION
## Summary
- Add adaptive token amount display formatting for swap outputs
- Use token decimals before truncating atomic amounts
- Keep extra precision for tiny non-zero amounts while trimming normal values