### PR TITLE
chore: keep mailbox polling until swap tx hash

### DIFF
--- a/src/features/messages/TransactionDeliveryWatcher.tsx
+++ b/src/features/messages/TransactionDeliveryWatcher.tsx
@@ -119,7 +119,7 @@ function DeliveryTargetWatcher({
       target.type === TransactionHistoryItemType.Swap ? target.destinationChain : undefined,
     chainAddresses,
     multiProvider,
-    enabled: target.type === TransactionHistoryItemType.Swap && !graphQlDelivery.isDelivered,
+    enabled: target.type === TransactionHistoryItemType.Swap && !graphQlDelivery.destinationTxHash,
   });
   // Swap recovery status is centralized here so the modal stays display-only.
   useSwapStatus(swap, target.type === TransactionHistoryItemType.Swap ? target.id : null);


### PR DESCRIPTION
## Summary

- keep the EVM/Tron mailbox watcher active until GraphQL has a destination transaction hash
- allows swap recovery status to finalize from RPC when GraphQL reports delivered before hash backfill