### PR TITLE
fix: dont import native tokens

### DIFF
--- a/src/features/tokens/hooks.ts
+++ b/src/features/tokens/hooks.ts
@@ -187,7 +187,7 @@ export function useAddToken(token?: IToken) {
     ? ADD_ASSET_SUPPORTED_PROTOCOLS.includes(token?.protocol)
     : false;
 
-  const canAddAsset = token && isAccountReady && isSupportedProtocol;
+  const canAddAsset = token && isAccountReady && isSupportedProtocol && !token.isHypNative();
 
   const { isPending, mutateAsync } = useMutation({
     mutationFn: () => {


### PR DESCRIPTION
## Summary
- Hides the "Add token to Wallet" button for `HypNative` token standards
- `HypNative` contracts extend `ERC4626Upgradeable` (via `LpCollateralRouter`) but never call `__ERC20_init`, so `symbol()` returns `""`
- When `wallet_watchAsset` is called, viem validates the passed symbol against the on-chain `symbol()` — the mismatch (`"NES" !== ""`) throws an `Invalid parameters` error
- Hiding the button is also semantically correct: native gas tokens are already in the user's wallet; the `HypNative` contract is only a bridge wrapper

## Test plan
- [x] Open the bridge with `?origin=nesa&originToken=NES&destination=bsc&destinationToken=NES`
- [x] Confirm "Add token to Wallet" button is no longer shown for the origin NESA NES token
- [x] Confirm "Add token to Wallet" still works for non-native synthetic tokens (e.g. BSC NES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)