### PR TITLE
feat: validate engine route security

### DIFF
--- a/src/features/api/routeTx.ts
+++ b/src/features/api/routeTx.ts
@@ -1,0 +1,9 @@
+import type { RouteResponse, RouteTx } from './types';
+
+export function getRouteTxs(route: RouteResponse): RouteTx[] {
+  return route.txs?.length ? route.txs : route.tx ? [route.tx] : [];
+}
+
+export function isChainRouteTx(tx: RouteTx): tx is Extract<RouteTx, { to: string }> {
+  return 'to' in tx;
+}

--- a/src/features/api/types.ts
+++ b/src/features/api/types.ts
@@ -2,12 +2,11 @@
 // extension since the UI doesn't generate spec docs.
 import { z } from 'zod';
 
-export const Address = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
-// Permissive token-address schema mirroring the engine's TokenAddress —
-// length-bounded string so non-EVM addresses (Solana base58 mints,
-// Cosmos bech32) validate. The strict EVM `Address` is still used for
-// request-side fields like sender/recipient.
-export const TokenAddress = z.string().min(1).max(100);
+export const HexAddress = z.string().regex(/^0x[0-9a-fA-F]{40}$/);
+// Mirrors the engine's Address type: chain-specific contract/token strings,
+// including non-EVM program ids such as Solana universal routers.
+export const Address = z.string().min(1).max(100);
+export const TokenAddress = Address;
 export const BigIntString = z.string().regex(/^\d+$/);
 export const Hex = z.string().regex(/^0x[0-9a-fA-F]*$/);
 // bytes20/bytes32 hex or a native non-EVM address. Engine validates per protocol.
@@ -55,7 +54,7 @@ export const ChainDiscoverySchema = z.object({
   // Optional until production engine redeploys with the field; the swap
   // form gates approvals on its presence so an undefined value just
   // surfaces as "Loading Permit2…" instead of crashing the chains list.
-  permit2: Address.optional(),
+  permit2: HexAddress.optional(),
   dex: z.string().nullable(),
   canSwap: z.boolean(),
   canExecute: z.boolean(),

--- a/src/features/routeSecurity/chainContracts.ts
+++ b/src/features/routeSecurity/chainContracts.ts
@@ -1,0 +1,41 @@
+import type { ChainAddresses } from '@hyperlane-xyz/registry';
+
+import type { ChainDiscovery } from '../api/types';
+import type { RouteSecurityValidationFailure } from './types';
+import { isUnsetAddress, sameTokenAddress } from './utils';
+
+type TrustedUniversalRouterResult =
+  | { valid: true; universalRouter: string }
+  | RouteSecurityValidationFailure;
+
+export function trustedUniversalRouterForChain({
+  chain,
+  chainAddresses,
+  unavailableReason,
+  mismatchReason,
+  warpRouteId,
+}: {
+  chain: ChainDiscovery | undefined;
+  chainAddresses: ChainAddresses | undefined;
+  unavailableReason: string;
+  mismatchReason: string;
+  warpRouteId?: string;
+}): TrustedUniversalRouterResult {
+  const apiUniversalRouter = chain?.universalRouter;
+  const registryUniversalRouter = chainAddresses?.universalRouter;
+
+  if (
+    !apiUniversalRouter ||
+    !registryUniversalRouter ||
+    isUnsetAddress(apiUniversalRouter) ||
+    isUnsetAddress(registryUniversalRouter)
+  ) {
+    return { valid: false, reason: unavailableReason, warpRouteId };
+  }
+
+  if (!sameTokenAddress(apiUniversalRouter, registryUniversalRouter)) {
+    return { valid: false, reason: mismatchReason, warpRouteId };
+  }
+
+  return { valid: true, universalRouter: registryUniversalRouter };
+}

--- a/src/features/routeSecurity/sdk.ts
+++ b/src/features/routeSecurity/sdk.ts
@@ -13,7 +13,7 @@ export function validateSdkRouteTx(
     return { valid: false, reason: 'SDK transaction shape is only supported for sdkWarp routes' };
   }
 
-  if (tx.protocol !== srcProtocol) {
+  if (!sameProtocol(tx.protocol, srcProtocol)) {
     return { valid: false, reason: 'SDK transaction protocol does not match source chain' };
   }
 
@@ -47,6 +47,10 @@ function sdkTransactionTarget(transaction: unknown): string | undefined {
   if (typeof transaction.to === 'string') return transaction.to;
   if (typeof transaction.contractAddress === 'string') return transaction.contractAddress;
   return undefined;
+}
+
+function sameProtocol(left: string, right: ProtocolType): boolean {
+  return left.toLowerCase() === right.toLowerCase();
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/features/routeSecurity/sdk.ts
+++ b/src/features/routeSecurity/sdk.ts
@@ -1,0 +1,54 @@
+import { ProtocolType } from '@hyperlane-xyz/utils';
+
+import type { RouteResponse, RouteTx } from '../api/types';
+import type { RouteSecurityValidationResult } from './types';
+import { firstBridge, sameTokenAddress } from './utils';
+
+export function validateSdkRouteTx(
+  route: RouteResponse,
+  tx: Extract<RouteTx, { protocol: string }>,
+  srcProtocol: ProtocolType,
+): RouteSecurityValidationResult {
+  if (route.executionKind !== 'sdkWarp') {
+    return { valid: false, reason: 'SDK transaction shape is only supported for sdkWarp routes' };
+  }
+
+  if (tx.protocol !== srcProtocol) {
+    return { valid: false, reason: 'SDK transaction protocol does not match source chain' };
+  }
+
+  if (tx.category !== 'transfer') {
+    return { valid: false, reason: 'SDK transaction category is not transfer' };
+  }
+
+  const warpRouteId = route.connection?.warpRouteId ?? firstBridge(route)?.warpRouteId;
+  if (!warpRouteId) return { valid: false, reason: 'SDK transaction missing warpRouteId' };
+  if (tx.metadata?.warpRouteId !== warpRouteId) {
+    return {
+      valid: false,
+      reason: 'SDK transaction warpRouteId does not match route',
+      warpRouteId,
+    };
+  }
+
+  const txTarget = sdkTransactionTarget(tx.transaction);
+  const bridge = firstBridge(route);
+  // Opaque SDK transaction shapes remain unpinned until we have a trusted,
+  // protocol-specific way to extract their invoked target.
+  if (txTarget && bridge && !sameTokenAddress(txTarget, bridge.router)) {
+    return { valid: false, reason: 'SDK transaction target does not match bridge router' };
+  }
+
+  return { valid: true };
+}
+
+function sdkTransactionTarget(transaction: unknown): string | undefined {
+  if (!isRecord(transaction)) return undefined;
+  if (typeof transaction.to === 'string') return transaction.to;
+  if (typeof transaction.contractAddress === 'string') return transaction.contractAddress;
+  return undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/features/routeSecurity/svm.ts
+++ b/src/features/routeSecurity/svm.ts
@@ -5,11 +5,12 @@ import { isEngineNativeToken } from './utils';
 export function validateSealevelRouteTx(
   route: RouteResponse,
   tx: Extract<RouteTx, { to: string }>,
+  trustedUniversalRouter: string,
 ): RouteSecurityValidationResult {
-  // TODO: Pin tx.to (the invoked programId) once registry/local trusted SVM
-  // universal-router program data exists. Account checks below only prove the
-  // expected warp accounts are present; they do not prove the invoked program
-  // is trusted.
+  if (tx.to !== trustedUniversalRouter) {
+    return { valid: false, reason: 'Sealevel transaction target does not match universal router' };
+  }
+
   if (!tx.accounts?.length) {
     return { valid: false, reason: 'Sealevel transaction missing accounts' };
   }

--- a/src/features/routeSecurity/svm.ts
+++ b/src/features/routeSecurity/svm.ts
@@ -1,0 +1,29 @@
+import type { RouteResponse, RouteTx } from '../api/types';
+import type { RouteSecurityValidationResult } from './types';
+import { isEngineNativeToken } from './utils';
+
+export function validateSealevelRouteTx(
+  route: RouteResponse,
+  tx: Extract<RouteTx, { to: string }>,
+): RouteSecurityValidationResult {
+  // TODO: Pin tx.to (the invoked programId) once registry/local trusted SVM
+  // universal-router program data exists. Account checks below only prove the
+  // expected warp accounts are present; they do not prove the invoked program
+  // is trusted.
+  if (!tx.accounts?.length) {
+    return { valid: false, reason: 'Sealevel transaction missing accounts' };
+  }
+
+  const accountKeys = new Set(tx.accounts.map((account) => account.pubkey));
+  for (const step of route.steps) {
+    if (step.type !== 'bridge') continue;
+    if (!accountKeys.has(step.router)) {
+      return { valid: false, reason: 'Sealevel transaction missing bridge router account' };
+    }
+    if (!isEngineNativeToken(step.asset) && !accountKeys.has(step.asset)) {
+      return { valid: false, reason: 'Sealevel transaction missing bridge asset account' };
+    }
+  }
+
+  return { valid: true };
+}

--- a/src/features/routeSecurity/types.ts
+++ b/src/features/routeSecurity/types.ts
@@ -1,0 +1,3 @@
+export type RouteSecurityValidationResult =
+  | { valid: true }
+  | { valid: false; reason: string; warpRouteId?: string };

--- a/src/features/routeSecurity/types.ts
+++ b/src/features/routeSecurity/types.ts
@@ -1,3 +1,8 @@
 export type RouteSecurityValidationResult =
   | { valid: true }
   | { valid: false; reason: string; warpRouteId?: string };
+
+export type RouteSecurityValidationFailure = Extract<
+  RouteSecurityValidationResult,
+  { valid: false }
+>;

--- a/src/features/routeSecurity/utils.ts
+++ b/src/features/routeSecurity/utils.ts
@@ -18,7 +18,7 @@ export function firstBridge(route: RouteResponse): QuoteBridgeStep | undefined {
 }
 
 export function sameTokenAddress(left: string, right: string): boolean {
-  if (eqAddress(left, right)) return true;
+  if (safeEqAddress(left, right)) return true;
   if (isHexAddressLike(left) && isHexAddressLike(right))
     return left.toLowerCase() === right.toLowerCase();
   return left === right;
@@ -30,6 +30,14 @@ export function isEngineNativeToken(address: string): boolean {
 
 export function isUnsetAddress(address: string): boolean {
   return isZeroishAddress(address);
+}
+
+function safeEqAddress(left: string, right: string): boolean {
+  try {
+    return eqAddress(left, right);
+  } catch {
+    return false;
+  }
 }
 
 function isHexAddressLike(address: string): boolean {

--- a/src/features/routeSecurity/utils.ts
+++ b/src/features/routeSecurity/utils.ts
@@ -1,0 +1,37 @@
+import { eqAddress, isZeroishAddress } from '@hyperlane-xyz/utils';
+
+import type { ChainDiscovery, QuoteBridgeStep, RouteResponse } from '../api/types';
+
+// Engine API native-token sentinel used in token/fee fields. This is not
+// claiming every VM's native asset address is 0x0.
+export const ENGINE_NATIVE_TOKEN_SENTINEL = '0x0000000000000000000000000000000000000000';
+
+export function chainForId(
+  chains: ChainDiscovery[] | undefined,
+  chainId: number,
+): ChainDiscovery | undefined {
+  return chains?.find((chain) => chain.id === chainId);
+}
+
+export function firstBridge(route: RouteResponse): QuoteBridgeStep | undefined {
+  return route.steps.find((step): step is QuoteBridgeStep => step.type === 'bridge');
+}
+
+export function sameTokenAddress(left: string, right: string): boolean {
+  if (eqAddress(left, right)) return true;
+  if (isHexAddressLike(left) && isHexAddressLike(right))
+    return left.toLowerCase() === right.toLowerCase();
+  return left === right;
+}
+
+export function isEngineNativeToken(address: string): boolean {
+  return sameTokenAddress(address, ENGINE_NATIVE_TOKEN_SENTINEL);
+}
+
+export function isUnsetAddress(address: string): boolean {
+  return isZeroishAddress(address);
+}
+
+function isHexAddressLike(address: string): boolean {
+  return /^0x[0-9a-fA-F]+$/.test(address);
+}

--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -1,0 +1,454 @@
+import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { describe, expect, test } from 'vitest';
+
+import type { ChainDiscovery, RouteResponse } from '../api/types';
+import type { RegistryWarpRouteMap } from '../warpRoutes/registryWarpRoutes';
+import { validateRouteSecurity } from './validateRouteSecurity';
+
+const NATIVE = '0x0000000000000000000000000000000000000000';
+const TOKEN = '0x1111111111111111111111111111111111111111';
+const MID_TOKEN = '0x2222222222222222222222222222222222222222';
+const DST_TOKEN = '0x3333333333333333333333333333333333333333';
+const UNIVERSAL_ROUTER = '0x4444444444444444444444444444444444444444';
+const BAD = '0x5555555555555555555555555555555555555555';
+const PERMIT2 = '0x6666666666666666666666666666666666666666';
+const BRIDGE_ROUTER = '0x7777777777777777777777777777777777777777';
+const DST_ROUTER = '0x8888888888888888888888888888888888888888';
+const STARKNET_ROUTER = '0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
+const STARKNET_TOKEN = '0x01a238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
+const SOL_UNIVERSAL_ROUTER_PROGRAM = '2CttnaLkYbNHbaFDFnQ8PMCnzUwTGrKnskBxPM4TRWGp';
+const SOL_ROUTER = 'SolRouter1111111111111111111111111111111111';
+const SOL_MINT = 'SolMint111111111111111111111111111111111111';
+
+const ETH = 1;
+const BASE = 8453;
+const SOL = 1399811149;
+const STARKNET = 358974494;
+
+const chainMetadata = {
+  ethereum: { chainId: ETH, domainId: ETH },
+  base: { chainId: BASE, domainId: BASE },
+  solanamainnet: { chainId: SOL, domainId: SOL },
+  starknet: { chainId: STARKNET, domainId: STARKNET },
+} as unknown as ChainMap<ChainMetadata>;
+
+const chains = [
+  chain({ id: ETH, chainName: 'ethereum', protocol: ProtocolType.Ethereum }),
+  chain({ id: BASE, chainName: 'base', protocol: ProtocolType.Ethereum }),
+  chain({
+    id: SOL,
+    chainName: 'solanamainnet',
+    protocol: ProtocolType.Sealevel,
+    universalRouter: NATIVE,
+    permit2: NATIVE,
+  }),
+  chain({
+    id: STARKNET,
+    chainName: 'starknet',
+    protocol: ProtocolType.Starknet,
+    universalRouter: NATIVE,
+    permit2: NATIVE,
+  }),
+];
+
+describe('validateRouteSecurity', () => {
+  test('accepts a universal router swap and bridge route with matching approval and tx target', () => {
+    expect(validateRouteSecurity(universalRouterRoute(), context())).toEqual({ valid: true });
+  });
+
+  test('accepts a same-chain universal router swap route', () => {
+    const route = sameChainSwapRoute();
+
+    expect(validateRouteSecurity(route, context({ dstChain: ETH }))).toEqual({ valid: true });
+  });
+
+  test('rejects a route whose path starts on a different chain', () => {
+    const route = universalRouterRoute();
+    route.steps[0].chain = BASE;
+
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Route step chain does not match expected path',
+    });
+  });
+
+  test('rejects a route whose final chain does not match the request destination', () => {
+    expect(
+      validateRouteSecurity(universalRouterRoute(), context({ dstChain: STARKNET })),
+    ).toMatchObject({
+      valid: false,
+      reason: 'Route destination does not match request destination',
+    });
+  });
+
+  test('rejects Permit2 approvals because the UI only performs direct ERC20 approval', () => {
+    const route = universalRouterRoute({
+      approval: {
+        token: TOKEN,
+        spender: PERMIT2,
+        permit2Spender: UNIVERSAL_ROUTER,
+        amount: '100',
+        kind: 'permit2',
+      },
+    });
+
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Permit2 approvals are not supported by this UI',
+    });
+  });
+
+  test('rejects approval amounts above the first route spend', () => {
+    const route = universalRouterRoute({
+      approval: { token: TOKEN, spender: UNIVERSAL_ROUTER, amount: '101', kind: 'erc20' },
+    });
+
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Approval amount exceeds route input amount',
+    });
+  });
+
+  test('rejects universal router approvals to a different spender', () => {
+    const route = universalRouterRoute({
+      approval: { token: TOKEN, spender: BAD, amount: '100', kind: 'erc20' },
+    });
+
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Approval spender does not match chain universal router',
+    });
+  });
+
+  test('rejects EVM route txs sent to a different executor', () => {
+    const route = universalRouterRoute({ txTo: BAD });
+
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'EVM transaction target does not match route executor',
+    });
+  });
+
+  test('accepts warpDirect EVM route txs sent to the bridge router', () => {
+    const route = universalRouterRoute({
+      approval: null,
+      executionKind: 'warpDirect',
+      txTo: BRIDGE_ROUTER,
+    });
+
+    expect(validateRouteSecurity(route, context())).toEqual({ valid: true });
+  });
+
+  test('accepts an SDK warp tx with matching protocol and warpRouteId metadata', () => {
+    expect(validateRouteSecurity(starknetSdkWarpRoute(), starknetContext())).toEqual({
+      valid: true,
+    });
+  });
+
+  test('rejects SDK warp txs with mismatched protocol', () => {
+    const route = starknetSdkWarpRoute({ protocol: ProtocolType.Ethereum });
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK transaction protocol does not match source chain',
+    });
+  });
+
+  test('rejects SDK warp txs with mismatched warpRouteId metadata', () => {
+    const route = starknetSdkWarpRoute({ warpRouteId: 'OTHER/test' });
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK transaction warpRouteId does not match route',
+    });
+  });
+
+  test('rejects SDK warp txs with known targets that do not match the bridge router', () => {
+    const route = starknetSdkWarpRoute({ contractAddress: BAD });
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK transaction target does not match bridge router',
+    });
+  });
+
+  test('accepts SDK warp txs without an inspectable transaction target', () => {
+    const route = starknetSdkWarpRoute({ transaction: { manifest: 'opaque' } });
+
+    expect(validateRouteSecurity(route, starknetContext())).toEqual({ valid: true });
+  });
+
+  test('accepts Sealevel universal router txs that include bridge router and asset accounts', () => {
+    expect(validateRouteSecurity(sealevelUniversalRouterRoute(), solanaContext())).toEqual({
+      valid: true,
+    });
+  });
+
+  test('rejects Sealevel universal router txs missing bridge route accounts', () => {
+    const route = sealevelUniversalRouterRoute({ accounts: [{ pubkey: SOL_MINT }] });
+
+    expect(validateRouteSecurity(route, solanaContext())).toMatchObject({
+      valid: false,
+      reason: 'Sealevel transaction missing bridge router account',
+    });
+  });
+});
+
+function context(routeOverrides: Partial<RouteSecurityTestContext> = {}) {
+  return {
+    chainMetadata,
+    registryWarpRoutes: {},
+    chains,
+    srcChain: ETH,
+    dstChain: BASE,
+    srcToken: TOKEN,
+    dstToken: DST_TOKEN,
+    ...routeOverrides,
+  };
+}
+
+function starknetContext() {
+  return context({
+    registryWarpRoutes: starknetRoutes(),
+    srcChain: STARKNET,
+    dstChain: ETH,
+    srcToken: STARKNET_TOKEN,
+    dstToken: DST_ROUTER,
+  });
+}
+
+function solanaContext(overrides: Partial<RouteSecurityTestContext> = {}) {
+  return context({
+    registryWarpRoutes: solanaRoutes(),
+    srcChain: SOL,
+    dstChain: ETH,
+    srcToken: SOL_MINT,
+    dstToken: DST_ROUTER,
+    ...overrides,
+  });
+}
+
+type RouteSecurityTestContext = Parameters<typeof validateRouteSecurity>[1];
+
+function universalRouterRoute(
+  args: {
+    approval?: RouteResponse['approval'];
+    executionKind?: RouteResponse['executionKind'];
+    txTo?: string;
+  } = {},
+): RouteResponse {
+  return {
+    steps: [
+      {
+        type: 'swap',
+        chain: ETH,
+        dex: 'test',
+        tokenIn: TOKEN,
+        tokenOut: MID_TOKEN,
+        amountIn: '100',
+        amountOut: '90',
+        path: [TOKEN, MID_TOKEN],
+        poolCount: 1,
+      },
+      {
+        type: 'bridge',
+        chain: ETH,
+        destChain: BASE,
+        asset: MID_TOKEN,
+        router: BRIDGE_ROUTER,
+        amountIn: '90',
+        amountOut: '90',
+        bridgeSymbol: 'TEST',
+        warpRouteId: 'TEST/route',
+        fee: { tokenFee: '0', igpToken: NATIVE, igpAmount: '0', localNativeFee: '0' },
+      },
+    ],
+    output: '90',
+    outputMin: '89',
+    executionKind: args.executionKind ?? 'universalRouter',
+    connection: { symbol: 'TEST', warpRouteId: 'TEST/route' },
+    gas: { originGas: '0', destGas: '0' },
+    tx: { to: args.txTo ?? UNIVERSAL_ROUTER, data: '0x', value: '0' },
+    approval:
+      'approval' in args
+        ? args.approval!
+        : {
+            token: TOKEN,
+            spender: UNIVERSAL_ROUTER,
+            amount: '100',
+            kind: 'erc20',
+          },
+  };
+}
+
+function sameChainSwapRoute(): RouteResponse {
+  return {
+    steps: [
+      {
+        type: 'swap',
+        chain: ETH,
+        dex: 'test',
+        tokenIn: TOKEN,
+        tokenOut: DST_TOKEN,
+        amountIn: '100',
+        amountOut: '90',
+        path: [TOKEN, DST_TOKEN],
+        poolCount: 1,
+      },
+    ],
+    output: '90',
+    outputMin: '89',
+    executionKind: 'universalRouter',
+    connection: null,
+    gas: { originGas: '0', destGas: '0' },
+    tx: { to: UNIVERSAL_ROUTER, data: '0x', value: '0' },
+    approval: {
+      token: TOKEN,
+      spender: UNIVERSAL_ROUTER,
+      amount: '100',
+      kind: 'erc20',
+    },
+  };
+}
+
+function starknetSdkWarpRoute(
+  args: {
+    contractAddress?: string;
+    protocol?: ProtocolType;
+    transaction?: unknown;
+    warpRouteId?: string;
+  } = {},
+): RouteResponse {
+  return {
+    steps: [
+      {
+        type: 'bridge',
+        chain: STARKNET,
+        destChain: ETH,
+        asset: STARKNET_TOKEN,
+        router: STARKNET_ROUTER,
+        amountIn: '100',
+        amountOut: '100',
+        bridgeSymbol: 'STRK',
+        warpRouteId: 'STRK/test',
+        fee: { tokenFee: '0', igpToken: NATIVE, igpAmount: '0', localNativeFee: '0' },
+      },
+    ],
+    output: '100',
+    outputMin: '100',
+    executionKind: 'sdkWarp',
+    connection: { symbol: 'STRK', warpRouteId: 'STRK/test' },
+    gas: { originGas: '0', destGas: '0' },
+    tx: {
+      protocol: args.protocol ?? ProtocolType.Starknet,
+      type: 'starknet',
+      category: 'transfer',
+      transaction: args.transaction ?? {
+        contractAddress: args.contractAddress ?? STARKNET_ROUTER,
+        entrypoint: 'transfer_remote',
+        calldata: [],
+      },
+      metadata: { warpRouteId: args.warpRouteId ?? 'STRK/test' },
+    },
+    approval: null,
+  };
+}
+
+function sealevelUniversalRouterRoute(
+  args: {
+    accounts?: Array<{ pubkey: string; isSigner?: boolean; isWritable?: boolean }>;
+    txTo?: string;
+  } = {},
+): RouteResponse {
+  return {
+    steps: [
+      {
+        type: 'bridge',
+        chain: SOL,
+        destChain: ETH,
+        asset: SOL_MINT,
+        router: SOL_ROUTER,
+        amountIn: '100',
+        amountOut: '100',
+        bridgeSymbol: 'SOL',
+        warpRouteId: 'SOL/test',
+        fee: { tokenFee: '0', igpToken: NATIVE, igpAmount: '0', localNativeFee: '0' },
+      },
+    ],
+    output: '100',
+    outputMin: '100',
+    executionKind: 'universalRouter',
+    connection: { symbol: 'SOL', warpRouteId: 'SOL/test' },
+    gas: { originGas: '0', destGas: '0' },
+    tx: {
+      to: args.txTo ?? SOL_UNIVERSAL_ROUTER_PROGRAM,
+      data: '',
+      value: '0',
+      accounts: (args.accounts ?? [{ pubkey: SOL_ROUTER }, { pubkey: SOL_MINT }]).map(
+        (account) => ({
+          pubkey: account.pubkey,
+          isSigner: account.isSigner ?? false,
+          isWritable: account.isWritable ?? false,
+        }),
+      ),
+    },
+    approval: null,
+  };
+}
+
+function starknetRoutes(): RegistryWarpRouteMap {
+  return {
+    'strk/test': {
+      id: 'STRK/test',
+      tokens: [
+        {
+          chainName: 'starknet',
+          addressOrDenom: STARKNET_ROUTER,
+          collateralAddressOrDenom: STARKNET_TOKEN,
+          standard: 'StarknetHypCollateral',
+        },
+        { chainName: 'ethereum', addressOrDenom: DST_ROUTER, standard: 'EvmHypSynthetic' },
+      ],
+    },
+  };
+}
+
+function solanaRoutes(): RegistryWarpRouteMap {
+  return {
+    'sol/test': {
+      id: 'SOL/test',
+      tokens: [
+        {
+          chainName: 'solanamainnet',
+          addressOrDenom: SOL_ROUTER,
+          collateralAddressOrDenom: SOL_MINT,
+          standard: 'SealevelHypCollateral',
+        },
+        { chainName: 'ethereum', addressOrDenom: DST_ROUTER, standard: 'EvmHypSynthetic' },
+      ],
+    },
+  };
+}
+
+function chain(args: {
+  id: number;
+  chainName: string;
+  protocol: ProtocolType;
+  universalRouter?: string;
+  permit2?: string;
+}): ChainDiscovery {
+  return {
+    id: args.id,
+    name: args.chainName,
+    chainName: args.chainName,
+    protocol: args.protocol,
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    universalRouter: args.universalRouter ?? UNIVERSAL_ROUTER,
+    permit2: args.permit2 ?? PERMIT2,
+    dex: null,
+    canSwap: true,
+    canExecute: true,
+    supportsNative: true,
+  };
+}

--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -40,7 +40,7 @@ const chains = [
     id: SOL,
     chainName: 'solanamainnet',
     protocol: ProtocolType.Sealevel,
-    universalRouter: NATIVE,
+    universalRouter: SOL_UNIVERSAL_ROUTER_PROGRAM,
     permit2: NATIVE,
   }),
   chain({
@@ -51,6 +51,13 @@ const chains = [
     permit2: NATIVE,
   }),
 ];
+
+const chainAddresses = {
+  ethereum: { universalRouter: UNIVERSAL_ROUTER },
+  base: { universalRouter: UNIVERSAL_ROUTER },
+  solanamainnet: { universalRouter: SOL_UNIVERSAL_ROUTER_PROGRAM },
+  starknet: { universalRouter: NATIVE },
+};
 
 describe('validateRouteSecurity', () => {
   test('accepts a universal router swap and bridge route with matching approval and tx target', () => {
@@ -168,6 +175,18 @@ describe('validateRouteSecurity', () => {
     });
   });
 
+  test('rejects universal router routes when engine discovery disagrees with registry addresses', () => {
+    const route = universalRouterRoute();
+    const mismatchedChains = chains.map((chain) =>
+      chain.id === ETH ? { ...chain, universalRouter: BAD } : chain,
+    );
+
+    expect(validateRouteSecurity(route, context({ chains: mismatchedChains }))).toMatchObject({
+      valid: false,
+      reason: 'Chain universal router does not match registry',
+    });
+  });
+
   test('rejects malformed engine token values without throwing', () => {
     const route = universalRouterRoute({
       approval: {
@@ -257,6 +276,47 @@ describe('validateRouteSecurity', () => {
     });
   });
 
+  test('accepts Sealevel native assets without a token account', () => {
+    const route = sealevelUniversalRouterRoute({
+      accounts: [{ pubkey: SOL_ROUTER }],
+      asset: NATIVE,
+      warpRouteId: 'SOL/native',
+    });
+
+    expect(
+      validateRouteSecurity(
+        route,
+        solanaContext({
+          registryWarpRoutes: solanaNativeRoutes(),
+          srcToken: NATIVE,
+        }),
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  test('rejects Sealevel universal router txs sent to a different program', () => {
+    const route = sealevelUniversalRouterRoute({ txTo: SOL_ROUTER });
+
+    expect(validateRouteSecurity(route, solanaContext())).toMatchObject({
+      valid: false,
+      reason: 'Sealevel transaction target does not match universal router',
+    });
+  });
+
+  test('rejects Sealevel universal router routes when engine discovery disagrees with registry addresses', () => {
+    const route = sealevelUniversalRouterRoute();
+    const mismatchedChains = chains.map((chain) =>
+      chain.id === SOL ? { ...chain, universalRouter: SOL_ROUTER } : chain,
+    );
+
+    expect(validateRouteSecurity(route, solanaContext({ chains: mismatchedChains }))).toMatchObject(
+      {
+        valid: false,
+        reason: 'Chain universal router does not match registry',
+      },
+    );
+  });
+
   test('rejects Sealevel universal router txs missing bridge route accounts', () => {
     const route = sealevelUniversalRouterRoute({ accounts: [{ pubkey: SOL_MINT }] });
 
@@ -272,6 +332,7 @@ function context(routeOverrides: Partial<RouteSecurityTestContext> = {}) {
     chainMetadata,
     registryWarpRoutes: {},
     chains,
+    chainAddresses,
     srcChain: ETH,
     dstChain: BASE,
     srcToken: TOKEN,
@@ -430,28 +491,31 @@ function starknetSdkWarpRoute(
 function sealevelUniversalRouterRoute(
   args: {
     accounts?: Array<{ pubkey: string; isSigner?: boolean; isWritable?: boolean }>;
+    asset?: string;
     txTo?: string;
+    warpRouteId?: string;
   } = {},
 ): RouteResponse {
+  const warpRouteId = args.warpRouteId ?? 'SOL/test';
   return {
     steps: [
       {
         type: 'bridge',
         chain: SOL,
         destChain: ETH,
-        asset: SOL_MINT,
+        asset: args.asset ?? SOL_MINT,
         router: SOL_ROUTER,
         amountIn: '100',
         amountOut: '100',
         bridgeSymbol: 'SOL',
-        warpRouteId: 'SOL/test',
+        warpRouteId,
         fee: { tokenFee: '0', igpToken: NATIVE, igpAmount: '0', localNativeFee: '0' },
       },
     ],
     output: '100',
     outputMin: '100',
     executionKind: 'universalRouter',
-    connection: { symbol: 'SOL', warpRouteId: 'SOL/test' },
+    connection: { symbol: 'SOL', warpRouteId },
     gas: { originGas: '0', destGas: '0' },
     tx: {
       to: args.txTo ?? SOL_UNIVERSAL_ROUTER_PROGRAM,
@@ -479,6 +543,22 @@ function starknetRoutes(): RegistryWarpRouteMap {
           addressOrDenom: STARKNET_ROUTER,
           collateralAddressOrDenom: STARKNET_TOKEN,
           standard: 'StarknetHypCollateral',
+        },
+        { chainName: 'ethereum', addressOrDenom: DST_ROUTER, standard: 'EvmHypSynthetic' },
+      ],
+    },
+  };
+}
+
+function solanaNativeRoutes(): RegistryWarpRouteMap {
+  return {
+    'sol/native': {
+      id: 'SOL/native',
+      tokens: [
+        {
+          chainName: 'solanamainnet',
+          addressOrDenom: SOL_ROUTER,
+          standard: 'SealevelHypNative',
         },
         { chainName: 'ethereum', addressOrDenom: DST_ROUTER, standard: 'EvmHypSynthetic' },
       ],

--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -63,6 +63,16 @@ describe('validateRouteSecurity', () => {
     expect(validateRouteSecurity(route, context({ dstChain: ETH }))).toEqual({ valid: true });
   });
 
+  test('accepts chain protocols with different casing', () => {
+    const mixedCaseChains = chains.map((chain) =>
+      chain.id === ETH ? { ...chain, protocol: 'Ethereum' } : chain,
+    );
+
+    expect(
+      validateRouteSecurity(universalRouterRoute(), context({ chains: mixedCaseChains })),
+    ).toEqual({ valid: true });
+  });
+
   test('rejects a route whose path starts on a different chain', () => {
     const route = universalRouterRoute();
     route.steps[0].chain = BASE;
@@ -110,6 +120,43 @@ describe('validateRouteSecurity', () => {
     });
   });
 
+  test('rejects approval amounts below the first route spend', () => {
+    const route = universalRouterRoute({
+      approval: { token: TOKEN, spender: UNIVERSAL_ROUTER, amount: '99', kind: 'erc20' },
+    });
+
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Approval amount is below route input amount',
+    });
+  });
+
+  test('rejects invalid approval amounts without throwing', () => {
+    const route = universalRouterRoute({
+      approval: { token: TOKEN, spender: UNIVERSAL_ROUTER, amount: 'invalid', kind: 'erc20' },
+    });
+
+    expect(() => validateRouteSecurity(route, context())).not.toThrow();
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Approval route has invalid amount',
+    });
+  });
+
+  test('rejects approvals for native first-spend routes', () => {
+    const route = universalRouterRoute({
+      approval: { token: NATIVE, spender: UNIVERSAL_ROUTER, amount: '100', kind: 'erc20' },
+    });
+    if (route.steps[0].type !== 'swap') throw new Error('expected swap first step');
+    route.steps[0].tokenIn = NATIVE;
+    route.steps[0].path = [NATIVE, MID_TOKEN];
+
+    expect(validateRouteSecurity(route, context({ srcToken: NATIVE }))).toMatchObject({
+      valid: false,
+      reason: 'Native route must not request approval',
+    });
+  });
+
   test('rejects universal router approvals to a different spender', () => {
     const route = universalRouterRoute({
       approval: { token: TOKEN, spender: BAD, amount: '100', kind: 'erc20' },
@@ -118,6 +165,23 @@ describe('validateRouteSecurity', () => {
     expect(validateRouteSecurity(route, context())).toMatchObject({
       valid: false,
       reason: 'Approval spender does not match chain universal router',
+    });
+  });
+
+  test('rejects malformed engine token values without throwing', () => {
+    const route = universalRouterRoute({
+      approval: {
+        token: 'not-an-address',
+        spender: UNIVERSAL_ROUTER,
+        amount: '100',
+        kind: 'erc20',
+      },
+    });
+
+    expect(() => validateRouteSecurity(route, context())).not.toThrow();
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Approval token does not match route input token',
     });
   });
 
@@ -142,6 +206,14 @@ describe('validateRouteSecurity', () => {
 
   test('accepts an SDK warp tx with matching protocol and warpRouteId metadata', () => {
     expect(validateRouteSecurity(starknetSdkWarpRoute(), starknetContext())).toEqual({
+      valid: true,
+    });
+  });
+
+  test('accepts SDK warp tx protocols with different casing', () => {
+    expect(
+      validateRouteSecurity(starknetSdkWarpRoute({ protocol: 'Starknet' }), starknetContext()),
+    ).toEqual({
       valid: true,
     });
   });
@@ -315,7 +387,7 @@ function sameChainSwapRoute(): RouteResponse {
 function starknetSdkWarpRoute(
   args: {
     contractAddress?: string;
-    protocol?: ProtocolType;
+    protocol?: string;
     transaction?: unknown;
     warpRouteId?: string;
   } = {},
@@ -434,7 +506,7 @@ function solanaRoutes(): RegistryWarpRouteMap {
 function chain(args: {
   id: number;
   chainName: string;
-  protocol: ProtocolType;
+  protocol: string;
   universalRouter?: string;
   permit2?: string;
 }): ChainDiscovery {

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -1,0 +1,176 @@
+import { isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
+
+import type { ChainDiscovery, QuoteStep, RouteResponse, RouteTx } from '../api/types';
+import { getRouteTxs, isEvmRouteTx } from '../transfer/engine/validate';
+import { validateSdkRouteTx } from './sdk';
+import { validateSealevelRouteTx } from './svm';
+import type { RouteSecurityValidationResult } from './types';
+import { chainForId, firstBridge, isUnsetAddress, sameTokenAddress } from './utils';
+import { validateWarpRoute, type WarpRouteValidationContext } from './validateWarpRoute';
+
+export interface RouteSecurityValidationContext extends WarpRouteValidationContext {
+  srcChain: number;
+  dstChain: number;
+}
+
+export function validateRouteSecurity(
+  route: RouteResponse,
+  context: RouteSecurityValidationContext,
+): RouteSecurityValidationResult {
+  const warpRouteValidation = validateWarpRoute(route, context);
+  if (!warpRouteValidation.valid) return warpRouteValidation;
+
+  const chainPathValidation = validateChainPath(route, context.srcChain, context.dstChain);
+  if (!chainPathValidation.valid) return chainPathValidation;
+
+  const approvalValidation = validateApproval(route, context);
+  if (!approvalValidation.valid) return approvalValidation;
+
+  return validateTxTargets(route, context);
+}
+
+function validateChainPath(
+  route: RouteResponse,
+  srcChain: number,
+  dstChain: number,
+): RouteSecurityValidationResult {
+  if (route.steps.length === 0) {
+    return { valid: false, reason: 'Route has no steps' };
+  }
+
+  let currentChain = srcChain;
+  for (const step of route.steps) {
+    if (step.chain !== currentChain) {
+      return { valid: false, reason: 'Route step chain does not match expected path' };
+    }
+    if (step.type === 'bridge') currentChain = step.destChain;
+  }
+
+  if (currentChain !== dstChain) {
+    return { valid: false, reason: 'Route destination does not match request destination' };
+  }
+
+  return { valid: true };
+}
+
+function validateApproval(
+  route: RouteResponse,
+  context: RouteSecurityValidationContext,
+): RouteSecurityValidationResult {
+  if (!route.approval) return { valid: true };
+
+  // Bridge-only approvals are already registry-checked by validateWarpRoute.
+  // Keep this second pass for swap-led routes and generic approval bounds.
+  if (route.approval.kind !== 'erc20') {
+    return { valid: false, reason: 'Permit2 approvals are not supported by this UI' };
+  }
+
+  const firstStep = route.steps[0];
+  if (!firstStep) return { valid: false, reason: 'Approval route has no spend step' };
+
+  const spendToken = spendTokenForStep(firstStep);
+  if (!sameTokenAddress(route.approval.token, spendToken)) {
+    return { valid: false, reason: 'Approval token does not match route input token' };
+  }
+
+  if (BigInt(route.approval.amount) > BigInt(firstStep.amountIn)) {
+    return { valid: false, reason: 'Approval amount exceeds route input amount' };
+  }
+
+  if (route.executionKind === 'sdkWarp') {
+    return { valid: false, reason: 'SDK warp route must not request approval' };
+  }
+
+  if (route.executionKind === 'universalRouter') {
+    const srcChain = chainForId(context.chains, context.srcChain);
+    if (!srcChain?.universalRouter || isUnsetAddress(srcChain.universalRouter)) {
+      return { valid: false, reason: 'Universal router approval target unavailable' };
+    }
+    if (!sameTokenAddress(route.approval.spender, srcChain.universalRouter)) {
+      return { valid: false, reason: 'Approval spender does not match chain universal router' };
+    }
+    return { valid: true };
+  }
+
+  const firstBridgeStep = firstBridge(route);
+  if (!firstBridgeStep) {
+    return { valid: false, reason: 'Direct warp approval route has no bridge step' };
+  }
+  if (!sameTokenAddress(route.approval.spender, firstBridgeStep.router)) {
+    return { valid: false, reason: 'Approval spender does not match bridge router' };
+  }
+
+  return { valid: true };
+}
+
+function validateTxTargets(
+  route: RouteResponse,
+  context: RouteSecurityValidationContext,
+): RouteSecurityValidationResult {
+  const txs = getRouteTxs(route);
+  if (txs.length === 0) return { valid: false, reason: 'Route has no transactions' };
+
+  const srcChain = chainForId(context.chains, context.srcChain);
+  if (!srcChain) return { valid: false, reason: 'Route source chain unavailable' };
+
+  const srcProtocol = protocolForChain(srcChain);
+  if (!srcProtocol) return { valid: false, reason: 'Route source protocol unavailable' };
+
+  for (const tx of txs) {
+    const validation = isEvmRouteTx(tx)
+      ? validateChainRouteTx(route, tx, srcChain, srcProtocol)
+      : validateSdkRouteTx(route, tx, srcProtocol);
+    if (!validation.valid) return validation;
+  }
+
+  return { valid: true };
+}
+
+function validateChainRouteTx(
+  route: RouteResponse,
+  tx: Extract<RouteTx, { to: string }>,
+  srcChain: ChainDiscovery,
+  srcProtocol: ProtocolType,
+): RouteSecurityValidationResult {
+  if (isEVMLike(srcProtocol)) {
+    const expectedTarget =
+      route.executionKind === 'universalRouter'
+        ? srcChain.universalRouter
+        : route.executionKind === 'warpDirect'
+          ? firstBridge(route)?.router
+          : undefined;
+    if (!expectedTarget || isUnsetAddress(expectedTarget)) {
+      return { valid: false, reason: 'EVM transaction target unavailable' };
+    }
+    if (!sameTokenAddress(tx.to, expectedTarget)) {
+      return { valid: false, reason: 'EVM transaction target does not match route executor' };
+    }
+    return { valid: true };
+  }
+
+  if (srcProtocol === ProtocolType.Sealevel) {
+    if (route.executionKind !== 'universalRouter') {
+      return {
+        valid: false,
+        reason: 'Sealevel chain transaction is only supported for universal router execution',
+      };
+    }
+    return validateSealevelRouteTx(route, tx);
+  }
+
+  return {
+    valid: false,
+    reason: 'Chain transaction shape is not supported for source protocol',
+  };
+}
+
+function spendTokenForStep(step: QuoteStep): string {
+  return step.type === 'swap' ? step.tokenIn : step.asset;
+}
+
+function protocolForChain(chain: ChainDiscovery | undefined): ProtocolType | undefined {
+  if (!chain) return undefined;
+  return Object.values(ProtocolType).includes(chain.protocol as ProtocolType)
+    ? (chain.protocol as ProtocolType)
+    : undefined;
+}

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -2,9 +2,10 @@ import { isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { getRouteTxs, isChainRouteTx } from '../api/routeTx';
 import type { ChainDiscovery, QuoteStep, RouteResponse, RouteTx } from '../api/types';
+import { trustedUniversalRouterForChain } from './chainContracts';
 import { validateSdkRouteTx } from './sdk';
 import { validateSealevelRouteTx } from './svm';
-import type { RouteSecurityValidationResult } from './types';
+import type { RouteSecurityValidationFailure, RouteSecurityValidationResult } from './types';
 import {
   chainForId,
   firstBridge,
@@ -101,10 +102,16 @@ function validateApproval(
 
   if (route.executionKind === 'universalRouter') {
     const srcChain = chainForId(context.chains, context.srcChain);
-    if (!srcChain?.universalRouter || isUnsetAddress(srcChain.universalRouter)) {
-      return { valid: false, reason: 'Universal router approval target unavailable' };
-    }
-    if (!sameTokenAddress(route.approval.spender, srcChain.universalRouter)) {
+    const trustedUniversalRouter = trustedUniversalRouterForChain({
+      chain: srcChain,
+      chainAddresses: srcChain?.chainName
+        ? context.chainAddresses?.[srcChain.chainName]
+        : undefined,
+      unavailableReason: 'Universal router approval target unavailable',
+      mismatchReason: 'Chain universal router does not match registry',
+    });
+    if (!trustedUniversalRouter.valid) return trustedUniversalRouter;
+    if (!sameTokenAddress(route.approval.spender, trustedUniversalRouter.universalRouter)) {
       return { valid: false, reason: 'Approval spender does not match chain universal router' };
     }
     return { valid: true };
@@ -136,7 +143,7 @@ function validateTxTargets(
 
   for (const tx of txs) {
     const validation = isChainRouteTx(tx)
-      ? validateChainRouteTx(route, tx, srcChain, srcProtocol)
+      ? validateChainRouteTx(route, tx, srcChain, srcProtocol, context)
       : validateSdkRouteTx(route, tx, srcProtocol);
     if (!validation.valid) return validation;
   }
@@ -149,18 +156,12 @@ function validateChainRouteTx(
   tx: Extract<RouteTx, { to: string }>,
   srcChain: ChainDiscovery,
   srcProtocol: ProtocolType,
+  context: RouteSecurityValidationContext,
 ): RouteSecurityValidationResult {
   if (isEVMLike(srcProtocol)) {
-    const expectedTarget =
-      route.executionKind === 'universalRouter'
-        ? srcChain.universalRouter
-        : route.executionKind === 'warpDirect'
-          ? firstBridge(route)?.router
-          : undefined;
-    if (!expectedTarget || isUnsetAddress(expectedTarget)) {
-      return { valid: false, reason: 'EVM transaction target unavailable' };
-    }
-    if (!sameTokenAddress(tx.to, expectedTarget)) {
+    const expectedTarget = expectedChainTxTarget(route, srcChain, context);
+    if (!expectedTarget.valid) return expectedTarget;
+    if (!sameTokenAddress(tx.to, expectedTarget.target)) {
       return { valid: false, reason: 'EVM transaction target does not match route executor' };
     }
     return { valid: true };
@@ -173,13 +174,47 @@ function validateChainRouteTx(
         reason: 'Sealevel chain transaction is only supported for universal router execution',
       };
     }
-    return validateSealevelRouteTx(route, tx);
+    const trustedUniversalRouter = trustedUniversalRouterForChain({
+      chain: srcChain,
+      chainAddresses: context.chainAddresses?.[srcChain.chainName],
+      unavailableReason: 'Sealevel universal router program unavailable',
+      mismatchReason: 'Chain universal router does not match registry',
+    });
+    if (!trustedUniversalRouter.valid) return trustedUniversalRouter;
+    return validateSealevelRouteTx(route, tx, trustedUniversalRouter.universalRouter);
   }
 
   return {
     valid: false,
     reason: 'Chain transaction shape is not supported for source protocol',
   };
+}
+
+function expectedChainTxTarget(
+  route: RouteResponse,
+  srcChain: ChainDiscovery,
+  context: RouteSecurityValidationContext,
+): RouteSecurityValidationFailure | { valid: true; target: string } {
+  if (route.executionKind === 'universalRouter') {
+    const trustedUniversalRouter = trustedUniversalRouterForChain({
+      chain: srcChain,
+      chainAddresses: context.chainAddresses?.[srcChain.chainName],
+      unavailableReason: 'EVM transaction target unavailable',
+      mismatchReason: 'Chain universal router does not match registry',
+    });
+    if (!trustedUniversalRouter.valid) return trustedUniversalRouter;
+    return { valid: true, target: trustedUniversalRouter.universalRouter };
+  }
+
+  if (route.executionKind === 'warpDirect') {
+    const expectedTarget = firstBridge(route)?.router;
+    if (!expectedTarget || isUnsetAddress(expectedTarget)) {
+      return { valid: false, reason: 'EVM transaction target unavailable' };
+    }
+    return { valid: true, target: expectedTarget };
+  }
+
+  return { valid: false, reason: 'EVM transaction target unavailable' };
 }
 
 function spendTokenForStep(step: QuoteStep): string {

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -66,8 +66,8 @@ function validateApproval(
 ): RouteSecurityValidationResult {
   if (!route.approval) return { valid: true };
 
-  // Bridge-only approvals are already registry-checked by validateWarpRoute.
-  // Keep this second pass for swap-led routes and generic approval bounds.
+  // validateWarpRoute handles bridge-only registry consistency; this pass
+  // applies UI-level approval constraints to any approval object.
   if (route.approval.kind !== 'erc20') {
     return { valid: false, reason: 'Permit2 approvals are not supported by this UI' };
   }

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -1,11 +1,17 @@
 import { isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
 
+import { getRouteTxs, isChainRouteTx } from '../api/routeTx';
 import type { ChainDiscovery, QuoteStep, RouteResponse, RouteTx } from '../api/types';
-import { getRouteTxs, isEvmRouteTx } from '../transfer/engine/validate';
 import { validateSdkRouteTx } from './sdk';
 import { validateSealevelRouteTx } from './svm';
 import type { RouteSecurityValidationResult } from './types';
-import { chainForId, firstBridge, isUnsetAddress, sameTokenAddress } from './utils';
+import {
+  chainForId,
+  firstBridge,
+  isEngineNativeToken,
+  isUnsetAddress,
+  sameTokenAddress,
+} from './utils';
 import { validateWarpRoute, type WarpRouteValidationContext } from './validateWarpRoute';
 
 export interface RouteSecurityValidationContext extends WarpRouteValidationContext {
@@ -69,12 +75,24 @@ function validateApproval(
   if (!firstStep) return { valid: false, reason: 'Approval route has no spend step' };
 
   const spendToken = spendTokenForStep(firstStep);
+  if (isEngineNativeToken(spendToken)) {
+    return { valid: false, reason: 'Native route must not request approval' };
+  }
   if (!sameTokenAddress(route.approval.token, spendToken)) {
     return { valid: false, reason: 'Approval token does not match route input token' };
   }
 
-  if (BigInt(route.approval.amount) > BigInt(firstStep.amountIn)) {
+  const approvalAmount = parseRouteAmount(route.approval.amount);
+  const spendAmount = parseRouteAmount(firstStep.amountIn);
+  if (approvalAmount == null || spendAmount == null) {
+    return { valid: false, reason: 'Approval route has invalid amount' };
+  }
+
+  if (approvalAmount > spendAmount) {
     return { valid: false, reason: 'Approval amount exceeds route input amount' };
+  }
+  if (approvalAmount < spendAmount) {
+    return { valid: false, reason: 'Approval amount is below route input amount' };
   }
 
   if (route.executionKind === 'sdkWarp') {
@@ -117,7 +135,7 @@ function validateTxTargets(
   if (!srcProtocol) return { valid: false, reason: 'Route source protocol unavailable' };
 
   for (const tx of txs) {
-    const validation = isEvmRouteTx(tx)
+    const validation = isChainRouteTx(tx)
       ? validateChainRouteTx(route, tx, srcChain, srcProtocol)
       : validateSdkRouteTx(route, tx, srcProtocol);
     if (!validation.valid) return validation;
@@ -168,9 +186,16 @@ function spendTokenForStep(step: QuoteStep): string {
   return step.type === 'swap' ? step.tokenIn : step.asset;
 }
 
+function parseRouteAmount(amount: string): bigint | null {
+  try {
+    return BigInt(amount);
+  } catch {
+    return null;
+  }
+}
+
 function protocolForChain(chain: ChainDiscovery | undefined): ProtocolType | undefined {
   if (!chain) return undefined;
-  return Object.values(ProtocolType).includes(chain.protocol as ProtocolType)
-    ? (chain.protocol as ProtocolType)
-    : undefined;
+  const protocol = chain.protocol.toLowerCase();
+  return Object.values(ProtocolType).find((value) => value.toLowerCase() === protocol);
 }

--- a/src/features/routeSecurity/validateWarpRoute.test.ts
+++ b/src/features/routeSecurity/validateWarpRoute.test.ts
@@ -29,6 +29,13 @@ const chains = [
   chain({ id: 358974494, chainName: 'starknet' }),
 ];
 
+const chainAddresses = {
+  ethereum: { universalRouter: UNIVERSAL_ROUTER },
+  base: { universalRouter: UNIVERSAL_ROUTER },
+  solanamainnet: { universalRouter: UNIVERSAL_ROUTER },
+  starknet: { universalRouter: UNIVERSAL_ROUTER },
+};
+
 describe('validateWarpRoute', () => {
   test('accepts a registry-matching native bridge route', () => {
     const route = bridgeRoute({
@@ -134,6 +141,26 @@ describe('validateWarpRoute', () => {
     });
 
     expect(validateWarpRoute(route, context(collateralRoutes()))).toEqual({ valid: true });
+  });
+
+  test('rejects universal router approvals when engine discovery disagrees with registry addresses', () => {
+    const route = bridgeRoute({
+      asset: COLLATERAL,
+      router: ROUTER,
+      approval: { token: COLLATERAL, spender: UNIVERSAL_ROUTER, amount: '1', kind: 'erc20' },
+      warpRouteId: 'USDC/test',
+      executionKind: 'universalRouter',
+    });
+    const mismatchedChains = chains.map((chain) =>
+      chain.id === 1 ? { ...chain, universalRouter: BAD } : chain,
+    );
+
+    expect(
+      validateWarpRoute(route, context(collateralRoutes(), undefined, undefined, mismatchedChains)),
+    ).toMatchObject({
+      valid: false,
+      reason: 'Chain universal router does not match registry',
+    });
   });
 
   test('accepts Permit2 approvals that target the universal router', () => {
@@ -288,7 +315,14 @@ function context(
   dstToken?: string,
   chainDiscovery: ChainDiscovery[] = chains,
 ) {
-  return { chainMetadata, registryWarpRoutes, chains: chainDiscovery, srcToken, dstToken };
+  return {
+    chainMetadata,
+    chainAddresses,
+    registryWarpRoutes,
+    chains: chainDiscovery,
+    srcToken,
+    dstToken,
+  };
 }
 
 function nativeRoutes(): RegistryWarpRouteMap {

--- a/src/features/routeSecurity/validateWarpRoute.ts
+++ b/src/features/routeSecurity/validateWarpRoute.ts
@@ -7,8 +7,8 @@ import {
   type RegistryWarpRouteMap,
   type RegistryWarpRouteToken,
 } from '../warpRoutes/registryWarpRoutes';
+import { chainForId, ENGINE_NATIVE_TOKEN_SENTINEL, sameTokenAddress } from './utils';
 
-const NATIVE_TOKEN = '0x0000000000000000000000000000000000000000';
 const HYP_NATIVE_STANDARDS = new Set([
   'EvmHypNative',
   'SealevelHypNative',
@@ -94,7 +94,7 @@ export function validateWarpRoute(
   }
 
   if (isNativeWarpStandard(origin.standard)) {
-    if (!sameTokenAddress(step.asset, NATIVE_TOKEN)) {
+    if (!sameTokenAddress(step.asset, ENGINE_NATIVE_TOKEN_SENTINEL)) {
       return { valid: false, reason: 'Native bridge asset must be native sentinel', warpRouteId };
     }
     if (route.approval) {
@@ -126,13 +126,6 @@ export function isBridgeOnlyRoute(
   return route.steps.length > 0 && route.steps.every((step) => step.type === 'bridge');
 }
 
-function chainForId(
-  chains: ChainDiscovery[] | undefined,
-  chainId: number,
-): ChainDiscovery | undefined {
-  return chains?.find((chain) => chain.id === chainId);
-}
-
 function chainNameForChainId(
   chainMetadata: ChainMap<ChainMetadata>,
   chainId: number,
@@ -152,7 +145,9 @@ function expectedSpendToken(token: RegistryWarpRouteToken): string {
 }
 
 function expectedDiscoveryToken(token: RegistryWarpRouteToken): string {
-  return isNativeWarpStandard(token.standard) ? NATIVE_TOKEN : expectedSpendToken(token);
+  return isNativeWarpStandard(token.standard)
+    ? ENGINE_NATIVE_TOKEN_SENTINEL
+    : expectedSpendToken(token);
 }
 
 function isNativeWarpStandard(standard: string): boolean {
@@ -208,15 +203,4 @@ function validateApprovalSpender(
     return { valid: false, reason: 'Approval spender does not match registry route', warpRouteId };
   }
   return { valid: true };
-}
-
-function sameTokenAddress(left: string, right: string): boolean {
-  if (isHexAddressLike(left) && isHexAddressLike(right)) {
-    return left.toLowerCase() === right.toLowerCase();
-  }
-  return left === right;
-}
-
-function isHexAddressLike(address: string): boolean {
-  return /^0x[0-9a-fA-F]+$/.test(address);
 }

--- a/src/features/routeSecurity/validateWarpRoute.ts
+++ b/src/features/routeSecurity/validateWarpRoute.ts
@@ -222,8 +222,8 @@ function validateApprovalSpender(
       mismatchReason: 'Chain universal router does not match registry',
       warpRouteId,
     });
-    if (!originChain?.permit2 || !approval.permit2Spender || !trustedUniversalRouter.valid) {
-      if (!trustedUniversalRouter.valid) return trustedUniversalRouter;
+    if (!trustedUniversalRouter.valid) return trustedUniversalRouter;
+    if (!originChain?.permit2 || !approval.permit2Spender) {
       return { valid: false, reason: 'Permit2 approval missing chain contracts', warpRouteId };
     }
     if (!sameTokenAddress(approval.spender, originChain.permit2)) {

--- a/src/features/routeSecurity/validateWarpRoute.ts
+++ b/src/features/routeSecurity/validateWarpRoute.ts
@@ -1,3 +1,4 @@
+import type { ChainAddresses } from '@hyperlane-xyz/registry';
 import type { ChainMap, ChainMetadata } from '@hyperlane-xyz/sdk';
 
 import type { ChainDiscovery, QuoteBridgeStep, RouteApproval, RouteResponse } from '../api/types';
@@ -7,6 +8,7 @@ import {
   type RegistryWarpRouteMap,
   type RegistryWarpRouteToken,
 } from '../warpRoutes/registryWarpRoutes';
+import { trustedUniversalRouterForChain } from './chainContracts';
 import { chainForId, ENGINE_NATIVE_TOKEN_SENTINEL, sameTokenAddress } from './utils';
 
 const HYP_NATIVE_STANDARDS = new Set([
@@ -24,6 +26,7 @@ export type WarpRouteValidationResult =
 
 export interface WarpRouteValidationContext {
   chainMetadata: ChainMap<ChainMetadata>;
+  chainAddresses?: ChainMap<ChainAddresses>;
   registryWarpRoutes: RegistryWarpRouteMap;
   chains?: ChainDiscovery[];
   srcToken?: string;
@@ -117,7 +120,14 @@ export function validateWarpRoute(
     return { valid: false, reason: 'Approval token does not match registry route', warpRouteId };
   }
 
-  return validateApprovalSpender(route, route.approval, origin, originChain, warpRouteId);
+  return validateApprovalSpender(
+    route,
+    route.approval,
+    origin,
+    originChain,
+    context.chainAddresses?.[originChainName],
+    warpRouteId,
+  );
 }
 
 export function isBridgeOnlyRoute(
@@ -159,13 +169,22 @@ function validateApprovalSpender(
   approval: RouteApproval,
   origin: RegistryWarpRouteToken,
   originChain: ChainDiscovery | undefined,
+  originChainAddresses: ChainAddresses | undefined,
   warpRouteId: string,
 ): WarpRouteValidationResult {
   if (approval.kind === 'permit2') {
     if (route.executionKind !== 'universalRouter') {
       return { valid: false, reason: 'Permit2 approval requires universal router', warpRouteId };
     }
-    if (!originChain?.permit2 || !originChain.universalRouter || !approval.permit2Spender) {
+    const trustedUniversalRouter = trustedUniversalRouterForChain({
+      chain: originChain,
+      chainAddresses: originChainAddresses,
+      unavailableReason: 'Permit2 approval missing chain contracts',
+      mismatchReason: 'Chain universal router does not match registry',
+      warpRouteId,
+    });
+    if (!originChain?.permit2 || !approval.permit2Spender || !trustedUniversalRouter.valid) {
+      if (!trustedUniversalRouter.valid) return trustedUniversalRouter;
       return { valid: false, reason: 'Permit2 approval missing chain contracts', warpRouteId };
     }
     if (!sameTokenAddress(approval.spender, originChain.permit2)) {
@@ -175,7 +194,7 @@ function validateApprovalSpender(
         warpRouteId,
       };
     }
-    if (!sameTokenAddress(approval.permit2Spender, originChain.universalRouter)) {
+    if (!sameTokenAddress(approval.permit2Spender, trustedUniversalRouter.universalRouter)) {
       return {
         valid: false,
         reason: 'Permit2 approval target does not match chain universal router',
@@ -186,10 +205,15 @@ function validateApprovalSpender(
   }
 
   if (route.executionKind === 'universalRouter') {
-    if (!originChain?.universalRouter) {
-      return { valid: false, reason: 'Universal router approval target unavailable', warpRouteId };
-    }
-    if (!sameTokenAddress(approval.spender, originChain.universalRouter)) {
+    const trustedUniversalRouter = trustedUniversalRouterForChain({
+      chain: originChain,
+      chainAddresses: originChainAddresses,
+      unavailableReason: 'Universal router approval target unavailable',
+      mismatchReason: 'Chain universal router does not match registry',
+      warpRouteId,
+    });
+    if (!trustedUniversalRouter.valid) return trustedUniversalRouter;
+    if (!sameTokenAddress(approval.spender, trustedUniversalRouter.universalRouter)) {
       return {
         valid: false,
         reason: 'Approval spender does not match chain universal router',

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -129,6 +129,7 @@ function TransferFormContent() {
     error: quoteError,
     isExpired,
     isQuoteSettled,
+    isRouteDataUnavailable,
   } = useQuote({
     values: { ...values, amount: debouncedAmount, recipient: effectiveRecipient },
     sender,
@@ -626,6 +627,7 @@ function TransferFormContent() {
         hasAmount={hasAmount}
         hasTokens={hasTokens}
         hasRoute={!!bestRoute}
+        isRouteDataUnavailable={isRouteDataUnavailable}
         isQuoteSettled={isQuoteSettled}
         isValidating={isValidating}
         onSendTransactions={onSendTransactions}
@@ -1083,6 +1085,7 @@ function ButtonSection({
   hasAmount,
   hasTokens,
   hasRoute,
+  isRouteDataUnavailable,
   isQuoteSettled,
   isValidating,
   onSendTransactions,
@@ -1096,6 +1099,7 @@ function ButtonSection({
   hasAmount: boolean;
   hasTokens: boolean;
   hasRoute: boolean;
+  isRouteDataUnavailable: boolean;
   isQuoteSettled: boolean;
   isValidating: boolean;
   onSendTransactions: () => Promise<void>;
@@ -1122,6 +1126,9 @@ function ButtonSection({
       text = 'Continue';
       disabled = false;
     }
+  } else if (isRouteDataUnavailable) {
+    text = 'Route data unavailable';
+    disabled = true;
   } else if (isQuoteSettled) {
     text = 'Route is not supported';
     disabled = true;

--- a/src/features/transfer/engine/useQuote.test.ts
+++ b/src/features/transfer/engine/useQuote.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { quoteExpiryDelayMs } from './useQuote';
+import { isQuoteSettledForSecurity, quoteExpiryDelayMs } from './useQuote';
 
 describe('quoteExpiryDelayMs', () => {
   test('returns time remaining until quote expiry', () => {
@@ -9,5 +9,19 @@ describe('quoteExpiryDelayMs', () => {
 
   test('clamps expired quotes to immediate timeout', () => {
     expect(quoteExpiryDelayMs(1_718_000_000, 1_718_000_030_000)).toBe(0);
+  });
+});
+
+describe('isQuoteSettledForSecurity', () => {
+  test('keeps successful quotes unsettled until security context settles', () => {
+    expect(isQuoteSettledForSecurity(true, false, false)).toBe(false);
+  });
+
+  test('settles successful quotes when security context is ready or failed', () => {
+    expect(isQuoteSettledForSecurity(true, false, true)).toBe(true);
+  });
+
+  test('settles quote errors without waiting for security context', () => {
+    expect(isQuoteSettledForSecurity(false, true, false)).toBe(true);
   });
 });

--- a/src/features/transfer/engine/useQuote.ts
+++ b/src/features/transfer/engine/useQuote.ts
@@ -41,6 +41,7 @@ interface UseQuoteArgs {
 export function useQuote({ values, sender, pause }: UseQuoteArgs) {
   const [now, setNow] = useState(() => Date.now());
   const chainMetadata = useStore((state) => state.chainMetadata);
+  const chainAddresses = useStore((state) => state.chainAddresses);
   const registryWarpRoutes = useStore((state) => state.registryWarpRoutes);
   const { data: chainsResp, isError: chainsError } = useChains();
 
@@ -111,6 +112,7 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
     const routes = query.data.routes.filter((route) => {
       const validation = validateRouteSecurity(route, {
         chainMetadata,
+        chainAddresses,
         registryWarpRoutes,
         chains: chainsResp.chains,
         srcChain: values.srcChain!,
@@ -132,6 +134,7 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
     };
   }, [
     chainMetadata,
+    chainAddresses,
     chainsResp?.chains,
     query.data,
     registryWarpRoutes,

--- a/src/features/transfer/engine/useQuote.ts
+++ b/src/features/transfer/engine/useQuote.ts
@@ -106,9 +106,11 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
     staleTime: REFRESH_MS,
   });
 
+  const hasChainAddresses = Object.keys(chainAddresses).length > 0;
   const augmented = useMemo<AugmentedQuote | undefined>(() => {
     if (!query.data) return undefined;
     if (!chainsResp?.chains) return undefined;
+    if (!hasChainAddresses) return undefined;
     const routes = query.data.routes.filter((route) => {
       const validation = validateRouteSecurity(route, {
         chainMetadata,
@@ -136,6 +138,7 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
     chainMetadata,
     chainAddresses,
     chainsResp?.chains,
+    hasChainAddresses,
     query.data,
     registryWarpRoutes,
     values.dstChain,
@@ -153,7 +156,7 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
   useTimeout(refreshNow, quoteExpiryDelay);
 
   const isExpired = augmented ? augmented.expiresAt * 1000 < now : false;
-  const isSecurityContextReady = !!chainsResp?.chains;
+  const isSecurityContextReady = !!chainsResp?.chains && hasChainAddresses;
   const isSecurityContextSettled = isSecurityContextReady || chainsError;
   const isQuoteSettled = isQuoteSettledForSecurity(
     query.isSuccess,

--- a/src/features/transfer/engine/useQuote.ts
+++ b/src/features/transfer/engine/useQuote.ts
@@ -7,7 +7,7 @@ import { logger } from '../../../utils/logger';
 import { useChains } from '../../api/hooks';
 import { routerClient } from '../../api/RouterClient';
 import type { QuoteResponse, RouteResponse } from '../../api/types';
-import { validateWarpRoute } from '../../routeSecurity/validateWarpRoute';
+import { validateRouteSecurity } from '../../routeSecurity/validateRouteSecurity';
 import { useStore } from '../../store';
 import { useTokens } from '../../tokens/hooks';
 import { tokenKey } from '../../tokens/utils';
@@ -107,16 +107,19 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
 
   const augmented = useMemo<AugmentedQuote | undefined>(() => {
     if (!query.data) return undefined;
+    if (!chainsResp?.chains) return undefined;
     const routes = query.data.routes.filter((route) => {
-      const validation = validateWarpRoute(route, {
+      const validation = validateRouteSecurity(route, {
         chainMetadata,
         registryWarpRoutes,
-        chains: chainsResp?.chains,
+        chains: chainsResp.chains,
+        srcChain: values.srcChain!,
+        dstChain: values.dstChain!,
         srcToken: values.srcToken,
         dstToken: values.dstToken,
       });
       if (validation.valid) return true;
-      logger.warn('Filtered unsafe bridge-only route', {
+      logger.warn('Filtered unsafe route', {
         reason: validation.reason,
         warpRouteId: validation.warpRouteId,
       });
@@ -132,7 +135,9 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
     chainsResp?.chains,
     query.data,
     registryWarpRoutes,
+    values.dstChain,
     values.dstToken,
+    values.srcChain,
     values.srcToken,
   ]);
 

--- a/src/features/transfer/engine/useQuote.ts
+++ b/src/features/transfer/engine/useQuote.ts
@@ -42,7 +42,7 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
   const [now, setNow] = useState(() => Date.now());
   const chainMetadata = useStore((state) => state.chainMetadata);
   const registryWarpRoutes = useStore((state) => state.registryWarpRoutes);
-  const { data: chainsResp } = useChains();
+  const { data: chainsResp, isError: chainsError } = useChains();
 
   // Pass sender + recipient through as-is — engine handles per-protocol normalization.
   const engineSender = sender || undefined;
@@ -150,18 +150,34 @@ export function useQuote({ values, sender, pause }: UseQuoteArgs) {
   useTimeout(refreshNow, quoteExpiryDelay);
 
   const isExpired = augmented ? augmented.expiresAt * 1000 < now : false;
-  const isQuoteSettled = query.isSuccess || query.isError;
+  const isSecurityContextReady = !!chainsResp?.chains;
+  const isSecurityContextSettled = isSecurityContextReady || chainsError;
+  const isQuoteSettled = isQuoteSettledForSecurity(
+    query.isSuccess,
+    query.isError,
+    isSecurityContextSettled,
+  );
+  const isRouteDataUnavailable = query.isSuccess && chainsError;
 
   return {
     ...query,
     quote: augmented,
     isExpired,
     isQuoteSettled,
+    isRouteDataUnavailable,
   };
 }
 
 export function quoteExpiryDelayMs(expiresAt: number, nowMs: number): number {
   return Math.max(expiresAt * 1000 - nowMs, 0);
+}
+
+export function isQuoteSettledForSecurity(
+  isSuccess: boolean,
+  isError: boolean,
+  isSecurityContextSettled: boolean,
+): boolean {
+  return isError || (isSuccess && isSecurityContextSettled);
 }
 
 function isQuoteRequestReady(v: TransferFormValues, sender: string | undefined): boolean {

--- a/src/features/transfer/engine/useTransfer.ts
+++ b/src/features/transfer/engine/useTransfer.ts
@@ -22,6 +22,7 @@ import { useCallback, useState } from 'react';
 import type { Address } from 'viem';
 
 import { logger } from '../../../utils/logger';
+import { getRouteTxs, isChainRouteTx } from '../../api/routeTx';
 import type { RouteTx } from '../../api/types';
 import { useMultiProvider } from '../../chains/hooks';
 import { useStore } from '../../store';
@@ -30,7 +31,6 @@ import { postCommitment } from './ccs';
 import { labelTransferMessages, type ParsedTransferMessage } from './messages';
 import { TransferStatus } from './types';
 import type { AugmentedRoute } from './types';
-import { getRouteTxs } from './validate';
 
 interface ExecuteArgs {
   transactionId: string;
@@ -265,10 +265,6 @@ function isEvmReceipt(receipt: TypedTransactionReceipt): boolean {
     receipt.type === ProviderType.EthersV5 ||
     receipt.type === ProviderType.Tron
   );
-}
-
-function isChainRouteTx(tx: RouteTx): tx is Extract<RouteTx, { to: string }> {
-  return 'to' in tx;
 }
 
 export async function toWalletTx(

--- a/src/features/transfer/engine/useTransfer.ts
+++ b/src/features/transfer/engine/useTransfer.ts
@@ -30,6 +30,7 @@ import { postCommitment } from './ccs';
 import { labelTransferMessages, type ParsedTransferMessage } from './messages';
 import { TransferStatus } from './types';
 import type { AugmentedRoute } from './types';
+import { getRouteTxs } from './validate';
 
 interface ExecuteArgs {
   transactionId: string;
@@ -68,7 +69,7 @@ export function useTransfer() {
       setIsPending(true);
 
       try {
-        const routeTxs = route.raw.txs?.length ? route.raw.txs : route.raw.tx ? [route.raw.tx] : [];
+        const routeTxs = getRouteTxs(route.raw);
         if (!routeTxs.length) throw new Error('Route has no tx');
 
         // Store route for status polling and recovery (non-persisted, session only).

--- a/src/features/transfer/engine/validate.ts
+++ b/src/features/transfer/engine/validate.ts
@@ -334,11 +334,11 @@ function isNativeAddress(addr: string): boolean {
   return /^0x0+$/i.test(addr);
 }
 
-function getRouteTxs(route: RouteResponse): RouteTx[] {
+export function getRouteTxs(route: RouteResponse): RouteTx[] {
   return route.txs?.length ? route.txs : route.tx ? [route.tx] : [];
 }
 
-function isEvmRouteTx(tx: RouteTx): tx is Extract<RouteTx, { to: string }> {
+export function isEvmRouteTx(tx: RouteTx): tx is Extract<RouteTx, { to: string }> {
   return 'to' in tx;
 }
 

--- a/src/features/transfer/engine/validate.ts
+++ b/src/features/transfer/engine/validate.ts
@@ -10,7 +10,8 @@ import {
 import { parseUnits } from 'viem';
 
 import { logger } from '../../../utils/logger';
-import type { ChainDiscovery, RouteResponse, RouteTx } from '../../api/types';
+import { getRouteTxs, isChainRouteTx } from '../../api/routeTx';
+import type { ChainDiscovery } from '../../api/types';
 import { estimateNativeGasCost, readBalance } from '../../balances/read';
 import { formatDisplayAmount } from '../../balances/utils';
 import type { UiToken } from '../../tokens/types';
@@ -257,7 +258,7 @@ export async function validateBalances(args: {
     }
   }
 
-  const originTx = getRouteTxs(bestRoute.raw).find(isEvmRouteTx) ?? null;
+  const originTx = getRouteTxs(bestRoute.raw).find(isChainRouteTx) ?? null;
   const txValue = originTx ? BigInt(originTx.value) : 0n;
   const gasCost = await estimateNativeGasCost(multiProvider, {
     chainName: srcChainInfo.chainName,
@@ -332,14 +333,6 @@ function balanceKey(chainId: number, address: string): string {
 
 function isNativeAddress(addr: string): boolean {
   return /^0x0+$/i.test(addr);
-}
-
-export function getRouteTxs(route: RouteResponse): RouteTx[] {
-  return route.txs?.length ? route.txs : route.tx ? [route.tx] : [];
-}
-
-export function isEvmRouteTx(tx: RouteTx): tx is Extract<RouteTx, { to: string }> {
-  return 'to' in tx;
 }
 
 function toEvmCanonical(addr: string, protocol: ProtocolType): string | null {

--- a/tests/e2e-wallet/helpers/quote.ts
+++ b/tests/e2e-wallet/helpers/quote.ts
@@ -1,7 +1,7 @@
 import type { Page, Route } from '@playwright/test';
 
-export const E2E_ROUTE_TX_TO = '0x1111111111111111111111111111111111111111';
-export const E2E_APPROVAL_SPENDER = '0x2222222222222222222222222222222222222222';
+export const E2E_ROUTE_TX_TO = '0x52dd779c1b5eeb54d5f218EfA72D52117ca04115'.toLowerCase();
+export const E2E_APPROVAL_SPENDER = E2E_ROUTE_TX_TO;
 
 interface InstallQuoteMockOptions {
   approval?: 'erc20' | 'none';
@@ -23,6 +23,55 @@ export async function installQuoteMock(
       amount: string;
     };
 
+    const txTo = opts.txTo ?? E2E_ROUTE_TX_TO;
+    const steps =
+      body.srcChain === body.dstChain
+        ? [
+            {
+              type: 'swap',
+              chain: body.srcChain,
+              dex: 'e2e',
+              tokenIn: body.srcToken,
+              tokenOut: body.dstToken,
+              amountIn: body.amount,
+              amountOut: opts.output ?? body.amount,
+              path: [body.srcToken, body.dstToken],
+              poolCount: 1,
+              minPoolTvlUsd: null,
+            },
+          ]
+        : [
+            {
+              type: 'swap',
+              chain: body.srcChain,
+              dex: 'e2e',
+              tokenIn: body.srcToken,
+              tokenOut: body.srcToken,
+              amountIn: body.amount,
+              amountOut: opts.output ?? body.amount,
+              path: [body.srcToken],
+              poolCount: 1,
+              minPoolTvlUsd: null,
+            },
+            {
+              type: 'bridge',
+              chain: body.srcChain,
+              destChain: body.dstChain,
+              asset: body.srcToken,
+              router: '0x3333333333333333333333333333333333333333',
+              amountIn: opts.output ?? body.amount,
+              amountOut: opts.output ?? body.amount,
+              fee: {
+                tokenFee: '0',
+                igpToken: '0x0000000000000000000000000000000000000000',
+                igpAmount: '0',
+                localNativeFee: '0',
+              },
+              bridgeSymbol: 'E2E',
+              warpRouteId: 'E2E/test',
+            },
+          ];
+
     return route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -30,20 +79,7 @@ export async function installQuoteMock(
         expiresAt: Math.floor(Date.now() / 1000) + 60,
         routes: [
           {
-            steps: [
-              {
-                type: 'swap',
-                chain: body.srcChain,
-                dex: 'e2e',
-                tokenIn: body.srcToken,
-                tokenOut: body.dstToken,
-                amountIn: body.amount,
-                amountOut: opts.output ?? body.amount,
-                path: [body.srcToken, body.dstToken],
-                poolCount: 1,
-                minPoolTvlUsd: null,
-              },
-            ],
+            steps,
             output: opts.output ?? body.amount,
             outputMin: opts.outputMin ?? opts.output ?? body.amount,
             executionKind: 'universalRouter',
@@ -53,13 +89,13 @@ export async function installQuoteMock(
               destGas: '0',
             },
             tx: {
-              to: opts.txTo ?? E2E_ROUTE_TX_TO,
+              to: txTo,
               data: '0x12345678',
               value: '0',
             },
             txs: [
               {
-                to: opts.txTo ?? E2E_ROUTE_TX_TO,
+                to: txTo,
                 data: '0x12345678',
                 value: '0',
               },


### PR DESCRIPTION
## Summary
- add client-side route security validation around engine quote responses
- validate bridge-only routes against registry warp routes, with published package fallback
- reject mismatched route paths, unsupported Permit2 approvals, native first-spend approvals, non-exact/invalid approval amounts, bad approval spenders, and bad route executors
- compare engine `/v1/chains` `universalRouter` values against locally assembled registry `chainAddresses[chain].universalRouter` before trusting approval spenders or tx targets
- validate SVM universal-router txs by pinning `tx.to` to the trusted registry/API universal-router program and checking bridge router/assets accounts
- keep Solana native assets compatible with the engine `0x000...` native sentinel while allowing Solana universal-router program ids in chain discovery
- validate generic SDK warp txs by execution kind, normalized source protocol, transfer category, warpRouteId, and known target fields when present
- split route-security logic into generic SDK/SVM/helpers for easier follow-up validation
- keep route tx helpers in a lightweight API module so quote/security validation does not import transfer form validators
- keep quotes unsettled until route-security context is available, and show a dedicated route-data-unavailable state on chain discovery failure

## Security Notes
- Universal-router routes now fail closed if the engine-discovered `universalRouter` is missing, unset, or disagrees with the registry/local `chainAddresses` value.
- SVM route txs now pin the invoked program id to the trusted universal-router address. This closes the previous residual where only account presence was checked.
- Opaque SDK transaction shapes are accepted only when no generic target field can be extracted; known `to`/`contractAddress` fields are checked against the bridge router.

## Verification
- `pnpm format`
- `pnpm lint` (passes with existing unrelated no-console warnings)
- `pnpm typecheck`
- `pnpm vitest src/features/routeSecurity/validateRouteSecurity.test.ts src/features/routeSecurity/validateWarpRoute.test.ts --watch false --reporter=dot`
- staging API sanity check: `solanamainnet` chain `universalRouter` is a base58 program id, while native `SOL` token address remains `0x0000000000000000000000000000000000000000` with `wrappedAddress=So11111111111111111111111111111111111111112`

Latest review loop also ran focused route-security/useQuote/useTransfer tests after each review fix.