### PR TITLE
fix: handle native alt-vm balance aliases

### DIFF
--- a/src/features/balances/aleo.test.ts
+++ b/src/features/balances/aleo.test.ts
@@ -1,0 +1,53 @@
+import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { TokenStandard } from '@hyperlane-xyz/sdk';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { directAleoBalanceDenom, readAleoTokenBalance } from './aleo';
+
+const getBalanceMock = vi.fn();
+
+describe('aleo balance routing', () => {
+  beforeEach(() => {
+    getBalanceMock.mockReset();
+    getBalanceMock.mockResolvedValue(987654n);
+  });
+
+  test('reads native zero-address tokens through the chain native denom', async () => {
+    const balance = await readAleoTokenBalance(multiProviderWithNativeDenom('credits'), {
+      chainName: 'aleo',
+      tokenAddress: '0x0000000000000000000000000000000000000000',
+      isNative: true,
+      owner: 'aleo1owner',
+      standard: TokenStandard.AleoHypNative,
+    });
+
+    expect(balance).toBe(987654n);
+    expect(getBalanceMock).toHaveBeenCalledWith({
+      address: 'aleo1owner',
+      denom: 'credits',
+    });
+  });
+
+  test('does not remap non-native zero-address token ids', () => {
+    expect(
+      directAleoBalanceDenom({
+        tokenAddress: '0x0000000000000000000000000000000000000000',
+        isNative: false,
+        standard: TokenStandard.AleoHypSynthetic,
+      }),
+    ).toBeNull();
+  });
+});
+
+function multiProviderWithNativeDenom(denom: string): MultiProtocolProvider {
+  return {
+    tryGetChainMetadata: () => ({
+      nativeToken: { denom },
+    }),
+    getProvider: () => ({
+      provider: {
+        getBalance: getBalanceMock,
+      },
+    }),
+  } as unknown as MultiProtocolProvider;
+}

--- a/src/features/balances/aleo.ts
+++ b/src/features/balances/aleo.ts
@@ -1,4 +1,5 @@
 import { Token, TokenStandard, type MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { isZeroishAddress } from '@hyperlane-xyz/utils';
 
 import { logger } from '../../utils/logger';
 import type { BalanceToken } from './types';
@@ -92,7 +93,7 @@ export function directAleoBalanceDenom(
   },
   nativeDenom?: string,
 ): string | null {
-  if (args.isNative && isZeroAddress(args.tokenAddress)) return nativeDenom ?? null;
+  if (args.isNative && isZeroishAddress(args.tokenAddress)) return nativeDenom ?? null;
   if (args.standard === TokenStandard.AleoHypCollateral && !isAleoTokenProgram(args.tokenAddress)) {
     return args.tokenAddress;
   }
@@ -109,8 +110,4 @@ function nativeDenomFor(
 ): string | undefined {
   if (!chainName) return undefined;
   return multiProvider.tryGetChainMetadata(chainName)?.nativeToken?.denom;
-}
-
-function isZeroAddress(address: string): boolean {
-  return /^0x0+$/i.test(address);
 }

--- a/src/features/balances/aleo.ts
+++ b/src/features/balances/aleo.ts
@@ -50,7 +50,7 @@ export async function readAleoTokenBalance(
   multiProvider: MultiProtocolProvider,
   args: AleoBalanceArgs,
 ): Promise<bigint> {
-  const directDenom = directAleoBalanceDenom(args);
+  const directDenom = directAleoBalanceDenom(args, nativeDenomFor(multiProvider, args.chainName));
   if (directDenom) {
     const provider = multiProvider.getProvider(args.chainName).provider as {
       getBalance(input: { address: string; denom: string }): Promise<bigint>;
@@ -84,11 +84,15 @@ export function resolveAleoBalanceStandard(args: {
   return TokenStandard.AleoHypSynthetic;
 }
 
-export function directAleoBalanceDenom(args: {
-  tokenAddress: string;
-  isNative: boolean;
-  standard?: string;
-}): string | null {
+export function directAleoBalanceDenom(
+  args: {
+    tokenAddress: string;
+    isNative: boolean;
+    standard?: string;
+  },
+  nativeDenom?: string,
+): string | null {
+  if (args.isNative && isZeroAddress(args.tokenAddress)) return nativeDenom ?? null;
   if (args.standard === TokenStandard.AleoHypCollateral && !isAleoTokenProgram(args.tokenAddress)) {
     return args.tokenAddress;
   }
@@ -97,4 +101,16 @@ export function directAleoBalanceDenom(args: {
 
 export function isAleoTokenProgram(address: string): boolean {
   return address.includes('.aleo/');
+}
+
+function nativeDenomFor(
+  multiProvider: MultiProtocolProvider,
+  chainName: string | undefined,
+): string | undefined {
+  if (!chainName) return undefined;
+  return multiProvider.tryGetChainMetadata(chainName)?.nativeToken?.denom;
+}
+
+function isZeroAddress(address: string): boolean {
+  return /^0x0+$/i.test(address);
 }

--- a/src/features/balances/aleo.ts
+++ b/src/features/balances/aleo.ts
@@ -4,6 +4,7 @@ import { isZeroishAddress } from '@hyperlane-xyz/utils';
 import { logger } from '../../utils/logger';
 import type { BalanceToken } from './types';
 import { getBalanceTokenKey } from './types';
+import { getNativeTokenDenom } from './utils';
 
 interface AleoBalanceArgs {
   chainName: string;
@@ -51,7 +52,10 @@ export async function readAleoTokenBalance(
   multiProvider: MultiProtocolProvider,
   args: AleoBalanceArgs,
 ): Promise<bigint> {
-  const directDenom = directAleoBalanceDenom(args, nativeDenomFor(multiProvider, args.chainName));
+  const directDenom = directAleoBalanceDenom(
+    args,
+    getNativeTokenDenom(multiProvider, args.chainName),
+  );
   if (directDenom) {
     const provider = multiProvider.getProvider(args.chainName).provider as {
       getBalance(input: { address: string; denom: string }): Promise<bigint>;
@@ -102,12 +106,4 @@ export function directAleoBalanceDenom(
 
 export function isAleoTokenProgram(address: string): boolean {
   return address.includes('.aleo/');
-}
-
-function nativeDenomFor(
-  multiProvider: MultiProtocolProvider,
-  chainName: string | undefined,
-): string | undefined {
-  if (!chainName) return undefined;
-  return multiProvider.tryGetChainMetadata(chainName)?.nativeToken?.denom;
 }

--- a/src/features/balances/cosmos.test.ts
+++ b/src/features/balances/cosmos.test.ts
@@ -1,0 +1,59 @@
+import { TokenStandard, type MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { connectMock, disconnectMock, getBalanceMock } = vi.hoisted(() => ({
+  connectMock: vi.fn(),
+  disconnectMock: vi.fn(),
+  getBalanceMock: vi.fn(),
+}));
+
+vi.mock('@cosmjs/stargate', () => ({
+  StargateClient: {
+    connect: connectMock,
+  },
+}));
+
+import { readCosmosTokenBalance } from './cosmos';
+
+describe('readCosmosTokenBalance', () => {
+  beforeEach(() => {
+    connectMock.mockReset();
+    disconnectMock.mockReset();
+    getBalanceMock.mockReset();
+    connectMock.mockResolvedValue({
+      getBalance: getBalanceMock,
+      disconnect: disconnectMock,
+    });
+    getBalanceMock.mockResolvedValue({ amount: '123456' });
+  });
+
+  test.each([
+    ['celestia', 'utia', 'celestia1owner'],
+    ['kyve', 'ukyve', 'kyve1owner'],
+  ])(
+    'reads %s native zero-address tokens through the chain native denom',
+    async (chainName, denom, owner) => {
+      const balance = await readCosmosTokenBalance(multiProviderWithNativeDenom(denom), {
+        chainName,
+        tokenAddress: '0x0000000000000000000000000000000000000000',
+        isNative: true,
+        owner,
+        standard: TokenStandard.CosmNativeHypCollateral,
+      });
+
+      expect(balance).toBe(123456n);
+      expect(connectMock).toHaveBeenCalledWith(`https://${chainName}-rpc.test`);
+      expect(getBalanceMock).toHaveBeenCalledWith(owner, denom);
+      expect(disconnectMock).toHaveBeenCalledOnce();
+    },
+  );
+});
+
+function multiProviderWithNativeDenom(denom: string): MultiProtocolProvider {
+  return {
+    tryGetChainMetadata: (chainName: string) => ({
+      nativeToken: { denom },
+      rpcUrls: [{ http: `https://${chainName}-rpc.test` }],
+    }),
+  } as unknown as MultiProtocolProvider;
+}

--- a/src/features/balances/cosmos.ts
+++ b/src/features/balances/cosmos.ts
@@ -1,9 +1,11 @@
 import { StargateClient } from '@cosmjs/stargate';
 import { Token, TokenStandard, type MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { isZeroishAddress } from '@hyperlane-xyz/utils';
 
 import { logger } from '../../utils/logger';
 import type { BalanceToken } from './types';
 import { getBalanceTokenKey } from './types';
+import { getNativeTokenDenom } from './utils';
 
 interface CosmosBalanceArgs {
   chainName: string;
@@ -27,9 +29,10 @@ export async function fetchCosmosChainBalances(
   if (tokens.length === 0) return out;
 
   const chainName = tokens[0]?.chainName;
+  const nativeDenom = getNativeTokenDenom(multiProvider, chainName);
   const rpcUrl = rpcUrlFor(multiProvider, chainName);
   const bankTokens = tokens
-    .map((token) => ({ token, denom: cosmosBankDenomForToken(token) }))
+    .map((token) => ({ token, denom: cosmosBankDenomForToken(token, nativeDenom) }))
     .filter((entry): entry is { token: BalanceToken; denom: string } => !!entry.denom);
 
   if (rpcUrl && bankTokens.length > 0) {
@@ -48,7 +51,7 @@ export async function fetchCosmosChainBalances(
 
   await Promise.all(
     tokens
-      .filter((token) => !cosmosBankDenomForToken(token))
+      .filter((token) => !cosmosBankDenomForToken(token, nativeDenom))
       .map(async (token) => {
         try {
           out[getBalanceTokenKey(token)] = await readCosmosTokenBalance(multiProvider, {
@@ -76,10 +79,14 @@ export async function readCosmosTokenBalance(
   multiProvider: MultiProtocolProvider,
   args: CosmosBalanceArgs,
 ): Promise<bigint> {
-  const denom = cosmosBankDenomForToken({
-    address: args.tokenAddress,
-    standard: args.standard,
-  });
+  const denom = cosmosBankDenomForToken(
+    {
+      address: args.tokenAddress,
+      isNative: args.isNative,
+      standard: args.standard,
+    },
+    getNativeTokenDenom(multiProvider, args.chainName),
+  );
   if (denom) {
     const rpcUrl = rpcUrlFor(multiProvider, args.chainName);
     if (!rpcUrl) return 0n;
@@ -105,12 +112,17 @@ export async function readCosmosTokenBalance(
   return (await token.getBalance(multiProvider, args.owner)).amount;
 }
 
-export function cosmosBankDenomForToken(token: {
-  address: string;
-  standard?: string;
-}): string | null {
+export function cosmosBankDenomForToken(
+  token: {
+    address: string;
+    isNative?: boolean;
+    standard?: string;
+  },
+  nativeDenom?: string,
+): string | null {
   if (token.standard === TokenStandard.CwHypNative) return null;
   if (token.standard === TokenStandard.CwHypSynthetic) return null;
+  if (token.isNative && isZeroishAddress(token.address)) return nativeDenom ?? null;
   if (
     token.standard === TokenStandard.CosmNativeHypCollateral &&
     isCosmosModuleTokenId(token.address)

--- a/src/features/balances/multivm.test.ts
+++ b/src/features/balances/multivm.test.ts
@@ -35,6 +35,31 @@ describe('cosmos balance routing', () => {
     ).toBe('hyperlane/0x1234');
   });
 
+  test.each(['utia', 'ukyve', 'uosmo'])(
+    'maps native zero-address aliases to the chain native denom %s',
+    (nativeDenom) => {
+      expect(
+        cosmosBankDenomForToken(
+          {
+            address: '0x0000000000000000000000000000000000000000',
+            isNative: true,
+            standard: TokenStandard.CosmNativeHypCollateral,
+          },
+          nativeDenom,
+        ),
+      ).toBe(nativeDenom);
+    },
+  );
+
+  test('does not remap non-native zero-address module token ids', () => {
+    expect(
+      cosmosBankDenomForToken({
+        address: '0x0000000000000000000000000000000000000000',
+        standard: TokenStandard.CosmNativeHypCollateral,
+      }),
+    ).toBeNull();
+  });
+
   test('keeps Cosmos native collateral module token ids on the SDK adapter', () => {
     expect(
       cosmosBankDenomForToken({

--- a/src/features/balances/radix.test.ts
+++ b/src/features/balances/radix.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+
+import { radixBalanceAddressForToken } from './radix';
+
+describe('radix balance address routing', () => {
+  test('maps native zero-address aliases to the Radix native resource denom', () => {
+    expect(
+      radixBalanceAddressForToken(
+        {
+          tokenAddress: '0x0000000000000000000000000000000000000000',
+          isNative: true,
+        },
+        'resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd',
+      ),
+    ).toBe('resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd');
+  });
+
+  test('keeps component token addresses on the Hyp adapter path', () => {
+    expect(
+      radixBalanceAddressForToken({
+        tokenAddress: 'component_rdx1cp0fd',
+        isNative: false,
+      }),
+    ).toBe('component_rdx1cp0fd');
+  });
+});

--- a/src/features/balances/radix.ts
+++ b/src/features/balances/radix.ts
@@ -3,6 +3,7 @@ import { Token, TokenStandard, type MultiProtocolProvider } from '@hyperlane-xyz
 import { logger } from '../../utils/logger';
 import type { BalanceToken } from './types';
 import { getBalanceTokenKey } from './types';
+import { getNativeTokenDenom } from './utils';
 
 interface RadixBalanceArgs {
   chainName: string;
@@ -50,7 +51,7 @@ export async function readRadixTokenBalance(
   multiProvider: MultiProtocolProvider,
   args: RadixBalanceArgs,
 ): Promise<bigint> {
-  const nativeDenom = multiProvider.tryGetChainMetadata(args.chainName)?.nativeToken?.denom;
+  const nativeDenom = getNativeTokenDenom(multiProvider, args.chainName);
   const token = new Token({
     chainName: args.chainName,
     standard: resolveRadixBalanceStandard(args),

--- a/src/features/balances/radix.ts
+++ b/src/features/balances/radix.ts
@@ -50,10 +50,11 @@ export async function readRadixTokenBalance(
   multiProvider: MultiProtocolProvider,
   args: RadixBalanceArgs,
 ): Promise<bigint> {
+  const nativeDenom = multiProvider.tryGetChainMetadata(args.chainName)?.nativeToken?.denom;
   const token = new Token({
     chainName: args.chainName,
     standard: resolveRadixBalanceStandard(args),
-    addressOrDenom: args.tokenAddress,
+    addressOrDenom: radixBalanceAddressForToken(args, nativeDenom),
     decimals: args.decimals ?? 18,
     symbol: args.symbol ?? '',
     name: args.name ?? args.symbol ?? '',
@@ -61,6 +62,17 @@ export async function readRadixTokenBalance(
     logoURI: args.logoURI,
   });
   return (await token.getBalance(multiProvider, args.owner)).amount;
+}
+
+export function radixBalanceAddressForToken(
+  args: {
+    tokenAddress: string;
+    isNative: boolean;
+  },
+  nativeDenom?: string,
+): string {
+  if (args.isNative) return nativeDenom ?? args.tokenAddress;
+  return args.tokenAddress;
 }
 
 export function resolveRadixBalanceStandard(args: {

--- a/src/features/balances/starknet.ts
+++ b/src/features/balances/starknet.ts
@@ -3,6 +3,7 @@ import { Token, TokenStandard, type MultiProtocolProvider } from '@hyperlane-xyz
 import { logger } from '../../utils/logger';
 import type { BalanceToken } from './types';
 import { getBalanceTokenKey } from './types';
+import { getNativeTokenDenom } from './utils';
 
 export async function fetchStarknetChainBalances(
   multiProvider: MultiProtocolProvider,
@@ -72,7 +73,7 @@ function resolveStarknetBalanceAddress(
   args: { chainName: string; tokenAddress: string; isNative: boolean },
 ): string {
   if (!args.isNative && !isZeroAddress(args.tokenAddress)) return args.tokenAddress;
-  const nativeAddress = multiProvider.tryGetChainMetadata(args.chainName)?.nativeToken?.denom;
+  const nativeAddress = getNativeTokenDenom(multiProvider, args.chainName);
   if (!nativeAddress) throw new Error(`Native token address not found for ${args.chainName}`);
   return nativeAddress;
 }

--- a/src/features/balances/utils.ts
+++ b/src/features/balances/utils.ts
@@ -1,3 +1,4 @@
+import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { fromWei, fromWeiRounded } from '@hyperlane-xyz/utils';
 
 import type { BalanceToken } from './types';
@@ -62,4 +63,12 @@ export function getFeePercentage(totalFeesUsd: number, transferUsd: number): str
   if (pct < 0.01) return '<0.01%';
   if (pct >= 100) return '>=100%';
   return `${pct.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%`;
+}
+
+export function getNativeTokenDenom(
+  multiProvider: MultiProtocolProvider,
+  chainName: string | undefined,
+): string | undefined {
+  if (!chainName) return undefined;
+  return multiProvider.tryGetChainMetadata(chainName)?.nativeToken?.denom;
 }


### PR DESCRIPTION
## Summary

- Resolve Aleo native zero-address balance reads through the chain native denom instead of passing the zero alias downstream.
- Resolve Radix native zero-address balance reads through the Radix resource denom while keeping component token balances on the Hyp adapter path.
- Add focused balance routing coverage for Aleo and Radix native aliases.