### PR TITLE
chore: remove USDC/aleo and USDT/aleo from nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -406,8 +406,6 @@ export const warpRouteWhitelist: Array<string> | null = [
   // Aleo warp routes
   'ALEO/aleo',
   'ETH/aleo',
-  'USDC/aleo',
-  'USDT/aleo',
   'USAD/aleo',
   'SOL/aleo',
   'WBTC/aleo',


### PR DESCRIPTION
## Summary
Removes `USDC/aleo` and `USDT/aleo` from the Nexus warp route whitelist while both routes are paused.

The Aleo v2 USDC/USDT token programs were deployed with an unset scaling factor (a CLI deploy bug), causing overminting on the Aleo side (e.g. sending 1 USDC from Ethereum minted 10^12 USDC on Aleo, since it did not scale 18→6 decimals). The routes are currently paused via the Aleo emergency pause function; collateral was never at risk. Pulling them from the UI whitelist while the Aleo team applies the onchain fix.

Other Aleo routes (`ALEO/aleo`, `ETH/aleo`, `USAD/aleo`, `SOL/aleo`, `WBTC/aleo`) are unaffected and remain whitelisted.

cc @troykessler

## Test plan
- [ ] Confirm `USDC/aleo` and `USDT/aleo` no longer appear in the Nexus token selection UI
- [ ] Re-add once the Aleo team resolves the scaling issue and unpauses the routes