### PR TITLE
fix: use rpc override as primary endpoint

### DIFF
--- a/src/features/chains/metadata.ts
+++ b/src/features/chains/metadata.ts
@@ -10,7 +10,6 @@ import {
   objFilter,
   objMap,
   promiseObjAll,
-  ProtocolType,
   tryParseJsonOrYaml,
 } from '@hyperlane-xyz/utils';
 import { z } from 'zod';
@@ -89,11 +88,9 @@ export async function assembleChainMetadata(
 
     if (!overridesUrl) return metadata;
 
-    // Only EVM supports fallback transport, so we are putting the override at the end
-    const rpcUrls =
-      metadata.protocol === ProtocolType.Ethereum
-        ? [...metadata.rpcUrls, overridesUrl]
-        : [overridesUrl, ...metadata.rpcUrls];
+    // Prefer the override as the primary RPC (e.g. a keyed premium endpoint),
+    // keeping the registry's public URLs as fallback for EVM's fallback transport.
+    const rpcUrls = [overridesUrl, ...metadata.rpcUrls];
 
     return { ...metadata, rpcUrls };
   });

--- a/src/features/chains/metadata.ts
+++ b/src/features/chains/metadata.ts
@@ -6,12 +6,7 @@ import {
   mergeChainMetadataMap,
   RpcUrlSchema,
 } from '@hyperlane-xyz/sdk';
-import {
-  objFilter,
-  objMap,
-  promiseObjAll,
-  tryParseJsonOrYaml,
-} from '@hyperlane-xyz/utils';
+import { objFilter, objMap, promiseObjAll, tryParseJsonOrYaml } from '@hyperlane-xyz/utils';
 import { z } from 'zod';
 
 import { chains as ChainsTS } from '../../consts/chains.ts';


### PR DESCRIPTION
## Summary
- `NEXT_PUBLIC_RPC_OVERRIDES` was appended to the **end** of the EVM `rpcUrls` list. Nexus's viem `fallback()` transport uses `rank=false`, so it always tries `rpcUrls[0]` (the public primary, e.g. `base.drpc.org`) first and only reaches the override after the primary exhausts its retries — meaning a configured keyed/premium endpoint was effectively never used.
- Prepend the override for all protocols so a keyed premium endpoint is the **primary** RPC, with the registry's public URLs kept as fallback (EVM fallback transport).

## Context
Needed so the newly-configured domain-restricted Alchemy key for `base` is actually used as primary on Nexus, resolving the recurring HTTP 429 rate-limit errors NESA hit on the base leg of NES transfers (public `base.drpc.org` was rate-limiting).

## Test plan
- [ ] `pnpm typecheck` (passes locally)
- [ ] `pnpm lint` (clean; pre-existing console warnings only)
- [ ] After deploy: confirm base RPC requests hit the Alchemy endpoint and NESA transfers succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)