### PR TITLE
fix: use rpc override as primary endpoint

### DIFF
--- a/src/features/chains/metadata.ts
+++ b/src/features/chains/metadata.ts
@@ -6,13 +6,7 @@ import {
   mergeChainMetadataMap,
   RpcUrlSchema,
 } from '@hyperlane-xyz/sdk';
-import {
-  objFilter,
-  objMap,
-  promiseObjAll,
-  ProtocolType,
-  tryParseJsonOrYaml,
-} from '@hyperlane-xyz/utils';
+import { objFilter, objMap, promiseObjAll, tryParseJsonOrYaml } from '@hyperlane-xyz/utils';
 import { z } from 'zod';
 
 import { chains as ChainsTS } from '../../consts/chains.ts';
@@ -89,11 +83,9 @@ export async function assembleChainMetadata(
 
     if (!overridesUrl) return metadata;
 
-    // Only EVM supports fallback transport, so we are putting the override at the end
-    const rpcUrls =
-      metadata.protocol === ProtocolType.Ethereum
-        ? [...metadata.rpcUrls, overridesUrl]
-        : [overridesUrl, ...metadata.rpcUrls];
+    // Prefer the override as the primary RPC (e.g. a keyed premium endpoint),
+    // keeping the registry's public URLs as fallback for EVM's fallback transport.
+    const rpcUrls = [overridesUrl, ...metadata.rpcUrls];
 
     return { ...metadata, rpcUrls };
   });


### PR DESCRIPTION
## Summary
Port of #1166 (which was merged to `nexus`, not `main`) — the diff from that branch to `main` is large, so this is a clean re-apply of only the relevant change.

- `NEXT_PUBLIC_RPC_OVERRIDES` was appended to the **end** of the EVM `rpcUrls` list. viem's `fallback()` transport uses `rank=false`, so it always tries `rpcUrls[0]` (the public primary, e.g. `base.drpc.org`) first and only reaches the override after the primary exhausts retries — meaning a configured keyed/premium endpoint was effectively never used.
- Prepend the override for all protocols so a keyed premium endpoint is the **primary** RPC, with the registry's public URLs kept as fallback (EVM fallback transport).

## Context
Fixes the recurring HTTP 429 rate-limit errors NESA hit on the base leg of NES transfers (public `base.drpc.org` was rate-limiting). Already merged to `nexus` as #1166; this brings the same fix to `main`.

## Test plan
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)