### PR TITLE
fix: repoint error boundary support link to Help Center

### DIFF
--- a/src/components/errors/ErrorBoundary.tsx
+++ b/src/components/errors/ErrorBoundary.tsx
@@ -9,9 +9,9 @@ export function ErrorBoundary({ children }: PropsWithChildren<unknown>) {
 
 function SupportLink() {
   return (
-    <a href={links.discord} target="_blank" rel="noopener noreferrer" className="mt-5 text-sm">
-      For support, join the{' '}
-      <span className="underline underline-offset-2">Hyperlane Discord</span>{' '}
+    <a href={links.support} target="_blank" rel="noopener noreferrer" className="mt-5 text-sm">
+      For support, visit the{' '}
+      <span className="underline underline-offset-2">Hyperlane Help Center</span>{' '}
     </a>
   );
 }


### PR DESCRIPTION
## Summary
- The warp UI "Fatal Error Occurred" error page linked to the Hyperlane **Discord**, which no longer exists.
- Repoints the support link to the Hyperlane **Help Center** (`links.support` → https://help.hyperlane.xyz/) and updates the copy to "For support, visit the Hyperlane Help Center".
- After this change `links.discord` is no longer referenced anywhere in `src/` (only its now-dead definition remains in `src/consts/links.ts`).

Reported by a customer who hit the error page (via a separate WalletConnect QR crash, tracked/fixed separately).

## Test plan
- [ ] Trigger the ErrorBoundary and confirm the support link points to https://help.hyperlane.xyz/ and reads "Hyperlane Help Center"