### PR TITLE
feat: add KII/kiichain to Nexus whitelist

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -430,6 +430,9 @@ export const warpRouteWhitelist: Array<string> | null = [
 
   // CROSS routes
   'CROSS/moonpay',
+
+  // KII routes
+  'KII/kiichain',
 ];
 
 /**


### PR DESCRIPTION
Adds `KII/kiichain` to the Nexus UI warp route whitelist.

| Field | Value |
| ----- | ----- |
| **Warp route** | `KII/kiichain` |
| **Type** | EvmHypNative on kiichain; EvmHypSynthetic on bsc, polygon, base, ethereum, mantle |
| **Symbol** | KII |

Requested by @eda — routes were deployed but not yet added to Nexus.