### PR TITLE
feat: update Nexus transfer analytics events

### DIFF
--- a/src/features/analytics/types.ts
+++ b/src/features/analytics/types.ts
@@ -34,8 +34,8 @@ export type EventProperties = {
   };
   [EVENT_NAME.TRANSACTION_SUBMITTED]: {
     chains: string;
-    tokenAddress: string;
-    tokenSymbol: string;
+    originToken: string;
+    destinationToken: string;
     amount: string;
     walletAddress: string;
     transactionHash: string;
@@ -51,8 +51,8 @@ export type EventProperties = {
   };
   [EVENT_NAME.TRANSACTION_SUBMISSION_FAILED]: {
     chains: string;
-    tokenAddress: string;
-    tokenSymbol: string;
+    originToken: string;
+    destinationToken: string;
     amount: string;
     walletAddress: string | null;
     recipient: string;

--- a/src/features/analytics/utils.test.ts
+++ b/src/features/analytics/utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+
+import { getAnalyticsChains, getAnalyticsToken } from './utils';
+
+describe('analytics event helpers', () => {
+  test('packs chains in dbt-compatible order', () => {
+    expect(
+      getAnalyticsChains(
+        { chainName: 'arbitrum', chainId: 42161 },
+        { chainName: 'base', chainId: 8453 },
+      ),
+    ).toBe('arbitrum|42161|base|8453');
+  });
+
+  test('packs one token address and symbol per field', () => {
+    expect(getAnalyticsToken({ address: '0xSource', symbol: 'CHIP' })).toBe('0xSource|CHIP');
+  });
+});

--- a/src/features/analytics/utils.ts
+++ b/src/features/analytics/utils.ts
@@ -19,6 +19,17 @@ export function trackEvent<T extends EVENT_NAME>(eventName: T, properties: Event
   });
 }
 
+export function getAnalyticsChains(
+  srcChain: Pick<UiToken, 'chainName' | 'chainId'>,
+  dstChain: Pick<UiToken, 'chainName' | 'chainId'>,
+) {
+  return `${srcChain.chainName}|${srcChain.chainId}|${dstChain.chainName}|${dstChain.chainId}`;
+}
+
+export function getAnalyticsToken(token: Pick<UiToken, 'address' | 'symbol'>) {
+  return `${token.address}|${token.symbol}`;
+}
+
 export function trackTokenSelectionEvent(
   tokenType: string,
   originToken: UiToken | undefined,
@@ -28,8 +39,8 @@ export function trackTokenSelectionEvent(
 
   trackEvent(EVENT_NAME.TOKEN_SELECTED, {
     tokenType,
-    originToken: originToken.symbol,
-    destinationToken: destinationToken.symbol,
+    originToken: getAnalyticsToken(originToken),
+    destinationToken: getAnalyticsToken(destinationToken),
     origin: originToken.chainName,
     destination: destinationToken.chainName,
     originChainId: originToken.chainId,
@@ -81,10 +92,10 @@ export function trackTransferValidationFailed({
 
   trackEvent(EVENT_NAME.TRANSACTION_SUBMISSION_FAILED, {
     amount: values.amount,
-    chains: `${srcToken.chainName}|${srcToken.chainId}|${dstToken.chainName}|${dstToken.chainId}`,
+    chains: getAnalyticsChains(srcToken, dstToken),
     walletAddress: sender || null,
-    tokenAddress: srcToken.address,
-    tokenSymbol: srcToken.symbol,
+    originToken: getAnalyticsToken(srcToken),
+    destinationToken: getAnalyticsToken(dstToken),
     recipient,
     error: firstError,
   });
@@ -97,8 +108,8 @@ export function trackUnsupportedRouteEvent(
   if (!originToken || !destinationToken) return;
 
   trackEvent(EVENT_NAME.UNSUPPORTED_ROUTE_SELECTED, {
-    originToken: originToken.symbol,
-    destinationToken: destinationToken.symbol,
+    originToken: getAnalyticsToken(originToken),
+    destinationToken: getAnalyticsToken(destinationToken),
     origin: originToken.chainName,
     destination: destinationToken.chainName,
     originChainId: originToken.chainId,

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -20,7 +20,7 @@ import { WARP_QUERY_PARAMS } from '../../../consts/args';
 import { config } from '../../../consts/config';
 import { logger } from '../../../utils/logger';
 import { updateQueryParams } from '../../../utils/queryParams';
-import { trackTransferValidationFailed } from '../../analytics/utils';
+import { trackTransferValidationFailed, trackUnsupportedRouteEvent } from '../../analytics/utils';
 import { useChains } from '../../api/hooks';
 import type { RouteTx } from '../../api/types';
 import { useTokenBalance } from '../../balances/hooks';
@@ -125,6 +125,7 @@ function TransferFormContent() {
   const debouncedAmount = useDebounce(values.amount, 750);
   const {
     quote,
+    data: quoteResponse,
     isLoading: quoteLoading,
     error: quoteError,
     isExpired,
@@ -189,10 +190,38 @@ function TransferFormContent() {
   const hasTokens = !!srcToken && !!dstToken;
 
   const [isValidating, setIsValidating] = useState(false);
+  const trackedUnsupportedRoutesRef = useRef<Set<string>>(new Set());
   const [{ addressConfirmed, showRecipientWarning }, setRecipientInfos] = useState({
     addressConfirmed: true,
     showRecipientWarning: false,
   });
+
+  useEffect(() => {
+    if (
+      !hasAmount ||
+      !srcToken ||
+      !dstToken ||
+      !quoteResponse ||
+      quoteResponse.routes.length > 0 ||
+      !isQuoteSettled ||
+      isRouteDataUnavailable
+    ) {
+      return;
+    }
+    const key = `${srcTokenKey ?? ''}->${dstTokenKey ?? ''}`;
+    if (trackedUnsupportedRoutesRef.current.has(key)) return;
+    trackedUnsupportedRoutesRef.current.add(key);
+    trackUnsupportedRouteEvent(srcToken, dstToken);
+  }, [
+    dstToken,
+    dstTokenKey,
+    hasAmount,
+    isQuoteSettled,
+    isRouteDataUnavailable,
+    quoteResponse,
+    srcToken,
+    srcTokenKey,
+  ]);
 
   // Validate is async; the user can keep editing while it runs. We
   // capture the values reference at request start and bail on resolve
@@ -441,6 +470,9 @@ function TransferFormContent() {
         dstChainId: values.dstChain,
         srcToken: srcToken.address,
         dstToken: dstToken.address,
+        amount: values.amount,
+        srcTokenSymbol: srcToken.symbol,
+        dstTokenSymbol: dstToken.symbol,
         sender,
         recipient: effectiveRecipient,
         approvalToken: approval?.token,

--- a/src/features/transfer/engine/useTransfer.ts
+++ b/src/features/transfer/engine/useTransfer.ts
@@ -22,6 +22,8 @@ import { useCallback, useState } from 'react';
 import type { Address } from 'viem';
 
 import { logger } from '../../../utils/logger';
+import { EVENT_NAME } from '../../analytics/types';
+import { getAnalyticsChains, getAnalyticsToken, trackEvent } from '../../analytics/utils';
 import { getRouteTxs, isChainRouteTx } from '../../api/routeTx';
 import type { RouteTx } from '../../api/types';
 import { useMultiProvider } from '../../chains/hooks';
@@ -39,6 +41,9 @@ interface ExecuteArgs {
   dstChainId: number;
   srcToken: string;
   dstToken: string;
+  amount: string;
+  srcTokenSymbol: string;
+  dstTokenSymbol: string;
   sender: string;
   recipient: string;
   /** Token returned by route.approval. Defaults to srcToken for older quotes. */
@@ -64,9 +69,12 @@ export function useTransfer() {
 
   const execute = useCallback(
     async (args: ExecuteArgs) => {
-      const { transactionId, route, srcChainId } = args;
+      const { transactionId, route, srcChainId, dstChainId } = args;
       setError(null);
       setIsPending(true);
+      let analyticsSrcChainName: string | null | undefined;
+      let analyticsDstChainName: string | null | undefined;
+      let submittedAnalytics = false;
 
       try {
         const routeTxs = getRouteTxs(route.raw);
@@ -75,11 +83,16 @@ export function useTransfer() {
         // Store route for status polling and recovery (non-persisted, session only).
         setTransferRoute(transactionId, route.raw);
 
-        const srcChainName = multiProvider.tryGetChainName(srcChainId);
+        analyticsSrcChainName = multiProvider.tryGetChainName(srcChainId);
+        analyticsDstChainName = multiProvider.tryGetChainName(dstChainId);
         const protocol = multiProvider.tryGetProtocol(srcChainId);
-        if (!srcChainName || !protocol) {
-          throw new Error(`No SDK metadata for chain ${srcChainId} — boot may not have completed.`);
+        if (!analyticsSrcChainName || !analyticsDstChainName || !protocol) {
+          throw new Error(
+            `No SDK metadata for route ${srcChainId}->${dstChainId} — boot may not have completed.`,
+          );
         }
+        const srcChainName = analyticsSrcChainName;
+        const dstChainName = analyticsDstChainName;
 
         const fns = transactionFns[protocol as keyof typeof transactionFns];
         if (!fns) throw new Error(`No transaction handler for protocol ${protocol}`);
@@ -204,6 +217,24 @@ export function useTransfer() {
           setError(err);
           throw err;
         }
+
+        trackEvent(EVENT_NAME.TRANSACTION_SUBMITTED, {
+          amount: args.amount,
+          chains: getAnalyticsChains(
+            { chainName: srcChainName, chainId: srcChainId },
+            { chainName: dstChainName, chainId: dstChainId },
+          ),
+          originToken: getAnalyticsToken({ address: args.srcToken, symbol: args.srcTokenSymbol }),
+          destinationToken: getAnalyticsToken({
+            address: args.dstToken,
+            symbol: args.dstTokenSymbol,
+          }),
+          walletAddress: args.sender,
+          transactionHash: hash,
+          recipient: args.recipient,
+        });
+        submittedAnalytics = true;
+
         // Same-chain transfer: finalize on origin confirm.
         if (!hasCrossChainStep) {
           updateTransferTransactionStatus(transactionId, TransferStatus.ConfirmedDestination, {
@@ -224,6 +255,26 @@ export function useTransfer() {
         return hash;
       } catch (err) {
         logger.error('Transfer broadcast failed', err);
+        if (!submittedAnalytics) {
+          trackEvent(EVENT_NAME.TRANSACTION_SUBMISSION_FAILED, {
+            amount: args.amount,
+            chains: getAnalyticsChains(
+              { chainName: analyticsSrcChainName ?? 'unknown', chainId: srcChainId },
+              { chainName: analyticsDstChainName ?? 'unknown', chainId: dstChainId },
+            ),
+            originToken: getAnalyticsToken({
+              address: args.srcToken,
+              symbol: args.srcTokenSymbol,
+            }),
+            destinationToken: getAnalyticsToken({
+              address: args.dstToken,
+              symbol: args.dstTokenSymbol,
+            }),
+            walletAddress: args.sender,
+            recipient: args.recipient,
+            error: err instanceof Error ? err.message : 'Transfer broadcast failed',
+          });
+        }
         updateTransferTransactionStatus(transactionId, TransferStatus.Failed);
         setError(err as Error);
         throw err;


### PR DESCRIPTION
## Summary

Updates Nexus transfer analytics for the engine-owned transfer flow so swap/bridge routes preserve both selected token identities and all existing CTA/event paths stay wired.

- Emit token fields as `address|symbol` via `originToken` and `destinationToken` instead of the old single source-token shape.
- Keep `Token Selected` wired from token selection using the selected token plus the current opposite-side token; skip until both sides are available so the event stays complete.
- Keep chain selection tracking wired from the unified token/chain modal.
- Keep wallet connection initiated tracking wired from both the protocol modal and connect-aware submit CTA, and wallet connected tracking from the wallet connection observer.
- Restore `Transaction Submitted` from the transfer execution path after the origin route tx confirms.
- Avoid double-emitting submitted + failed analytics if post-submission bookkeeping throws.
- Keep `transactionHash` as the confirmed origin tx hash, which matches the existing dbt join path.
- Keep `recipient` on submitted and failed transaction events.
- Track `Unsupported Route Selected` once per token pair only after the raw quote response returns `routes: []`.
- Track `Transaction Submission Failed` for both form validation failures and transfer execution/broadcast failures.
- Add focused tests for the packed chain/token analytics helpers.

## Validation

- `pnpm format`
- `pnpm vitest src/features/analytics/utils.test.ts src/features/transfer/engine/useTransfer.test.ts --watch false`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`