### PR TITLE
chore: increase root route bundle budget

### DIFF
--- a/scripts/check-bundle-size.mjs
+++ b/scripts/check-bundle-size.mjs
@@ -5,7 +5,7 @@ const STATS_PATH = '.next/diagnostics/route-bundle-stats.json';
 const MIB = 1024 * 1024;
 const mibToBytes = (mib) => Math.round(mib * MIB);
 const ROUTE_BUDGETS = {
-  '/': { raw: mibToBytes(47), gzip: mibToBytes(8.2) },
+  '/': { raw: mibToBytes(50), gzip: mibToBytes(8.2) },
   '/embed': { raw: mibToBytes(49), gzip: mibToBytes(8.6) },
   '/blocked': { raw: mibToBytes(29), gzip: mibToBytes(5.4) },
 };


### PR DESCRIPTION
## Summary

- Increase the root route raw bundle budget from 47 MiB to 50 MiB.
- Keep the 8.2 MiB gzip budget unchanged.

## Context

This accommodates customized deployments such as Nexus while preserving the compressed-size regression guard.
