### PR TITLE
chore: update MAGIC Nexus whitelist entry after ronin removal

### DIFF
--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -253,9 +253,6 @@ export const warpRouteWhitelist: Array<string> | null = [
   // CHILL routes
   'CHILL/solanamainnet-sonicsvm',
 
-  // MAGIC route
-  'MAGIC/arbitrum-abstract-ronin-base',
-
   // bbSOL
   'bbSOL/solanamainnet-soon',
 

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -254,7 +254,7 @@ export const warpRouteWhitelist: Array<string> | null = [
   'CHILL/solanamainnet-sonicsvm',
 
   // MAGIC route
-  'MAGIC/abstract-arbitrum-base',
+  'MAGIC/abstract',
 
   // bbSOL
   'bbSOL/solanamainnet-soon',

--- a/src/consts/warpRouteWhitelist.ts
+++ b/src/consts/warpRouteWhitelist.ts
@@ -253,6 +253,9 @@ export const warpRouteWhitelist: Array<string> | null = [
   // CHILL routes
   'CHILL/solanamainnet-sonicsvm',
 
+  // MAGIC route
+  'MAGIC/abstract-arbitrum-base',
+
   // bbSOL
   'bbSOL/solanamainnet-soon',
 


### PR DESCRIPTION
Updates the MAGIC entry in the Nexus warp route whitelist after the `ronin` leg was removed from the route.

The MAGIC route ID is chain-enumerated, so dropping ronin in the registry renames it. This repoints the whitelist entry to the new ID so the route stays visible on Nexus (now spanning arbitrum, abstract, base — ronin dropped):

`MAGIC/arbitrum-abstract-ronin-base` → `MAGIC/abstract-arbitrum-base`

Depends on the registry rename: hyperlane-xyz/hyperlane-registry#1641 (merge that first so the renamed config is live before this ships).