### PR TITLE
fix: preserve disabled chain gate

### DIFF
--- a/src/features/chains/hooks.test.ts
+++ b/src/features/chains/hooks.test.ts
@@ -1,0 +1,54 @@
+import { ChainDisabledReason, ChainStatus } from '@hyperlane-xyz/sdk';
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { ChainDiscovery } from '../api/types';
+import { toTransferChainInfo } from './hooks';
+
+vi.mock('../../consts/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../consts/config')>();
+  return {
+    ...actual,
+    config: { ...actual.config, shouldDisableChains: true },
+  };
+});
+
+describe('toTransferChainInfo', () => {
+  test('preserves disabled-chain metadata for engine-returned chains', () => {
+    const chainInfo = toTransferChainInfo(engineChain(), {
+      tryGetChainMetadata: (chainName: string) =>
+        chainName === 'botanix'
+          ? {
+              name: chainName,
+              displayName: 'Botanix',
+              protocol: ProtocolType.Ethereum,
+              availability: {
+                status: ChainStatus.Disabled,
+                reasons: [ChainDisabledReason.Unavailable],
+              },
+            }
+          : undefined,
+    } as never);
+
+    expect(chainInfo).toMatchObject({
+      name: 'botanix',
+      displayName: 'Botanix',
+      disabled: true,
+    });
+  });
+});
+
+function engineChain(): ChainDiscovery {
+  return {
+    id: 3637,
+    name: 'Botanix',
+    chainName: 'botanix',
+    protocol: ProtocolType.Ethereum,
+    nativeCurrency: { name: 'Bitcoin', symbol: 'BTC', decimals: 18 },
+    universalRouter: '0x0000000000000000000000000000000000000001',
+    dex: null,
+    canSwap: false,
+    canExecute: true,
+    supportsNative: true,
+  };
+}

--- a/src/features/chains/hooks.ts
+++ b/src/features/chains/hooks.ts
@@ -1,12 +1,11 @@
-import { ChainName, ChainStatus } from '@hyperlane-xyz/sdk';
+import { ChainName, type MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { useMemo } from 'react';
 
-import { config } from '../../consts/config';
 import { useChains } from '../api/hooks';
 import type { ChainDiscovery } from '../api/types';
 import { useStore } from '../store';
-import { getChainDisplayName } from './utils';
+import { getChainDisplayName, isChainDisabled } from './utils';
 
 export function useMultiProvider() {
   return useStore((s) => s.multiProvider);
@@ -56,7 +55,7 @@ export function useChainInfos(): ChainInfo[] {
       chainId: chain.chainId,
       protocol: chain.protocol,
       isTestnet: !!chain.isTestnet,
-      disabled: config.shouldDisableChains && chain.availability?.status === ChainStatus.Disabled,
+      disabled: isChainDisabled(chain),
     }));
     return chainInfos;
   }, [chainMetadata]);
@@ -80,19 +79,26 @@ export function useTransferChainInfos(): ChainInfo[] {
   return useMemo(() => {
     const chains: ChainInfo[] = [];
     for (const c of (data?.chains ?? []) as ChainDiscovery[]) {
-      const meta = mp.tryGetChainMetadata(c.chainName);
-      chains.push({
-        name: c.chainName,
-        displayName: c.displayName || meta?.displayName || c.chainName,
-        chainId: c.id,
-        protocol: (meta?.protocol ?? mapProtocol(c.protocol)) as ProtocolType,
-        isTestnet: !!meta?.isTestnet,
-        disabled: false,
-        canSwap: c.canSwap,
-      });
+      chains.push(toTransferChainInfo(c, mp));
     }
     return chains;
   }, [data, mp]);
+}
+
+export function toTransferChainInfo(
+  chain: ChainDiscovery,
+  multiProvider: Pick<MultiProtocolProvider, 'tryGetChainMetadata'>,
+): ChainInfo {
+  const meta = multiProvider.tryGetChainMetadata(chain.chainName);
+  return {
+    name: chain.chainName,
+    displayName: chain.displayName || meta?.displayName || chain.chainName,
+    chainId: chain.id,
+    protocol: (meta?.protocol ?? mapProtocol(chain.protocol)) as ProtocolType,
+    isTestnet: !!meta?.isTestnet,
+    disabled: isChainDisabled(meta ?? null),
+    canSwap: chain.canSwap,
+  };
 }
 
 function mapProtocol(p: string): ProtocolType {

--- a/src/features/transfer/engine/useFormInitialValues.test.ts
+++ b/src/features/transfer/engine/useFormInitialValues.test.ts
@@ -1,0 +1,75 @@
+import { ChainDisabledReason, ChainStatus } from '@hyperlane-xyz/sdk';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { UiToken } from '../../tokens/types';
+import { getInitialValuesFromTokens } from './useFormInitialValues';
+
+vi.mock('../../../consts/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../consts/config')>();
+  return {
+    ...actual,
+    config: { ...actual.config, shouldDisableChains: true },
+  };
+});
+
+describe('getInitialValuesFromTokens', () => {
+  test('does not hydrate disabled-chain origin and destination tokens', () => {
+    const values = getInitialValuesFromTokens(
+      [
+        token({ chainName: 'botanix', chainId: 3637, address: BOTANIX_TOKEN }),
+        token({ chainName: 'artela', chainId: 11820, address: ARTELA_TOKEN }),
+      ],
+      {
+        originId: `botanix-${BOTANIX_TOKEN}`,
+        destinationId: `artela-${ARTELA_TOKEN}`,
+      },
+      multiProvider(['botanix', 'artela']),
+    );
+
+    expect(values).toMatchObject({
+      srcChain: null,
+      srcToken: '',
+      dstChain: null,
+      dstToken: '',
+    });
+  });
+});
+
+const BOTANIX_TOKEN = '0x0000000000000000000000000000000000000001';
+const ARTELA_TOKEN = '0x0000000000000000000000000000000000000002';
+
+function token(overrides: Partial<UiToken>): UiToken {
+  return {
+    chainId: 1,
+    address: '0x0000000000000000000000000000000000000000',
+    symbol: 'TEST',
+    decimals: 18,
+    isNative: false,
+    isBridgeToken: true,
+    isPoolToken: false,
+    canBridge: true,
+    canSwap: false,
+    bridgeSymbols: ['TEST'],
+    warpRouteIds: ['TEST/route'],
+    chainName: 'ethereum',
+    name: 'Test',
+    addressOrDenom: '0x0000000000000000000000000000000000000000',
+    ...overrides,
+  };
+}
+
+function multiProvider(disabledChains: string[]) {
+  const disabledChainSet = new Set(disabledChains);
+  return {
+    tryGetChainMetadata: (chainName: string) => {
+      if (!disabledChainSet.has(chainName)) return { name: chainName };
+      return {
+        name: chainName,
+        availability: {
+          status: ChainStatus.Disabled,
+          reasons: [ChainDisabledReason.Unavailable],
+        },
+      };
+    },
+  } as never;
+}

--- a/src/features/transfer/engine/useFormInitialValues.ts
+++ b/src/features/transfer/engine/useFormInitialValues.ts
@@ -1,9 +1,13 @@
+import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { useMemo } from 'react';
 
 import { WARP_QUERY_PARAMS } from '../../../consts/args';
 import { config } from '../../../consts/config';
 import { getQueryParams } from '../../../utils/queryParams';
+import { useMultiProvider } from '../../chains/hooks';
+import { isChainDisabled } from '../../chains/utils';
 import { useTokens } from '../../tokens/hooks';
+import type { UiToken } from '../../tokens/types';
 import type { TransferFormValues } from './types';
 
 const EMPTY_VALUES: TransferFormValues = {
@@ -24,32 +28,44 @@ const EMPTY_VALUES: TransferFormValues = {
 // Falls back to `config.defaultTransferOriginToken` /
 // `defaultTransferDestinationToken` when the URL has no override.
 export function useFormInitialValues(): TransferFormValues {
+  const multiProvider = useMultiProvider();
+  const initialIds = useMemo(() => readInitialIds(), []);
   const ids = useMemo(() => {
     const out: string[] = [];
-    const { originId, destinationId } = readInitialIds();
+    const { originId, destinationId } = initialIds;
     if (originId) out.push(originId);
     if (destinationId) out.push(destinationId);
     return out;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-time read; URL changes after mount intentionally ignored
-  }, []);
+  }, [initialIds]);
 
   const { data: tokens } = useTokens(ids.length ? { ids } : {});
 
   return useMemo(() => {
-    if (!ids.length || !tokens.length) return EMPTY_VALUES;
+    return getInitialValuesFromTokens(tokens, initialIds, multiProvider);
+  }, [tokens, initialIds, multiProvider]);
+}
 
-    const { originId, destinationId } = readInitialIds();
-    const origin = originId ? tokens.find((t) => matchesId(t, originId)) : undefined;
-    const destination = destinationId ? tokens.find((t) => matchesId(t, destinationId)) : undefined;
+export function getInitialValuesFromTokens(
+  tokens: UiToken[],
+  initialIds: { originId: string | undefined; destinationId: string | undefined },
+  multiProvider: Pick<MultiProtocolProvider, 'tryGetChainMetadata'>,
+): TransferFormValues {
+  if (!initialIds.originId && !initialIds.destinationId) return EMPTY_VALUES;
+  if (!tokens.length) return EMPTY_VALUES;
 
-    return {
-      ...EMPTY_VALUES,
-      srcChain: origin?.chainId ?? null,
-      srcToken: origin?.address ?? '',
-      dstChain: destination?.chainId ?? null,
-      dstToken: destination?.address ?? '',
-    };
-  }, [tokens, ids]);
+  const { originId, destinationId } = initialIds;
+  const origin = originId ? tokens.find((t) => matchesId(t, originId)) : undefined;
+  const destination = destinationId ? tokens.find((t) => matchesId(t, destinationId)) : undefined;
+  const enabledOrigin = isTokenChainEnabled(origin, multiProvider);
+  const enabledDestination = isTokenChainEnabled(destination, multiProvider);
+
+  return {
+    ...EMPTY_VALUES,
+    srcChain: enabledOrigin?.chainId ?? null,
+    srcToken: enabledOrigin?.address ?? '',
+    dstChain: enabledDestination?.chainId ?? null,
+    dstToken: enabledDestination?.address ?? '',
+  };
 }
 
 function readInitialIds(): { originId: string | undefined; destinationId: string | undefined } {
@@ -88,6 +104,15 @@ function matchesId(t: { chainName: string; address: string }, id: string): boole
   if (!id.startsWith(prefix)) return false;
   const address = id.slice(prefix.length);
   return normalizeTokenAddress(t.address) === normalizeTokenAddress(address);
+}
+
+function isTokenChainEnabled<T extends { chainName: string }>(
+  token: T | undefined,
+  multiProvider: Pick<MultiProtocolProvider, 'tryGetChainMetadata'>,
+): T | undefined {
+  if (!token) return undefined;
+  const metadata = multiProvider.tryGetChainMetadata(token.chainName);
+  return isChainDisabled(metadata ?? null) ? undefined : token;
 }
 
 function normalizeTokenAddress(address: string): string {

--- a/src/features/transfer/engine/validate.test.ts
+++ b/src/features/transfer/engine/validate.test.ts
@@ -1,10 +1,11 @@
+import { ChainDisabledReason, ChainStatus } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ChainDiscovery, RouteResponse } from '../../api/types';
 import type { UiToken } from '../../tokens/types';
 import type { AugmentedRoute } from './types';
-import { validateBalances, validateQuote } from './validate';
+import { validateBalances, validateChains, validateQuote } from './validate';
 
 const { readBalanceMock, estimateNativeGasCostMock } = vi.hoisted(() => ({
   readBalanceMock: vi.fn(),
@@ -15,6 +16,14 @@ vi.mock('../../balances/read', () => ({
   readBalance: readBalanceMock,
   estimateNativeGasCost: estimateNativeGasCostMock,
 }));
+
+vi.mock('../../../consts/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../consts/config')>();
+  return {
+    ...actual,
+    config: { ...actual.config, shouldDisableChains: true },
+  };
+});
 
 const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
 const BONK_ADDRESS = '0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
@@ -187,9 +196,58 @@ describe('validateQuote', () => {
   });
 });
 
-function multiProvider(protocol = ProtocolType.Starknet) {
+describe('validateChains', () => {
+  test('rejects disabled origin chains returned by the engine', () => {
+    expect(
+      validateChains(
+        {
+          srcChain: 3637,
+          dstChain: 1,
+          srcToken: NATIVE_ADDRESS,
+          dstToken: NATIVE_ADDRESS,
+          amount: '1',
+          recipient: '',
+          slippageBps: 100,
+        },
+        [botanixChain(), evmChain()],
+        multiProvider(ProtocolType.Ethereum, ['botanix']),
+      ),
+    ).toEqual({ ok: false, error: { srcChain: 'Origin chain unavailable' } });
+  });
+
+  test('rejects disabled destination chains returned by the engine', () => {
+    expect(
+      validateChains(
+        {
+          srcChain: 1,
+          dstChain: 3637,
+          srcToken: NATIVE_ADDRESS,
+          dstToken: NATIVE_ADDRESS,
+          amount: '1',
+          recipient: '',
+          slippageBps: 100,
+        },
+        [evmChain(), botanixChain()],
+        multiProvider(ProtocolType.Ethereum, ['botanix']),
+      ),
+    ).toEqual({ ok: false, error: { dstChain: 'Destination chain unavailable' } });
+  });
+});
+
+function multiProvider(protocol = ProtocolType.Starknet, disabledChains: string[] = []) {
+  const disabledChainSet = new Set(disabledChains);
   return {
     tryGetProtocol: () => protocol,
+    tryGetChainMetadata: (chainName: string) =>
+      disabledChainSet.has(chainName)
+        ? {
+            name: chainName,
+            availability: {
+              status: ChainStatus.Disabled,
+              reasons: [ChainDisabledReason.Unavailable],
+            },
+          }
+        : { name: chainName },
   } as never;
 }
 
@@ -230,6 +288,21 @@ function evmChain(): ChainDiscovery {
     chainName: 'ethereum',
     protocol: ProtocolType.Ethereum,
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    universalRouter: '0x0000000000000000000000000000000000000001',
+    dex: null,
+    canSwap: false,
+    canExecute: true,
+    supportsNative: true,
+  };
+}
+
+function botanixChain(): ChainDiscovery {
+  return {
+    id: 3637,
+    name: 'Botanix',
+    chainName: 'botanix',
+    protocol: ProtocolType.Ethereum,
+    nativeCurrency: { name: 'Bitcoin', symbol: 'BTC', decimals: 18 },
     universalRouter: '0x0000000000000000000000000000000000000001',
     dex: null,
     canSwap: false,

--- a/src/features/transfer/engine/validate.ts
+++ b/src/features/transfer/engine/validate.ts
@@ -14,6 +14,7 @@ import { getRouteTxs, isChainRouteTx } from '../../api/routeTx';
 import type { ChainDiscovery } from '../../api/types';
 import { estimateNativeGasCost, readBalance } from '../../balances/read';
 import { formatDisplayAmount } from '../../balances/utils';
+import { isChainDisabled } from '../../chains/utils';
 import type { UiToken } from '../../tokens/types';
 import { tokenKey } from '../../tokens/utils';
 import type { AugmentedRoute, FeeComponent, TransferFormValues } from './types';
@@ -55,7 +56,7 @@ export async function validateTransferForm(args: {
     nativeExecutionFee,
   } = args;
 
-  const chainsResult = validateChains(values, chains);
+  const chainsResult = validateChains(values, chains, multiProvider);
   if (!chainsResult.ok) return chainsResult.error;
   const { srcChainInfo, dstChainInfo } = chainsResult;
 
@@ -101,6 +102,7 @@ export type ValidateChainsResult =
 export function validateChains(
   values: TransferFormValues,
   chains: ChainDiscovery[] | undefined,
+  multiProvider?: MultiProtocolProvider,
 ): ValidateChainsResult {
   if (values.srcChain == null) return { ok: false, error: { srcChain: 'Origin chain required' } };
   if (values.dstChain == null)
@@ -109,7 +111,22 @@ export function validateChains(
   const dstChainInfo = chains?.find((c) => c.id === values.dstChain);
   if (!srcChainInfo) return { ok: false, error: { srcChain: 'Origin chain not supported' } };
   if (!dstChainInfo) return { ok: false, error: { dstChain: 'Destination chain not supported' } };
+  if (multiProvider) {
+    if (isEngineChainDisabled(srcChainInfo, multiProvider)) {
+      return { ok: false, error: { srcChain: 'Origin chain unavailable' } };
+    }
+    if (isEngineChainDisabled(dstChainInfo, multiProvider)) {
+      return { ok: false, error: { dstChain: 'Destination chain unavailable' } };
+    }
+  }
   return { ok: true, srcChainInfo, dstChainInfo };
+}
+
+function isEngineChainDisabled(
+  chainInfo: ChainDiscovery,
+  multiProvider: MultiProtocolProvider,
+): boolean {
+  return isChainDisabled(multiProvider.tryGetChainMetadata(chainInfo.chainName) ?? null);
 }
 
 export function validateRecipient(


### PR DESCRIPTION
Fixes the engine-backed transfer flow so local disabled-chain metadata is still honored when `config.shouldDisableChains` is enabled.

Changes:
- Derive disabled state for `/v1/chains` entries from registry chain metadata instead of hardcoding `disabled: false`.
- Ignore disabled-chain tokens during transfer initial-value hydration so deep links/defaults do not prefill unavailable chains.
- Enforce the same disabled-chain check in form validation before quote/send.
- Add focused tests for engine-returned disabled chains in picker mapping, hydration, and validation.

Validation:
- `pnpm vitest --run src/features/transfer/engine/useFormInitialValues.test.ts src/features/chains/hooks.test.ts src/features/transfer/engine/validate.test.ts`
- `pnpm test`
- `pnpm typecheck`
- `pnpm lint` (passes with existing mock-wallet console warnings)
- `pnpm build`
