### PR TITLE
feat: classify submitted Nexus transactions as bridge or swap

### DIFF
--- a/src/features/analytics/utils.test.ts
+++ b/src/features/analytics/utils.test.ts
@@ -12,6 +12,16 @@ describe('analytics event helpers', () => {
     ).toBe('arbitrum|42161|base|8453');
   });
 
+  test('packs transaction type after the existing chain fields', () => {
+    expect(
+      getAnalyticsChains(
+        { chainName: 'arbitrum', chainId: 42161 },
+        { chainName: 'base', chainId: 8453 },
+        'swap',
+      ),
+    ).toBe('arbitrum|42161|base|8453|swap');
+  });
+
   test('packs one token address and symbol per field', () => {
     expect(getAnalyticsToken({ address: '0xSource', symbol: 'CHIP' })).toBe('0xSource|CHIP');
   });

--- a/src/features/analytics/utils.ts
+++ b/src/features/analytics/utils.ts
@@ -22,9 +22,13 @@ export function trackEvent<T extends EVENT_NAME>(eventName: T, properties: Event
 export function getAnalyticsChains(
   srcChain: Pick<UiToken, 'chainName' | 'chainId'>,
   dstChain: Pick<UiToken, 'chainName' | 'chainId'>,
+  transactionType?: AnalyticsTransactionType,
 ) {
-  return `${srcChain.chainName}|${srcChain.chainId}|${dstChain.chainName}|${dstChain.chainId}`;
+  const chains = `${srcChain.chainName}|${srcChain.chainId}|${dstChain.chainName}|${dstChain.chainId}`;
+  return transactionType ? `${chains}|${transactionType}` : chains;
 }
+
+export type AnalyticsTransactionType = 'bridge' | 'swap';
 
 export function getAnalyticsToken(token: Pick<UiToken, 'address' | 'symbol'>) {
   return `${token.address}|${token.symbol}`;

--- a/src/features/transfer/engine/useTransfer.ts
+++ b/src/features/transfer/engine/useTransfer.ts
@@ -28,6 +28,7 @@ import { getAnalyticsChains, getAnalyticsToken, trackEvent } from '../../analyti
 import { getRouteTxs, isChainRouteTx } from '../../api/routeTx';
 import type { RouteTx } from '../../api/types';
 import { useMultiProvider } from '../../chains/hooks';
+import { isBridgeOnlyRoute } from '../../routeSecurity/validateWarpRoute';
 import { useStore } from '../../store';
 import { submitToRelayApi } from '../relayApi';
 import { postCommitment } from './ccs';
@@ -76,6 +77,7 @@ export function useTransfer() {
       let analyticsSrcChainName: string | null | undefined;
       let analyticsDstChainName: string | null | undefined;
       let submittedAnalytics = false;
+      const analyticsTransactionType = isBridgeOnlyRoute(route.raw) ? 'bridge' : 'swap';
 
       try {
         const routeTxs = getRouteTxs(route.raw);
@@ -224,6 +226,7 @@ export function useTransfer() {
           chains: getAnalyticsChains(
             { chainName: srcChainName, chainId: srcChainId },
             { chainName: dstChainName, chainId: dstChainId },
+            analyticsTransactionType,
           ),
           originToken: getAnalyticsToken({ address: args.srcToken, symbol: args.srcTokenSymbol }),
           destinationToken: getAnalyticsToken({


### PR DESCRIPTION
## Summary

- classify submitted Nexus transactions using `isBridgeOnlyRoute`
- record bridge or swap in the existing packed `chains` analytics field to stay within the Vercel property limit
- classify swap-only and swap-plus-bridge routes as `swap`