### PR TITLE
fix: stop destination prefill after user interaction

### DIFF
--- a/src/features/tokens/TokenSelectField.tsx
+++ b/src/features/tokens/TokenSelectField.tsx
@@ -30,13 +30,18 @@ import { getRoutePrefillToken, tokenKey } from './utils';
 
 type Props = {
   selectionMode: TokenSelectionMode;
+  hasInteractedWithDestinationTokenRef: MutableRefObject<boolean>;
   disabled?: boolean;
 };
 
 // Reads source/destination token from form state via two paired fields
 // (chainId + tokenAddress) and writes both atomically when the user
 // picks one in the modal.
-export function TokenSelectField({ selectionMode, disabled }: Props) {
+export function TokenSelectField({
+  selectionMode,
+  hasInteractedWithDestinationTokenRef,
+  disabled,
+}: Props) {
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingChain, setEditingChain] = useState<string | null>(null);
@@ -86,23 +91,26 @@ export function TokenSelectField({ selectionMode, disabled }: Props) {
       isOrigin ? token : counterpartToken,
       isOrigin ? counterpartToken : token,
     );
+    if (!isOrigin) hasInteractedWithDestinationTokenRef.current = true;
     if (isOrigin) {
       // Reset amount when origin changes (warp UI does the same).
       setFieldValue('amount', '');
       latestOriginSelectionRef.current = tokenKey(token.chainId, token.address);
-      void prefillBestDestinationToken({
-        originToken: token,
-        currentDestinationToken: counterpartToken,
-        latestRecipientRef,
-        chainIdToName,
-        multiProvider,
-        queryClient,
-        syncTokens,
-        latestOriginSelectionRef,
-        latestCounterpartKeyRef,
-        counterpartKeyAtRequestStart: counterpartKey,
-        setFieldValue,
-      });
+      if (!hasInteractedWithDestinationTokenRef.current) {
+        void prefillBestDestinationToken({
+          originToken: token,
+          currentDestinationToken: counterpartToken,
+          latestRecipientRef,
+          chainIdToName,
+          multiProvider,
+          queryClient,
+          syncTokens,
+          latestOriginSelectionRef,
+          latestCounterpartKeyRef,
+          counterpartKeyAtRequestStart: counterpartKey,
+          setFieldValue,
+        });
+      }
     } else if (shouldClearAddress(multiProvider, values.recipient, token.chainName)) {
       setFieldValue('recipient', '');
     }

--- a/src/features/tokens/TokenSelectField.tsx
+++ b/src/features/tokens/TokenSelectField.tsx
@@ -30,7 +30,7 @@ import { getRoutePrefillToken, tokenKey } from './utils';
 
 type Props = {
   selectionMode: TokenSelectionMode;
-  hasInteractedWithDestinationTokenRef: MutableRefObject<boolean>;
+  hasSelectedDestinationTokenRef: MutableRefObject<boolean>;
   disabled?: boolean;
 };
 
@@ -39,7 +39,7 @@ type Props = {
 // picks one in the modal.
 export function TokenSelectField({
   selectionMode,
-  hasInteractedWithDestinationTokenRef,
+  hasSelectedDestinationTokenRef,
   disabled,
 }: Props) {
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
@@ -91,15 +91,16 @@ export function TokenSelectField({
       isOrigin ? token : counterpartToken,
       isOrigin ? counterpartToken : token,
     );
-    if (!isOrigin) hasInteractedWithDestinationTokenRef.current = true;
+    if (!isOrigin) hasSelectedDestinationTokenRef.current = true;
     if (isOrigin) {
       // Reset amount when origin changes (warp UI does the same).
       setFieldValue('amount', '');
       latestOriginSelectionRef.current = tokenKey(token.chainId, token.address);
-      if (!hasInteractedWithDestinationTokenRef.current) {
+      if (!hasSelectedDestinationTokenRef.current) {
         void prefillBestDestinationToken({
           originToken: token,
           currentDestinationToken: counterpartToken,
+          hasSelectedDestinationTokenRef,
           latestRecipientRef,
           chainIdToName,
           multiProvider,
@@ -166,6 +167,7 @@ export function TokenSelectField({
 async function prefillBestDestinationToken({
   originToken,
   currentDestinationToken,
+  hasSelectedDestinationTokenRef,
   latestRecipientRef,
   chainIdToName,
   multiProvider,
@@ -178,6 +180,7 @@ async function prefillBestDestinationToken({
 }: {
   originToken: UiToken;
   currentDestinationToken?: UiToken;
+  hasSelectedDestinationTokenRef: MutableRefObject<boolean>;
   latestRecipientRef: MutableRefObject<string>;
   chainIdToName: Map<number, string>;
   multiProvider: ReturnType<typeof useMultiProvider>;
@@ -201,6 +204,7 @@ async function prefillBestDestinationToken({
       return;
     }
     if (latestCounterpartKeyRef.current !== counterpartKeyAtRequestStart) return;
+    if (hasSelectedDestinationTokenRef.current) return;
 
     const routeTokens = result.tokens.flatMap((token) => {
       if (token.decimals == null) return [];

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -79,7 +79,7 @@ export function TransferForm() {
 function TransferFormContent() {
   const { values, errors, setErrors, setFieldValue, setValues } =
     useFormikContext<TransferFormValues>();
-  const hasInteractedWithDestinationTokenRef = useRef(false);
+  const hasSelectedDestinationTokenRef = useRef(false);
   const multiProvider = useMultiProvider();
   const tokenMap = useTokenByKeyMap();
   const { data: chainsResp } = useChains();
@@ -581,7 +581,7 @@ function TransferFormContent() {
           srcChainName={srcChainName}
           srcToken={srcToken}
           sender={sender}
-          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
+          hasSelectedDestinationTokenRef={hasSelectedDestinationTokenRef}
         />
       </TransferSection>
 
@@ -596,7 +596,7 @@ function TransferFormContent() {
           bestRoute={bestRoute}
           quoteLoading={quoteLoading}
           inputUsd={amountUsd}
-          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
+          hasSelectedDestinationTokenRef={hasSelectedDestinationTokenRef}
         />
       </TransferSection>
 
@@ -818,13 +818,13 @@ function OriginTokenCard({
   srcChainName,
   srcToken,
   sender,
-  hasInteractedWithDestinationTokenRef,
+  hasSelectedDestinationTokenRef,
 }: {
   isReview: boolean;
   srcChainName: string | undefined;
   srcToken: UiToken | undefined;
   sender: string | undefined;
-  hasInteractedWithDestinationTokenRef: React.MutableRefObject<boolean>;
+  hasSelectedDestinationTokenRef: React.MutableRefObject<boolean>;
 }) {
   const { values } = useFormikContext<TransferFormValues>();
   const { data: balance, isLoading: isBalanceLoading } = useTokenBalance(srcToken, sender);
@@ -839,7 +839,7 @@ function OriginTokenCard({
       <div className="transfer-chain-field rounded-[7px] border border-gray-400/25 bg-white p-3 shadow-input dark:border-primary-300/[0.18] dark:bg-transparent dark:shadow-none">
         <TokenSelectField
           selectionMode="origin"
-          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
+          hasSelectedDestinationTokenRef={hasSelectedDestinationTokenRef}
           disabled={isReview}
         />
 
@@ -883,7 +883,7 @@ function DestinationTokenCard({
   bestRoute,
   quoteLoading,
   inputUsd,
-  hasInteractedWithDestinationTokenRef,
+  hasSelectedDestinationTokenRef,
 }: {
   isReview: boolean;
   dstChainName: string | undefined;
@@ -892,7 +892,7 @@ function DestinationTokenCard({
   bestRoute: AugmentedRoute | undefined;
   quoteLoading: boolean;
   inputUsd: number | null;
-  hasInteractedWithDestinationTokenRef: React.MutableRefObject<boolean>;
+  hasSelectedDestinationTokenRef: React.MutableRefObject<boolean>;
 }) {
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
   const { data: balance } = useTokenBalance(dstToken, recipient);
@@ -936,7 +936,7 @@ function DestinationTokenCard({
       <div className="transfer-chain-field rounded-[7px] border border-gray-400/25 bg-white p-3 shadow-input dark:border-primary-300/[0.18] dark:bg-transparent dark:shadow-none">
         <TokenSelectField
           selectionMode="destination"
-          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
+          hasSelectedDestinationTokenRef={hasSelectedDestinationTokenRef}
           disabled={isReview}
         />
 

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -79,6 +79,7 @@ export function TransferForm() {
 function TransferFormContent() {
   const { values, errors, setErrors, setFieldValue, setValues } =
     useFormikContext<TransferFormValues>();
+  const hasInteractedWithDestinationTokenRef = useRef(false);
   const multiProvider = useMultiProvider();
   const tokenMap = useTokenByKeyMap();
   const { data: chainsResp } = useChains();
@@ -580,6 +581,7 @@ function TransferFormContent() {
           srcChainName={srcChainName}
           srcToken={srcToken}
           sender={sender}
+          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
         />
       </TransferSection>
 
@@ -594,6 +596,7 @@ function TransferFormContent() {
           bestRoute={bestRoute}
           quoteLoading={quoteLoading}
           inputUsd={amountUsd}
+          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
         />
       </TransferSection>
 
@@ -815,11 +818,13 @@ function OriginTokenCard({
   srcChainName,
   srcToken,
   sender,
+  hasInteractedWithDestinationTokenRef,
 }: {
   isReview: boolean;
   srcChainName: string | undefined;
   srcToken: UiToken | undefined;
   sender: string | undefined;
+  hasInteractedWithDestinationTokenRef: React.MutableRefObject<boolean>;
 }) {
   const { values } = useFormikContext<TransferFormValues>();
   const { data: balance, isLoading: isBalanceLoading } = useTokenBalance(srcToken, sender);
@@ -832,7 +837,11 @@ function OriginTokenCard({
       </div>
 
       <div className="transfer-chain-field rounded-[7px] border border-gray-400/25 bg-white p-3 shadow-input dark:border-primary-300/[0.18] dark:bg-transparent dark:shadow-none">
-        <TokenSelectField selectionMode="origin" disabled={isReview} />
+        <TokenSelectField
+          selectionMode="origin"
+          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
+          disabled={isReview}
+        />
 
         <div className="transfer-divider my-2.5 h-px bg-primary-50 dark:bg-primary-300/[0.22]" />
 
@@ -874,6 +883,7 @@ function DestinationTokenCard({
   bestRoute,
   quoteLoading,
   inputUsd,
+  hasInteractedWithDestinationTokenRef,
 }: {
   isReview: boolean;
   dstChainName: string | undefined;
@@ -882,6 +892,7 @@ function DestinationTokenCard({
   bestRoute: AugmentedRoute | undefined;
   quoteLoading: boolean;
   inputUsd: number | null;
+  hasInteractedWithDestinationTokenRef: React.MutableRefObject<boolean>;
 }) {
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
   const { data: balance } = useTokenBalance(dstToken, recipient);
@@ -923,7 +934,11 @@ function DestinationTokenCard({
       </div>
 
       <div className="transfer-chain-field rounded-[7px] border border-gray-400/25 bg-white p-3 shadow-input dark:border-primary-300/[0.18] dark:bg-transparent dark:shadow-none">
-        <TokenSelectField selectionMode="destination" disabled={isReview} />
+        <TokenSelectField
+          selectionMode="destination"
+          hasInteractedWithDestinationTokenRef={hasInteractedWithDestinationTokenRef}
+          disabled={isReview}
+        />
 
         <div className="transfer-divider my-2.5 h-px bg-primary-50 dark:bg-primary-300/[0.22]" />
 

--- a/tests/helpers/routerApi.ts
+++ b/tests/helpers/routerApi.ts
@@ -35,7 +35,7 @@ const chains = [
   },
 ];
 
-const tokens = [
+export const routerApiTokens = [
   {
     chainId: 56,
     address: ZERO,
@@ -95,7 +95,7 @@ export async function installRouterApiMock(page: Page): Promise<void> {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ tokens }),
+      body: JSON.stringify({ tokens: routerApiTokens }),
     }),
   );
 
@@ -103,7 +103,7 @@ export async function installRouterApiMock(page: Page): Promise<void> {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ direction: 'fromSource', tokens }),
+      body: JSON.stringify({ direction: 'fromSource', tokens: routerApiTokens }),
     }),
   );
 }

--- a/tests/token-selection/destination-prefill.spec.ts
+++ b/tests/token-selection/destination-prefill.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 import { getDestinationTokenButton, getOriginTokenButton } from '../helpers/locators';
-import { installRouterApiMock } from '../helpers/routerApi';
+import { installRouterApiMock, routerApiTokens } from '../helpers/routerApi';
 
 test.describe('Token Selection - Destination Prefill', () => {
   test.beforeEach(async ({ page }) => {
@@ -22,22 +22,54 @@ test.describe('Token Selection - Destination Prefill', () => {
     await selectToken(page, 'destination', 'Base');
     await expect(destinationButton).toHaveAttribute('data-chain', 'base');
 
-    let requestedPrefill = false;
-    page.on('request', (request) => {
-      if (isBaseOriginPrefillRequest(request)) requestedPrefill = true;
+    await getOriginTokenButton(page).click();
+    const requestedPrefill = page.waitForRequest(isBaseOriginPrefillRequest, { timeout: 500 }).then(
+      () => true,
+      () => false,
+    );
+    await selectTokenRow(page, 'Base');
+
+    await expect(getOriginTokenButton(page)).toHaveAttribute('data-chain', 'base');
+    expect(await requestedPrefill).toBe(false);
+    await expect(destinationButton).toHaveAttribute('data-chain', 'base');
+  });
+
+  test('does not apply an in-flight prefill after destination selection', async ({ page }) => {
+    let releasePrefill = () => undefined;
+    const prefillGate = new Promise<void>((resolve) => {
+      releasePrefill = resolve;
+    });
+    await page.route('**/v1/available-routes**', async (route) => {
+      if (!isBaseOriginPrefillRequest(route.request())) return route.fallback();
+      await prefillGate;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ direction: 'fromSource', tokens: [routerApiTokens[0]] }),
+      });
     });
 
+    const prefillRequest = page.waitForRequest(isBaseOriginPrefillRequest);
     await selectToken(page, 'origin', 'Base');
-    await expect(getOriginTokenButton(page)).toHaveAttribute('data-chain', 'base');
+    await prefillRequest;
+    await selectToken(page, 'destination', 'Base');
 
-    expect(requestedPrefill).toBe(false);
-    await expect(destinationButton).toHaveAttribute('data-chain', 'base');
+    const prefillResponse = page.waitForResponse(isBaseOriginPrefillRequest);
+    releasePrefill();
+    await prefillResponse;
+    await page.waitForTimeout(100);
+
+    await expect(getDestinationTokenButton(page)).toHaveAttribute('data-chain', 'base');
   });
 });
 
 async function selectToken(page: Page, mode: 'origin' | 'destination', chainName: string) {
   const selector = mode === 'origin' ? getOriginTokenButton(page) : getDestinationTokenButton(page);
   await selector.click();
+  await selectTokenRow(page, chainName);
+}
+
+async function selectTokenRow(page: Page, chainName: string) {
   await page.locator('.token-picker-row').filter({ hasText: chainName }).first().click();
 }
 

--- a/tests/token-selection/destination-prefill.spec.ts
+++ b/tests/token-selection/destination-prefill.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { getDestinationTokenButton, getOriginTokenButton } from '../helpers/locators';
+import { installRouterApiMock } from '../helpers/routerApi';
+
+test.describe('Token Selection - Destination Prefill', () => {
+  test.beforeEach(async ({ page }) => {
+    await installRouterApiMock(page);
+    await page.goto('http://localhost:3000');
+    await page.getByText('Send').first().waitFor({ state: 'visible' });
+  });
+
+  test('requests destination prefill before destination token selection', async ({ page }) => {
+    const prefillRequest = page.waitForRequest(isBaseOriginPrefillRequest);
+
+    await selectToken(page, 'origin', 'Base');
+    await prefillRequest;
+  });
+
+  test('stops prefilling after destination token selection', async ({ page }) => {
+    const destinationButton = getDestinationTokenButton(page);
+    await selectToken(page, 'destination', 'Base');
+    await expect(destinationButton).toHaveAttribute('data-chain', 'base');
+
+    let requestedPrefill = false;
+    page.on('request', (request) => {
+      if (isBaseOriginPrefillRequest(request)) requestedPrefill = true;
+    });
+
+    await selectToken(page, 'origin', 'Base');
+    await expect(getOriginTokenButton(page)).toHaveAttribute('data-chain', 'base');
+
+    expect(requestedPrefill).toBe(false);
+    await expect(destinationButton).toHaveAttribute('data-chain', 'base');
+  });
+});
+
+async function selectToken(page: Page, mode: 'origin' | 'destination', chainName: string) {
+  const selector = mode === 'origin' ? getOriginTokenButton(page) : getDestinationTokenButton(page);
+  await selector.click();
+  await page.locator('.token-picker-row').filter({ hasText: chainName }).first().click();
+}
+
+function isBaseOriginPrefillRequest(request: { url(): string }): boolean {
+  const url = new URL(request.url());
+  return url.pathname === '/v1/available-routes' && url.searchParams.get('srcChain') === '8453';
+}


### PR DESCRIPTION
## Summary

- track whether the user selected a destination token
- skip automatic destination prefilling on later origin selections
- cover prefill behavior before and after destination selection with browser tests
