### PR TITLE
perf: defer Solana wallet adapters

### DIFF
--- a/src/components/buttons/ConnectAwareSubmitButton.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.tsx
@@ -1,15 +1,13 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { useTimeout } from '@hyperlane-xyz/widgets';
-import {
-  useAccountForChain,
-  useConnectFns,
-} from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
+import { useAccountForChain } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import { useFormikContext } from 'formik';
 import { useCallback } from 'react';
 
 import { EVENT_NAME } from '../../features/analytics/types';
 import { trackEvent } from '../../features/analytics/utils';
 import { useChainProtocol, useMultiProvider } from '../../features/chains/hooks';
+import { useAppConnectFns } from '../../features/wallet/useAppConnectFns';
 import { SolidButton } from './SolidButton';
 
 interface Props {
@@ -26,7 +24,7 @@ export function ConnectAwareSubmitButton<FormValues = any>({
   disabled,
 }: Props) {
   const protocol = useChainProtocol(chainName) || ProtocolType.Ethereum;
-  const connectFns = useConnectFns();
+  const connectFns = useAppConnectFns();
   const connectFn = connectFns[protocol];
 
   const multiProvider = useMultiProvider();

--- a/src/features/chains/ChainWalletWarning.tsx
+++ b/src/features/chains/ChainWalletWarning.tsx
@@ -1,6 +1,5 @@
 import { toTitleCase } from '@hyperlane-xyz/utils';
 import {
-  useConnectFns,
   useDisconnectFns,
   useWalletDetails,
 } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
@@ -9,6 +8,7 @@ import { useMemo } from 'react';
 import { FormWarningBanner } from '../../components/banner/FormWarningBanner';
 import { config } from '../../consts/config';
 import { logger } from '../../utils/logger';
+import { useAppConnectFns } from '../wallet/useAppConnectFns';
 import { useMultiProvider } from './hooks';
 import { getChainDisplayName } from './utils';
 
@@ -16,7 +16,7 @@ export function ChainWalletWarning({ origin }: { origin: ChainName }) {
   const multiProvider = useMultiProvider();
 
   const wallets = useWalletDetails();
-  const connectFns = useConnectFns();
+  const connectFns = useAppConnectFns();
   const disconnectFns = useDisconnectFns();
 
   const { isVisible, chainDisplayName, walletWhitelist, connectFn, disconnectFn } = useMemo(() => {

--- a/src/features/wallet/WalletDropdown.tsx
+++ b/src/features/wallet/WalletDropdown.tsx
@@ -3,7 +3,6 @@ import { ChevronIcon, DropdownMenu, useModal, XIcon } from '@hyperlane-xyz/widge
 import {
   useAccountAddressForChain,
   useAccountForChain,
-  useConnectFns,
   useDisconnectFns,
 } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import React, { useCallback, useMemo } from 'react';
@@ -12,6 +11,7 @@ import { Color } from '../../styles/Color';
 import { logger } from '../../utils/logger';
 import { useChainProtocol, useMultiProvider } from '../chains/hooks';
 import { RecipientAddressModal } from './RecipientAddressModal';
+import { useAppConnectFns } from './useAppConnectFns';
 
 interface WalletDropdownProps {
   chainName: string | undefined;
@@ -141,7 +141,7 @@ export function WalletDropdown({
 // Self-contained connect button with its own hooks
 function ConnectWalletButton({ chainName }: { chainName?: string }) {
   const protocol = useChainProtocol(chainName || '') || ProtocolType.Ethereum;
-  const connectFns = useConnectFns();
+  const connectFns = useAppConnectFns();
   const connectFn = connectFns[protocol];
 
   const onConnect = useCallback(() => {
@@ -163,7 +163,7 @@ function ConnectWalletButton({ chainName }: { chainName?: string }) {
 
 // Self-contained connect menu item with its own hooks
 function ConnectMenuItem({ protocol }: { protocol: ProtocolType }) {
-  const connectFns = useConnectFns();
+  const connectFns = useAppConnectFns();
   const connectFn = connectFns[protocol];
 
   const onConnect = useCallback(() => {

--- a/src/features/wallet/WalletProtocolModal.tsx
+++ b/src/features/wallet/WalletProtocolModal.tsx
@@ -1,9 +1,9 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { Modal, PROTOCOL_TO_LOGO } from '@hyperlane-xyz/widgets';
-import { useConnectFns } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import clsx from 'clsx';
 
 import { logger } from '../../utils/logger';
+import { useAppConnectFns } from './useAppConnectFns';
 
 interface WalletProtocolModalProps {
   isOpen: boolean;
@@ -33,7 +33,7 @@ export function WalletProtocolModal({
   protocols,
   onProtocolSelected,
 }: WalletProtocolModalProps) {
-  const connectFns = useConnectFns();
+  const connectFns = useAppConnectFns();
 
   const onClickProtocol = (protocol: ProtocolType) => {
     const connectFn = connectFns[protocol];

--- a/src/features/wallet/context/SolanaWalletAdaptersLoader.tsx
+++ b/src/features/wallet/context/SolanaWalletAdaptersLoader.tsx
@@ -1,0 +1,39 @@
+import { SnapWalletAdapter } from '@drift-labs/snap-wallet-adapter';
+import type { Adapter } from '@solana/wallet-adapter-base';
+import {
+  BackpackWalletAdapter,
+  LedgerWalletAdapter,
+  PhantomWalletAdapter,
+  SalmonWalletAdapter,
+  SolflareWalletAdapter,
+  TrustWalletAdapter,
+} from '@solana/wallet-adapter-wallets';
+import { useEffect } from 'react';
+
+interface Props {
+  onError: (error: unknown) => void;
+  onLoad: (adapters: Adapter[]) => void;
+}
+
+let adapters: Adapter[] | undefined;
+
+export default function SolanaWalletAdaptersLoader({ onError, onLoad }: Props) {
+  useEffect(() => {
+    try {
+      adapters ??= [
+        new PhantomWalletAdapter(),
+        new BackpackWalletAdapter(),
+        new SolflareWalletAdapter(),
+        new SalmonWalletAdapter(),
+        new SnapWalletAdapter(),
+        new TrustWalletAdapter(),
+        new LedgerWalletAdapter(),
+      ];
+      onLoad(adapters);
+    } catch (error) {
+      onError(error);
+    }
+  }, [onError, onLoad]);
+
+  return null;
+}

--- a/src/features/wallet/context/SolanaWalletContext.tsx
+++ b/src/features/wallet/context/SolanaWalletContext.tsx
@@ -1,19 +1,21 @@
-import { SnapWalletAdapter } from '@drift-labs/snap-wallet-adapter';
-import { WalletAdapterNetwork, WalletError } from '@solana/wallet-adapter-base';
-import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
-import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
+import { WalletAdapterNetwork, WalletError, type Adapter } from '@solana/wallet-adapter-base';
+import { ConnectionProvider, useWallet, WalletProvider } from '@solana/wallet-adapter-react';
+import { useWalletModal, WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 
 import '@solana/wallet-adapter-react-ui/styles.css';
-import {
-  LedgerWalletAdapter,
-  SalmonWalletAdapter,
-  SolflareWalletAdapter,
-  TrustWalletAdapter,
-  PhantomWalletAdapter,
-  BackpackWalletAdapter,
-} from '@solana/wallet-adapter-wallets';
 import { clusterApiUrl } from '@solana/web3.js';
-import { PropsWithChildren, useCallback, useMemo } from 'react';
+import {
+  createContext,
+  lazy,
+  PropsWithChildren,
+  Suspense,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { toast } from 'react-toastify';
 
 import { logger } from '../../../utils/logger';
@@ -21,27 +23,64 @@ import { E2EAutoConnectSolana } from '../_e2e/E2EAutoConnectSolana';
 import { isE2EMode } from '../_e2e/isE2E';
 import { MockSolanaAdapter } from '../_e2e/MockSolanaAdapter';
 
+const SolanaWalletAdaptersLoader = lazy(() => import('./SolanaWalletAdaptersLoader'));
+
+interface SolanaWalletActivation {
+  connect: () => void;
+  isLoading: boolean;
+}
+
+const SolanaWalletActivationContext = createContext<SolanaWalletActivation | undefined>(undefined);
+
+export function useSolanaWalletActivation(): SolanaWalletActivation {
+  const value = useContext(SolanaWalletActivationContext);
+  if (!value) throw new Error('Solana wallet activation context is unavailable');
+  return value;
+}
+
 export function SolanaWalletContext({ children }: PropsWithChildren<unknown>) {
   // TODO support multiple networks
   const network = WalletAdapterNetwork.Mainnet;
   const endpoint = useMemo(() => clusterApiUrl(network), [network]);
   const e2e = isE2EMode();
-  const wallets = useMemo(
-    () => {
-      const real = [
-        new PhantomWalletAdapter(),
-        new BackpackWalletAdapter(),
-        new SolflareWalletAdapter(),
-        new SalmonWalletAdapter(),
-        new SnapWalletAdapter(),
-        new TrustWalletAdapter(),
-        new LedgerWalletAdapter(),
-      ];
-      return e2e ? [new MockSolanaAdapter()] : real;
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [network, e2e],
-  );
+  const [wallets, setWallets] = useState<Adapter[]>(() => (e2e ? [new MockSolanaAdapter()] : []));
+  const [isLoading, setIsLoading] = useState(false);
+  const [connectRequest, setConnectRequest] = useState(0);
+  const [shouldLoadWallets, setShouldLoadWallets] = useState(false);
+  const pendingConnectRef = useRef(false);
+
+  const connect = useCallback(() => {
+    if (wallets.length) {
+      setConnectRequest((request) => request + 1);
+      return;
+    }
+
+    pendingConnectRef.current = true;
+    setIsLoading(true);
+    setShouldLoadWallets(true);
+  }, [wallets.length]);
+
+  const onWalletsLoaded = useCallback((adapters: Adapter[]) => {
+    setWallets(adapters);
+    setIsLoading(false);
+    setShouldLoadWallets(false);
+    if (!pendingConnectRef.current) return;
+    pendingConnectRef.current = false;
+    setConnectRequest((request) => request + 1);
+  }, []);
+
+  const onWalletsLoadError = useCallback((error: unknown) => {
+    pendingConnectRef.current = false;
+    setIsLoading(false);
+    setShouldLoadWallets(false);
+    logger.error('Error loading Solana wallet adapters', error);
+    toast.error('Error preparing Solana wallets');
+  }, []);
+
+  useEffect(() => {
+    if (e2e || typeof window === 'undefined' || !window.localStorage.getItem('walletName')) return;
+    setShouldLoadWallets(true);
+  }, [e2e]);
 
   const onError = useCallback((error: WalletError) => {
     logger.error('Error initializing Solana wallet provider', error);
@@ -52,10 +91,45 @@ export function SolanaWalletContext({ children }: PropsWithChildren<unknown>) {
     <ConnectionProvider endpoint={endpoint}>
       <WalletProvider wallets={wallets} onError={onError} autoConnect>
         <WalletModalProvider>
-          {e2e && <E2EAutoConnectSolana />}
-          {children}
+          <SolanaWalletActivationBridge
+            connect={connect}
+            connectRequest={connectRequest}
+            isLoading={isLoading}
+          >
+            {shouldLoadWallets && (
+              <Suspense fallback={null}>
+                <SolanaWalletAdaptersLoader onError={onWalletsLoadError} onLoad={onWalletsLoaded} />
+              </Suspense>
+            )}
+            {e2e && <E2EAutoConnectSolana />}
+            {children}
+          </SolanaWalletActivationBridge>
         </WalletModalProvider>
       </WalletProvider>
     </ConnectionProvider>
+  );
+}
+
+function SolanaWalletActivationBridge({
+  children,
+  connect,
+  connectRequest,
+  isLoading,
+}: PropsWithChildren<SolanaWalletActivation & { connectRequest: number }>) {
+  const { setVisible } = useWalletModal();
+  const { wallets } = useWallet();
+  const handledRequest = useRef(0);
+
+  useEffect(() => {
+    if (!wallets.length || connectRequest <= handledRequest.current) return;
+    handledRequest.current = connectRequest;
+    setVisible(true);
+  }, [connectRequest, setVisible, wallets.length]);
+
+  const value = useMemo(() => ({ connect, isLoading }), [connect, isLoading]);
+  return (
+    <SolanaWalletActivationContext.Provider value={value}>
+      {children}
+    </SolanaWalletActivationContext.Provider>
   );
 }

--- a/src/features/wallet/useAppConnectFns.ts
+++ b/src/features/wallet/useAppConnectFns.ts
@@ -1,0 +1,15 @@
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { useConnectFns } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
+import { useMemo } from 'react';
+
+import { useSolanaWalletActivation } from './context/SolanaWalletContext';
+
+export function useAppConnectFns() {
+  const connectFns = useConnectFns();
+  const { connect: connectSolana } = useSolanaWalletActivation();
+
+  return useMemo(
+    () => ({ ...connectFns, [ProtocolType.Sealevel]: connectSolana }),
+    [connectFns, connectSolana],
+  );
+}


### PR DESCRIPTION
## Summary

- Load the seven Solana wallet adapters only when a user chooses Solana.
- Preserve auto-connect by loading adapters on startup only when a prior Solana wallet selection exists.
- Route every app-level connect entry point through the deferred activation flow.
- Keep E2E mock-wallet behavior unchanged.

## Benchmarks

Production build, root route:

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| First-load JS, raw | 15,755,499 B | 15,693,017 B | -62,482 B (-0.40%) |
| First-load JS, gzip | 4,057,487 B | 4,047,745 B | -9,742 B (-0.24%) |
| First-load chunks | 53 | 53 | unchanged |

The deferred Solana adapter chunk is 183,367 B raw / 43,848 B gzip. In a clean browser session it was absent from the initial page load; selecting Solana requested the chunk and then displayed Phantom, Backpack, Solflare, Salmon, Connect by Drift, Trust, and Ledger.

## Validation

- pnpm typecheck
- pnpm lint (passes with two pre-existing E2E mock console warnings)
- pnpm test (294 tests)
- E2E_USE_PROD=1 pnpm exec playwright test tests/wallet-connect/protocol-wallet-modals.spec.ts --project=chromium --reporter=list (2 tests)
- pnpm build
- pnpm check:bundle
- Manual production-browser verification of clean load and deferred Solana wallet modal

No dependencies, package manifests, lockfiles, or unrelated documentation files changed. Cosmos adapter startup remains a separate follow-up because the current CosmosKit provider snapshots its wallet list at mount.