### PR TITLE
perf: defer Cosmos wallet modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@cosmos-kit/keplr": "^2.12.2",
     "@cosmos-kit/leap": "^2.12.2",
     "@cosmos-kit/react": "2.18.0",
+    "@cosmos-kit/react-lite": "2.18.1",
     "@drift-labs/snap-wallet-adapter": "^0.3.0",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@cosmos-kit/react':
         specifier: 2.18.0
         version: 2.18.0(@cosmjs/amino@0.36.2)(@cosmjs/proto-signing@0.32.4)(@interchain-ui/react@1.26.3(@types/react@19.2.17)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@react-native-async-storage/async-storage@1.24.0(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.59))(bufferutil@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
+      '@cosmos-kit/react-lite':
+        specifier: 2.18.1
+        version: 2.18.1(@cosmjs/amino@0.36.2)(@cosmjs/proto-signing@0.32.4)(@react-native-async-storage/async-storage@1.24.0(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(bufferutil@4.1.0)(react@19.2.7)(utf-8-validate@6.0.6)))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.59))(bufferutil@4.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(utf-8-validate@6.0.6)
       '@drift-labs/snap-wallet-adapter':
         specifier: ^0.3.0
         version: 0.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)

--- a/src/features/wallet/context/CosmosWalletContext.tsx
+++ b/src/features/wallet/context/CosmosWalletContext.tsx
@@ -1,13 +1,14 @@
-import { ChakraProvider, extendTheme } from '@chakra-ui/react';
 import { GasPrice } from '@cosmjs/stargate';
+import type { WalletModalProps } from '@cosmos-kit/core';
 import { wallets as cosmostationWallets } from '@cosmos-kit/cosmostation';
 import { wallets as keplrWallets } from '@cosmos-kit/keplr';
 import { wallets as leapWallets } from '@cosmos-kit/leap';
-import { ChainProvider } from '@cosmos-kit/react';
+import { ChainProvider } from '@cosmos-kit/react-lite';
 import { cosmoshub } from '@hyperlane-xyz/registry';
 import { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
 import { getCosmosKitChainConfigs } from '@hyperlane-xyz/widgets/walletIntegrations/cosmos';
 import '@interchain-ui/react/styles';
+import dynamic from 'next/dynamic';
 import { PropsWithChildren, useMemo } from 'react';
 
 import { APP_DESCRIPTION, APP_NAME, APP_URL } from '../../../consts/app';
@@ -17,12 +18,29 @@ import { E2EAutoConnectCosmos } from '../_e2e/E2EAutoConnectCosmos';
 import { isE2EMode } from '../_e2e/isE2E';
 import { MockCosmosWallet } from '../_e2e/MockCosmosWallet';
 
-const theme = extendTheme({
-  fonts: {
-    heading: `'Neue Haas Grotesk', 'Helvetica', 'sans-serif'`,
-    body: `'Neue Haas Grotesk', 'Helvetica', 'sans-serif'`,
+const LazyCosmosWalletModal = dynamic(
+  async () => {
+    // DefaultModal reads this provider directly, so keep both in the same lazy chunk.
+    const [{ DefaultModal }, { SelectedWalletRepoProvider }] = await Promise.all([
+      import('@cosmos-kit/react'),
+      import('@cosmos-kit/react/esm/context'),
+    ]);
+
+    return function CosmosKitWalletModal(props: WalletModalProps) {
+      return (
+        <SelectedWalletRepoProvider>
+          <DefaultModal {...props} />
+        </SelectedWalletRepoProvider>
+      );
+    };
   },
-});
+  { ssr: false },
+);
+
+function CosmosWalletModal(props: WalletModalProps) {
+  if (!props.isOpen) return <></>;
+  return <LazyCosmosWalletModal {...props} />;
+}
 
 export function CosmosWalletContext({ children }: PropsWithChildren<unknown>) {
   const chainMetadata = useMultiProvider().metadata;
@@ -41,44 +59,40 @@ export function CosmosWalletContext({ children }: PropsWithChildren<unknown>) {
     return [...keplrWallets, ...cosmostationWallets, ...leapWithoutSnap];
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [e2e]);
-  // TODO replace Chakra here with a custom modal for ChainProvider
-  // Using Chakra + @cosmos-kit/react instead of @cosmos-kit/react-lite adds about 600Kb to the bundle
   return (
-    <ChakraProvider theme={theme}>
-      <ChainProvider
-        chains={chains}
-        assetLists={assets}
-        wallets={walletsList}
-        walletConnectOptions={{
-          signClient: {
-            projectId: config.walletConnectProjectId,
-            metadata: {
-              name: APP_NAME,
-              description: APP_DESCRIPTION,
-              url: APP_URL,
-              icons: [],
-            },
+    <ChainProvider
+      chains={chains}
+      assetLists={assets}
+      wallets={walletsList}
+      walletConnectOptions={{
+        signClient: {
+          projectId: config.walletConnectProjectId,
+          metadata: {
+            name: APP_NAME,
+            description: APP_DESCRIPTION,
+            url: APP_URL,
+            icons: [],
           },
-        }}
-        signerOptions={{
-          signingCosmwasm: () => {
-            return {
-              // TODO cosmos get gas price from registry or RPC
-              gasPrice: GasPrice.fromString('0.03token'),
-            };
-          },
-          signingStargate: () => {
-            return {
-              // TODO cosmos get gas price from registry or RPC
-              gasPrice: GasPrice.fromString('0.2tia'),
-            };
-          },
-        }}
-        modalTheme={{ defaultTheme: 'light' }}
-      >
-        {e2e && <E2EAutoConnectCosmos />}
-        {children}
-      </ChainProvider>
-    </ChakraProvider>
+        },
+      }}
+      signerOptions={{
+        signingCosmwasm: () => {
+          return {
+            // TODO cosmos get gas price from registry or RPC
+            gasPrice: GasPrice.fromString('0.03token'),
+          };
+        },
+        signingStargate: () => {
+          return {
+            // TODO cosmos get gas price from registry or RPC
+            gasPrice: GasPrice.fromString('0.2tia'),
+          };
+        },
+      }}
+      walletModal={CosmosWalletModal}
+    >
+      {e2e && <E2EAutoConnectCosmos />}
+      {children}
+    </ChainProvider>
   );
 }

--- a/tests/wallet-connect/protocol-wallet-modals.spec.ts
+++ b/tests/wallet-connect/protocol-wallet-modals.spec.ts
@@ -55,4 +55,33 @@ test.describe('Wallet Connect - Protocol Modals', () => {
     await page.keyboard.press('Escape');
     await expect(dialog).not.toBeVisible();
   });
+
+  test('Cosmos: should lazy-load the Cosmos wallet modal', async ({ page }) => {
+    await page
+      .getByRole('banner')
+      .getByRole('button', { name: 'Connect wallet', exact: true })
+      .click();
+
+    await page
+      .getByRole('dialog')
+      .getByRole('button', {
+        name: 'Cosmos Connect to a Cosmos-compatible wallet',
+      })
+      .click();
+
+    const dialog = page.getByRole('dialog', { name: 'Select your wallet' });
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole('button', { name: 'Keplr Keplr' }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole('button', { name: 'Cosmostation Cosmostation' }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole('button', { name: 'Leap Leap' }),
+    ).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialog).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary

- `perf:` replace the Chakra-wrapped CosmosKit provider with the lite provider
- `perf:` load CosmosKit's existing wallet modal and selected-wallet context only when the Cosmos picker opens
- `test:` cover the header-to-Cosmos wallet picker flow and its wallet options

## Benchmarks

Production `/` bundle, using the same checkout and configuration:

| Variant | Raw JS | Gzip JS | Chunks |
| --- | ---: | ---: | ---: |
| `main` | 15,755,499 B | 4,072,660 B | 53 |
| This PR | 14,590,298 B | 3,739,672 B | 54 |
| Change | -1,165,201 B (-7.40%) | -332,988 B (-8.18%) | +1 |

A static-modal lite-provider variant saved only 91,125 gzip bytes (-2.24%), so the conditional split accounts for another 241,863 gzip bytes without replacing CosmosKit's wallet behavior.

`@cosmos-kit/react-lite@2.18.1` was already in the lockfile transitively; this PR promotes the same pinned version to a direct dependency and adds no new package implementation.

## Verification

- production build and bundle limits pass
- TypeScript passes
- 294 unit tests pass
- three Chromium protocol-wallet modal tests pass, including the new Cosmos regression
- verified in the rendered browser: Cosmos wallet list, missing-Keplr install state, back navigation, close, and reopen
- no wallet was connected and no transaction was submitted
