### PR TITLE
fix: resolve SVM synthetic balances and route display

### DIFF
--- a/src/features/balances/sealevel.test.ts
+++ b/src/features/balances/sealevel.test.ts
@@ -1,4 +1,4 @@
-import { SealevelTokenAdapter, TokenStandard } from '@hyperlane-xyz/sdk';
+import { TokenStandard } from '@hyperlane-xyz/sdk';
 import {
   AccountLayout,
   ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -6,7 +6,7 @@ import {
   TOKEN_2022_PROGRAM_ID,
 } from '@solana/spl-token';
 import { Connection, PublicKey } from '@solana/web3.js';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   deriveSealevelHypSyntheticMint,
@@ -31,11 +31,22 @@ const token: BalanceToken = {
   standard: TokenStandard.SealevelHypSynthetic,
 };
 
+const getAccountInfo = vi.fn();
+const getTokenAccountBalance = vi.fn();
 const multiProvider = {
   tryGetChainMetadata: () => ({
     rpcUrls: [{ http: RPC_URL }],
   }),
+  getSolanaWeb3Provider: () => ({
+    getAccountInfo,
+    getTokenAccountBalance,
+  }),
 } as never;
+
+beforeEach(() => {
+  getAccountInfo.mockReset();
+  getTokenAccountBalance.mockReset();
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -48,10 +59,9 @@ describe('deriveSealevelHypSyntheticMint', () => {
 });
 
 describe('Sealevel synthetic balances', () => {
-  test('uses the SDK synthetic adapter for single-token reads', async () => {
-    const getBalance = vi
-      .spyOn(SealevelTokenAdapter.prototype, 'getBalance')
-      .mockResolvedValue(123n);
+  test('uses the mint owner to derive the Token-2022 ATA for single-token reads', async () => {
+    getAccountInfo.mockResolvedValue({ owner: TOKEN_2022_PROGRAM_ID });
+    getTokenAccountBalance.mockResolvedValue({ value: { amount: '123' } });
 
     const balance = await readSealevelTokenBalance(multiProvider, {
       chainName: token.chainName,
@@ -62,9 +72,15 @@ describe('Sealevel synthetic balances', () => {
     });
 
     expect(balance).toBe(123n);
-    expect(getBalance).toHaveBeenCalledWith(OWNER);
-    expect((getBalance.mock.instances[0] as SealevelTokenAdapter).addresses.token).toBe(
-      SYNTHETIC_MINT,
+    expect(getAccountInfo).toHaveBeenCalledWith(new PublicKey(SYNTHETIC_MINT));
+    expect(getTokenAccountBalance).toHaveBeenCalledWith(
+      getAssociatedTokenAddressSync(
+        new PublicKey(SYNTHETIC_MINT),
+        new PublicKey(OWNER),
+        true,
+        TOKEN_2022_PROGRAM_ID,
+        ASSOCIATED_TOKEN_PROGRAM_ID,
+      ),
     );
   });
 

--- a/src/features/balances/sealevel.test.ts
+++ b/src/features/balances/sealevel.test.ts
@@ -1,0 +1,97 @@
+import { SealevelTokenAdapter, TokenStandard } from '@hyperlane-xyz/sdk';
+import {
+  AccountLayout,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  TOKEN_2022_PROGRAM_ID,
+} from '@solana/spl-token';
+import { Connection, PublicKey } from '@solana/web3.js';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  deriveSealevelHypSyntheticMint,
+  fetchSealevelChainBalances,
+  readSealevelTokenBalance,
+} from './sealevel';
+import type { BalanceToken } from './types';
+import { getBalanceTokenKey } from './types';
+
+const WARP_ROUTER = '4iQfUG5RC58qAdwiLUUv3xmUnADviy4TQ1pqJVrSR2fE';
+const SYNTHETIC_MINT = 'BWsnyEa1XtsNRdgPaDoA1WVUonF7BBGZTd2zc72NQsWT';
+const OWNER = '11111111111111111111111111111111';
+const RPC_URL = 'https://solana-rpc.test';
+
+const token: BalanceToken = {
+  chainId: 1399811149,
+  chainName: 'solanamainnet',
+  address: WARP_ROUTER,
+  symbol: 'BLEND',
+  decimals: 9,
+  isNative: false,
+  standard: TokenStandard.SealevelHypSynthetic,
+};
+
+const multiProvider = {
+  tryGetChainMetadata: () => ({
+    rpcUrls: [{ http: RPC_URL }],
+  }),
+} as never;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('deriveSealevelHypSyntheticMint', () => {
+  test('derives the BLEND Token-2022 mint from its Warp router', () => {
+    expect(deriveSealevelHypSyntheticMint(WARP_ROUTER).toBase58()).toBe(SYNTHETIC_MINT);
+  });
+});
+
+describe('Sealevel synthetic balances', () => {
+  test('uses the SDK synthetic adapter for single-token reads', async () => {
+    const getBalance = vi
+      .spyOn(SealevelTokenAdapter.prototype, 'getBalance')
+      .mockResolvedValue(123n);
+
+    const balance = await readSealevelTokenBalance(multiProvider, {
+      chainName: token.chainName,
+      tokenAddress: token.address,
+      isNative: token.isNative,
+      owner: OWNER,
+      standard: token.standard,
+    });
+
+    expect(balance).toBe(123n);
+    expect(getBalance).toHaveBeenCalledWith(OWNER);
+    expect((getBalance.mock.instances[0] as SealevelTokenAdapter).addresses.token).toBe(
+      SYNTHETIC_MINT,
+    );
+  });
+
+  test('reads the Token-2022 ATA derived from the synthetic mint in batched reads', async () => {
+    const getMultipleAccountsInfo = vi
+      .spyOn(Connection.prototype, 'getMultipleAccountsInfo')
+      .mockResolvedValue([
+        {
+          data: Buffer.alloc(AccountLayout.span),
+          executable: false,
+          lamports: 0,
+          owner: TOKEN_2022_PROGRAM_ID,
+          rentEpoch: 0,
+        },
+      ]);
+    vi.spyOn(AccountLayout, 'decode').mockReturnValue({ amount: 456n } as never);
+
+    const balances = await fetchSealevelChainBalances(RPC_URL, [token], OWNER);
+
+    const expectedAta = getAssociatedTokenAddressSync(
+      new PublicKey(SYNTHETIC_MINT),
+      new PublicKey(OWNER),
+      true,
+      TOKEN_2022_PROGRAM_ID,
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    );
+    expect(getMultipleAccountsInfo).toHaveBeenCalledWith([expectedAta]);
+    expect(balances[getBalanceTokenKey(token)]).toBe(456n);
+  });
+});

--- a/src/features/balances/sealevel.ts
+++ b/src/features/balances/sealevel.ts
@@ -1,4 +1,9 @@
-import { TokenStandard, type MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import {
+  BaseSealevelAdapter,
+  SealevelTokenAdapter,
+  TokenStandard,
+  type MultiProtocolProvider,
+} from '@hyperlane-xyz/sdk';
 import {
   AccountLayout,
   ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -14,6 +19,7 @@ import type { BalanceToken } from './types';
 import { getBalanceTokenKey } from './types';
 
 const ZERO_ADDRESS = /^0x0+$/i;
+const HYP_SYNTHETIC_MINT_SEEDS = ['hyperlane_token', '-', 'mint'];
 
 export async function fetchSealevelChainBalances(
   rpcUrl: string,
@@ -31,6 +37,29 @@ export async function fetchSealevelChainBalances(
       nativeTokens.push(token);
       continue;
     }
+
+    if (token.standard === TokenStandard.SealevelHypSynthetic) {
+      try {
+        const mint = deriveSealevelHypSyntheticMint(token.address);
+        splEntries.push({
+          token,
+          ata: getAssociatedTokenAddressSync(
+            mint,
+            ownerKey,
+            true,
+            TOKEN_2022_PROGRAM_ID,
+            ASSOCIATED_TOKEN_PROGRAM_ID,
+          ),
+        });
+      } catch (err) {
+        logger.warn(
+          `Could not resolve synthetic balance account for ${token.symbol}`,
+          err as Error,
+        );
+      }
+      continue;
+    }
+
     let mint: PublicKey;
     try {
       mint = new PublicKey(token.address);
@@ -86,7 +115,17 @@ export async function readSealevelTokenBalance(
   ) {
     return BigInt(await connection.getBalance(ownerKey));
   }
+  if (args.standard === TokenStandard.SealevelHypSynthetic) {
+    const adapter = new SealevelTokenAdapter(args.chainName, multiProvider, {
+      token: deriveSealevelHypSyntheticMint(args.tokenAddress).toBase58(),
+    });
+    return adapter.getBalance(args.owner);
+  }
   return fetchSplBalance(connection, ownerKey, args.tokenAddress);
+}
+
+export function deriveSealevelHypSyntheticMint(warpRouter: string): PublicKey {
+  return BaseSealevelAdapter.derivePda(HYP_SYNTHETIC_MINT_SEEDS, warpRouter);
 }
 
 export function isSealevelNativeBalance(token: {

--- a/src/features/balances/sealevel.ts
+++ b/src/features/balances/sealevel.ts
@@ -104,6 +104,13 @@ export async function readSealevelTokenBalance(
 ): Promise<bigint> {
   const rpcUrl = multiProvider.tryGetChainMetadata(args.chainName)?.rpcUrls?.[0]?.http;
   if (!rpcUrl) throw new Error(`Missing Sealevel RPC URL for ${args.chainName}`);
+  if (args.standard === TokenStandard.SealevelHypSynthetic) {
+    const adapter = new SealevelTokenAdapter(args.chainName, multiProvider, {
+      token: deriveSealevelHypSyntheticMint(args.tokenAddress).toBase58(),
+    });
+    return adapter.getBalance(args.owner);
+  }
+
   const connection = new Connection(rpcUrl, 'confirmed');
   const ownerKey = new PublicKey(args.owner);
   if (
@@ -114,12 +121,6 @@ export async function readSealevelTokenBalance(
     })
   ) {
     return BigInt(await connection.getBalance(ownerKey));
-  }
-  if (args.standard === TokenStandard.SealevelHypSynthetic) {
-    const adapter = new SealevelTokenAdapter(args.chainName, multiProvider, {
-      token: deriveSealevelHypSyntheticMint(args.tokenAddress).toBase58(),
-    });
-    return adapter.getBalance(args.owner);
   }
   return fetchSplBalance(connection, ownerKey, args.tokenAddress);
 }

--- a/src/features/transfer/engine/routeSelection/RouteSelectionModal.tsx
+++ b/src/features/transfer/engine/routeSelection/RouteSelectionModal.tsx
@@ -163,7 +163,7 @@ function RouteFlowDiagram({
   // picked Base→Viction) are never fetched by the token picker, so
   // tokens like WETH on Arb would otherwise stay unresolved.
   useRouteChainTokens(steps);
-  const nodes = buildFlowNodes(steps);
+  const nodes = buildFlowNodes(steps, { destinationTokenAddress: dstToken?.address });
   const lastIdx = nodes.length - 1;
   const firstNode = nodes[0];
   const lastNode = nodes[lastIdx];
@@ -288,7 +288,15 @@ function StepEdge({
 }) {
   if (step.type === 'swap')
     return <SwapEdge step={step} tokenMap={tokenMap} resolvedTokenOut={tokenOut} />;
-  return <CrossChainEdge step={step} tokenMap={tokenMap} stepIndex={stepIndex} steps={steps} />;
+  return (
+    <CrossChainEdge
+      step={step}
+      tokenMap={tokenMap}
+      resolvedDestAsset={tokenOut}
+      stepIndex={stepIndex}
+      steps={steps}
+    />
+  );
 }
 
 // ── Native wrapper display edge ─────────────────────────────────────────
@@ -459,11 +467,13 @@ function SwapEdge({
 function CrossChainEdge({
   step,
   tokenMap,
+  resolvedDestAsset,
   stepIndex,
   steps,
 }: {
   step: QuoteBridgeStep;
   tokenMap: Map<string, UiToken>;
+  resolvedDestAsset: UiToken | null;
   stepIndex: number;
   steps: QuoteStep[];
 }) {
@@ -477,7 +487,7 @@ function CrossChainEdge({
       ? getTokenByKeyFromMap(tokenMap, tokenKey(step.destChain, nextStep.tokenIn))
       : nextStep?.type === 'bridge'
         ? getTokenByKeyFromMap(tokenMap, tokenKey(step.destChain, nextStep.asset))
-        : asset;
+        : (resolvedDestAsset ?? asset);
 
   const amountIn = formatStepAmount(step.amountIn, asset?.decimals ?? 18);
   const amountOut = formatStepAmount(step.amountOut, destAsset?.decimals ?? asset?.decimals ?? 18);

--- a/src/features/transfer/engine/routeSelection/utils.test.ts
+++ b/src/features/transfer/engine/routeSelection/utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+
+import type { QuoteBridgeStep, QuoteSwapStep } from '../../../api/types';
+import { buildFlowNodes } from './utils';
+
+const ALEO_CHAIN_ID = 1634493807;
+const SOLANA_CHAIN_ID = 1399811149;
+const NATIVE_TOKEN = '0x0000000000000000000000000000000000000000';
+const SOLANA_ALEO = 'SolanaAleoSynthetic1111111111111111111111111';
+
+const bridgeStep: QuoteBridgeStep = {
+  type: 'bridge',
+  chain: ALEO_CHAIN_ID,
+  destChain: SOLANA_CHAIN_ID,
+  asset: NATIVE_TOKEN,
+  router: 'hyp_warp_token_credits.aleo/router',
+  amountIn: '100000',
+  amountOut: '100000',
+  bridgeSymbol: 'ALEO',
+  warpRouteId: 'ALEO/aleo',
+  fee: {
+    tokenFee: '0',
+    igpToken: NATIVE_TOKEN,
+    igpAmount: '7661056',
+    localNativeFee: '0',
+  },
+};
+
+describe('buildFlowNodes', () => {
+  test('uses the selected destination token for a terminal bridge', () => {
+    expect(buildFlowNodes([bridgeStep], { destinationTokenAddress: SOLANA_ALEO })).toEqual([
+      { chainId: ALEO_CHAIN_ID, tokenAddress: NATIVE_TOKEN },
+      { chainId: SOLANA_CHAIN_ID, tokenAddress: SOLANA_ALEO },
+    ]);
+  });
+
+  test('uses the next destination swap input for a non-terminal bridge', () => {
+    const swapStep: QuoteSwapStep = {
+      type: 'swap',
+      chain: SOLANA_CHAIN_ID,
+      dex: 'raydium',
+      tokenIn: 'SolanaBridgeMint11111111111111111111111111',
+      tokenOut: SOLANA_ALEO,
+      amountIn: '100000',
+      amountOut: '99000',
+      path: ['SolanaBridgeMint11111111111111111111111111', SOLANA_ALEO],
+      poolCount: 1,
+    };
+
+    expect(
+      buildFlowNodes([bridgeStep, swapStep], { destinationTokenAddress: SOLANA_ALEO }),
+    ).toEqual([
+      { chainId: ALEO_CHAIN_ID, tokenAddress: NATIVE_TOKEN },
+      { chainId: SOLANA_CHAIN_ID, tokenAddress: swapStep.tokenIn },
+      { chainId: SOLANA_CHAIN_ID, tokenAddress: SOLANA_ALEO },
+    ]);
+  });
+});

--- a/src/features/transfer/engine/routeSelection/utils.ts
+++ b/src/features/transfer/engine/routeSelection/utils.ts
@@ -6,7 +6,10 @@ export interface FlowNode {
   chainId: number;
 }
 
-export function buildFlowNodes(steps: QuoteStep[]): FlowNode[] {
+export function buildFlowNodes(
+  steps: QuoteStep[],
+  boundaryTokens: { destinationTokenAddress?: string } = {},
+): FlowNode[] {
   const nodes: FlowNode[] = [];
 
   for (let i = 0; i < steps.length; i++) {
@@ -28,7 +31,7 @@ export function buildFlowNodes(steps: QuoteStep[]): FlowNode[] {
           ? nextStep.tokenIn
           : nextStep?.type === 'bridge'
             ? nextStep.asset
-            : step.asset;
+            : (boundaryTokens.destinationTokenAddress ?? step.asset);
       nodes.push({ tokenAddress: destAddress, chainId: step.destChain });
     }
   }


### PR DESCRIPTION
## Summary

- derive Sealevel synthetic Token-2022 mints from Warp router program IDs before reading balances
- use the SDK Sealevel token adapter for single-token balance validation while preserving batched UI reads
- show the selected destination token for terminal cross-chain route nodes, fixing Aleo → Solana ALEO routes displaying SOL
- add focused regression coverage for both issues
