### PR TITLE
fix: don't double-count same-token IGP fee in balance validation

### DIFF
--- a/src/features/transfer/engine/validate.test.ts
+++ b/src/features/transfer/engine/validate.test.ts
@@ -146,6 +146,66 @@ describe('validateBalances', () => {
     expect(errors).toBeNull();
     expect(readBalanceMock).toHaveBeenCalledTimes(1);
   });
+
+  // Regression: native-token warp routes (e.g. GNET galactica→solana) pay the
+  // interchain fee in the source native token, so the engine folds it into
+  // amountIn (amountOut = amountIn − igp) and tx.value = amountIn. The balance
+  // check must not add the same-token IGP again — the full balance covers it.
+  test('does not double count same-token IGP already included in amountIn for native source', async () => {
+    readBalanceMock.mockResolvedValueOnce(1000n);
+
+    const route: AugmentedRoute = {
+      raw: {
+        steps: [
+          {
+            type: 'bridge',
+            chain: 358974494,
+            destChain: 1399811149,
+            asset: NATIVE_ADDRESS,
+            router: NATIVE_ADDRESS,
+            amountIn: '1000',
+            amountOut: '767',
+            bridgeSymbol: 'STRK',
+            warpRouteId: 'STRK/native',
+            fee: {
+              tokenFee: '0',
+              igpToken: NATIVE_ADDRESS,
+              igpAmount: '233',
+              localNativeFee: '0',
+            },
+          },
+        ],
+        output: '767',
+        outputMin: '767',
+        executionKind: 'warpDirect',
+        connection: { symbol: 'STRK', warpRouteId: 'STRK/native' },
+        gas: { originGas: '0', destGas: '0' },
+        tx: { to: '0x0000000000000000000000000000000000000001', data: '0x', value: '1000' },
+        txs: [],
+        approval: null,
+      } as RouteResponse,
+      feeBreakdown: {
+        components: [
+          { category: 'igp', amount: 233n, chainId: 358974494, tokenAddress: NATIVE_ADDRESS },
+        ],
+        originGas: 0n,
+        destGas: 0n,
+      },
+      hasFixedOutput: true,
+    };
+
+    const errors = await validateBalances({
+      multiProvider: multiProvider(),
+      srcChainInfo: starknetChain(),
+      srcToken: strkToken(),
+      sender: '0xsender',
+      bestRoute: route,
+      amountAtomic: 1000n,
+    });
+
+    expect(errors).toBeNull();
+    expect(readBalanceMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('validateQuote', () => {

--- a/src/features/transfer/engine/validate.ts
+++ b/src/features/transfer/engine/validate.ts
@@ -235,7 +235,6 @@ export async function validateBalances(args: {
 
   const igpByToken = aggregateIgp(bestRoute.feeBreakdown.components);
   const srcKey = balanceKey(srcToken.chainId, srcToken.address);
-  const sameTokenIgp = igpByToken.get(srcKey) ?? 0n;
   const nativeFee = igpByToken.get(balanceKey(srcChainInfo.id, NATIVE_ADDRESS)) ?? 0n;
 
   let srcBalance: bigint | null;
@@ -257,11 +256,16 @@ export async function validateBalances(args: {
     return null;
   }
 
-  if (srcBalance != null && amountIn + sameTokenIgp > srcBalance) {
+  // amountIn is the gross debit from the sender: the engine already nets any
+  // same-token fee out of the output (amountOut = amountIn − same-token fees),
+  // so an interchain fee denominated in the source token (e.g. native-token
+  // warp routes where IGP is paid in the native gas token) is already included
+  // in amountIn. Adding it again would double-count the fee.
+  if (srcBalance != null && amountIn > srcBalance) {
     return {
       amount: formatInsufficientBalanceMessage({
         base: `Insufficient ${srcToken.symbol} balance`,
-        deficit: amountIn + sameTokenIgp - srcBalance,
+        deficit: amountIn - srcBalance,
         decimals: srcToken.decimals,
         symbol: srcToken.symbol,
       }),
@@ -296,7 +300,7 @@ export async function validateBalances(args: {
     tx: originTx,
     approvalPending,
   });
-  const quotedNativeDebit = srcToken.isNative ? amountIn + sameTokenIgp : nativeFee;
+  const quotedNativeDebit = srcToken.isNative ? amountIn : nativeFee;
   const nativeRequired = maxBigInt(txValue, quotedNativeDebit) + gasCost + nativeExecutionFee;
   if (nativeRequired > 0n) {
     let nativeBalance: bigint | null = srcToken.isNative ? srcBalance : null;


### PR DESCRIPTION
## Summary
- Bridge transfers on **native-token warp routes** (e.g. GNET galactica→solana) were falsely blocked with `Insufficient <TOKEN> balance (need X more)` even when the wallet held enough.
- Root cause: for native routes the interchain gas fee is paid in the **same** token being sent. The engine already nets that fee out of the output (`amountOut = amountIn − igp`) and sets `tx.value = amountIn`, so the fee is **already included in `amountIn`**. `validateBalances` added the same-token IGP again on top, over-requiring by exactly the fee amount.
- ERC20 collateral/synthetic routes were unaffected because their IGP is paid in **native** (a different token → `sameTokenIgp = 0`, validated on the separate native path). This is why prior EVM testing didn't surface it — the bug is specific to native-source (same-token-IGP) routes, independent of VM.

### Change
- `validateBalances`: require `amountIn` (already gross of same-token fees) for the source-token check instead of `amountIn + sameTokenIgp`; likewise use `amountIn` (not `amountIn + sameTokenIgp`) for `quotedNativeDebit`. The native path still bounds by the real `tx.value` via `max(txValue, ...)`.
- Added a regression test mirroring the GNET scenario (`amountOut = amountIn − igp`, `tx.value = amountIn`, balance exactly `amountIn`) that fails before the fix and passes after.

### Live confirmation
- Galactica GNET router `0x8dD4105615773b9e28a83304Ea3739ecA8C45de9`, `quoteGasPayment(solana) = 233.18 GNET`, origin `scale = 1`. Observed: Send `1224` → Receive `990.82` (= 1224 − 233.18), balance `1224.72` → false "need 232.46 more".

## Test plan
- [x] `vitest run src/features/transfer/engine/validate.test.ts` (11 passed)
- [x] Regression test verified failing pre-fix, passing post-fix
- [x] `tsc --noEmit` clean
- [x] `oxlint ./src` clean (only 2 pre-existing unrelated warnings)