### PR TITLE
fix: prompt destination wallet connect when recipient is empty

### DIFF
--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -1198,11 +1198,8 @@ function ButtonSection({
   const dstMetadata = dstChainName ? multiProvider.tryGetChainMetadata(dstChainName) : undefined;
   const dstDisplay = dstMetadata?.displayName || dstMetadata?.name || dstChainName || 'destination';
 
-  // Once the origin wallet is connected but no recipient exists — the destination
-  // wallet isn't connected and no custom recipient was entered — the engine quote
-  // comes back empty and would otherwise read "Route is not supported". Point the
-  // submit button at the destination chain so it prompts to connect that protocol's
-  // wallet instead of implying the route is unavailable.
+  // Origin connected but recipient still missing: prompt the destination wallet connect
+  // instead of the empty-quote "Route is not supported".
   const promptDestConnect = originConnected && needsRecipient && hasTokens && !!dstChainName;
   const connectChainName = promptDestConnect && dstChainName ? dstChainName : srcChainName;
 

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -1196,11 +1196,13 @@ function ButtonSection({
 }) {
   const multiProvider = useMultiProvider();
   const dstMetadata = dstChainName ? multiProvider.tryGetChainMetadata(dstChainName) : undefined;
-  const dstDisplay = dstMetadata?.displayName || dstMetadata?.name || dstChainName || 'destination';
+  const dstDisplay = dstMetadata?.displayName ?? dstMetadata?.name ?? dstChainName ?? 'destination';
 
-  // Origin connected but recipient still missing: prompt the destination wallet connect
-  // instead of the empty-quote "Route is not supported".
-  const promptDestConnect = originConnected && needsRecipient && hasTokens && !!dstChainName;
+  // Origin connected + amount entered but recipient still missing: prompt the
+  // destination wallet connect instead of the empty-quote "Route is not supported".
+  // Gate on hasAmount so the earlier "Enter amount" hint still shows first.
+  const promptDestConnect =
+    originConnected && needsRecipient && hasTokens && hasAmount && !!dstChainName;
   const connectChainName = promptDestConnect && dstChainName ? dstChainName : srcChainName;
 
   let text = 'Continue';

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -674,6 +674,8 @@ function TransferFormContent() {
         onSendTransactions={onSendTransactions}
         sendPending={isActiveTransferInFlight}
         recipientConfirmed={addressConfirmed}
+        originConnected={!!sender}
+        needsRecipient={!effectiveRecipient}
       />
 
       <RecipientConfirmationModal
@@ -1172,6 +1174,8 @@ function ButtonSection({
   onSendTransactions,
   sendPending,
   recipientConfirmed,
+  originConnected,
+  needsRecipient,
 }: {
   isReview: boolean;
   setIsReview: (b: boolean) => void;
@@ -1187,10 +1191,20 @@ function ButtonSection({
   onSendTransactions: () => Promise<void>;
   sendPending: boolean;
   recipientConfirmed: boolean;
+  originConnected: boolean;
+  needsRecipient: boolean;
 }) {
   const multiProvider = useMultiProvider();
   const dstMetadata = dstChainName ? multiProvider.tryGetChainMetadata(dstChainName) : undefined;
   const dstDisplay = dstMetadata?.displayName || dstMetadata?.name || dstChainName || 'destination';
+
+  // Once the origin wallet is connected but no recipient exists — the destination
+  // wallet isn't connected and no custom recipient was entered — the engine quote
+  // comes back empty and would otherwise read "Route is not supported". Point the
+  // submit button at the destination chain so it prompts to connect that protocol's
+  // wallet instead of implying the route is unavailable.
+  const promptDestConnect = originConnected && needsRecipient && hasTokens && !!dstChainName;
+  const connectChainName = promptDestConnect && dstChainName ? dstChainName : srcChainName;
 
   let text = 'Continue';
   let disabled = false;
@@ -1225,7 +1239,7 @@ function ButtonSection({
   if (!isReview) {
     return (
       <ConnectAwareSubmitButton
-        chainName={srcChainName}
+        chainName={connectChainName}
         text={text}
         disabled={disabled || !recipientConfirmed}
         classes="w-full mb-4 px-3 py-2.5 font-secondary text-xl text-cream-100"

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -1198,11 +1198,11 @@ function ButtonSection({
   const dstMetadata = dstChainName ? multiProvider.tryGetChainMetadata(dstChainName) : undefined;
   const dstDisplay = dstMetadata?.displayName ?? dstMetadata?.name ?? dstChainName ?? 'destination';
 
-  // Origin connected + amount entered but recipient still missing: prompt the
-  // destination wallet connect instead of the empty-quote "Route is not supported".
-  // Gate on hasAmount so the earlier "Enter amount" hint still shows first.
-  const promptDestConnect =
-    originConnected && needsRecipient && hasTokens && hasAmount && !!dstChainName;
+  // Origin connected but recipient still missing (no custom recipient and no
+  // connected destination wallet): prompt the destination wallet connect instead
+  // of the empty-quote "Route is not supported". Amount is inconsequential here —
+  // the connect prompt only depends on wallet/recipient state.
+  const promptDestConnect = originConnected && needsRecipient && hasTokens && !!dstChainName;
   const connectChainName = promptDestConnect && dstChainName ? dstChainName : srcChainName;
 
   let text = 'Continue';

--- a/src/features/transfer/engine/useQuote.test.ts
+++ b/src/features/transfer/engine/useQuote.test.ts
@@ -1,7 +1,48 @@
 import { describe, expect, test } from 'vitest';
 
 import type { RouteResponse } from '../../api/types';
-import { isQuoteSettledForSecurity, quoteExpiryDelayMs, validateRouteAmounts } from './useQuote';
+import type { TransferFormValues } from './types';
+import {
+  isQuoteRequestReady,
+  isQuoteSettledForSecurity,
+  quoteExpiryDelayMs,
+  validateRouteAmounts,
+} from './useQuote';
+
+function readyValues(overrides: Partial<TransferFormValues> = {}): TransferFormValues {
+  return {
+    srcChain: 1,
+    dstChain: 2,
+    srcToken: '0xToken',
+    dstToken: '0xToken',
+    amount: '1',
+    recipient: '0xRecipient',
+    slippageBps: 100,
+    ...overrides,
+  };
+}
+
+describe('isQuoteRequestReady', () => {
+  const sender = '0xSender';
+
+  test('is ready when sender and recipient are both present', () => {
+    expect(isQuoteRequestReady(readyValues(), sender)).toBe(true);
+  });
+
+  test('is not ready without a sender', () => {
+    expect(isQuoteRequestReady(readyValues(), undefined)).toBe(false);
+  });
+
+  test('is not ready when recipient is empty', () => {
+    expect(isQuoteRequestReady(readyValues({ recipient: '' }), sender)).toBe(false);
+  });
+
+  test('becomes ready once a recipient is set', () => {
+    const empty = readyValues({ recipient: '' });
+    expect(isQuoteRequestReady(empty, sender)).toBe(false);
+    expect(isQuoteRequestReady({ ...empty, recipient: '0xRecipient' }, sender)).toBe(true);
+  });
+});
 
 describe('quoteExpiryDelayMs', () => {
   test('returns time remaining until quote expiry', () => {

--- a/src/features/transfer/engine/useQuote.ts
+++ b/src/features/transfer/engine/useQuote.ts
@@ -308,7 +308,7 @@ function compoundSlippageMin(output: bigint, slippageBps: number, swapStepCount:
   return (output * numerator) / denominator;
 }
 
-function isQuoteRequestReady(v: TransferFormValues, sender: string | undefined): boolean {
+export function isQuoteRequestReady(v: TransferFormValues, sender: string | undefined): boolean {
   // Non-empty checks only — engine validates / normalizes per-protocol address shapes.
   // Recipient is the effective recipient (custom input or connected destination wallet);
   // gate on it like sender so we don't quote a route the user can't yet receive.

--- a/src/features/transfer/engine/useQuote.ts
+++ b/src/features/transfer/engine/useQuote.ts
@@ -310,7 +310,10 @@ function compoundSlippageMin(output: bigint, slippageBps: number, swapStepCount:
 
 function isQuoteRequestReady(v: TransferFormValues, sender: string | undefined): boolean {
   // Non-empty checks only — engine validates / normalizes per-protocol address shapes.
+  // Recipient is the effective recipient (custom input or connected destination wallet);
+  // gate on it like sender so we don't quote a route the user can't yet receive.
   if (!sender) return false;
+  if (!v.recipient) return false;
   if (v.srcChain == null || v.dstChain == null) return false;
   if (!v.srcToken || !v.dstToken) return false;
   if (!v.amount || Number(v.amount) <= 0) return false;


### PR DESCRIPTION
## Summary
When the origin wallet is connected but no recipient exists (destination-protocol wallet not connected and no custom recipient typed):
- point `ConnectAwareSubmitButton` at the destination chain so it prompts **"Connect wallet"** for the destination protocol (e.g. Aleo) instead of showing the empty-quote **"Route is not supported"**; and
- gate the engine quote on the effective recipient the same way it's gated on the sender, so no `/v1/quote` fires until a recipient is known.

Once the destination wallet connects (or a custom recipient is entered), the recipient fills in and the normal quote flow resumes.

## Test plan
- [x] `pnpm typecheck`, `pnpm lint`, `useQuote` unit tests pass
- [ ] Manual: connect EVM origin → ETH→ETH Aleo → button reads "Connect wallet", no /quote call → connect Aleo wallet → quote proceeds
- [ ] Regression: origin-not-connected still prompts origin; EVM→EVM single-wallet unaffected