### PR TITLE
fix: make wallet connect checks chain-aware

### DIFF
--- a/src/components/buttons/ConnectAwareSubmitButton.test.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.test.tsx
@@ -1,0 +1,34 @@
+import { ProtocolType } from '@hyperlane-xyz/utils';
+import { Formik } from 'formik';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test, vi } from 'vitest';
+
+import { ConnectAwareSubmitButton } from './ConnectAwareSubmitButton';
+
+vi.mock('@hyperlane-xyz/widgets/walletIntegrations/multiProtocol', () => ({
+  useAccountAddressForChain: () => undefined,
+  useAccountForChain: () => ({
+    protocol: ProtocolType.Cosmos,
+    addresses: [{ chainName: 'cosmoshub', address: 'cosmos1connected' }],
+    isReady: true,
+  }),
+  useConnectFns: () => ({}),
+}));
+
+vi.mock('../../features/chains/hooks', () => ({
+  useChainProtocol: () => ProtocolType.Cosmos,
+  useMultiProvider: () => ({}),
+}));
+
+describe('ConnectAwareSubmitButton', () => {
+  test('prompts connect when the selected Cosmos chain has no address', () => {
+    const markup = renderToStaticMarkup(
+      <Formik initialValues={{}} onSubmit={vi.fn()}>
+        <ConnectAwareSubmitButton chainName="neutron" text="Fetching quote…" disabled />
+      </Formik>,
+    );
+
+    expect(markup).toContain('Connect wallet');
+    expect(markup).not.toContain('disabled=""');
+  });
+});

--- a/src/components/buttons/ConnectAwareSubmitButton.tsx
+++ b/src/components/buttons/ConnectAwareSubmitButton.tsx
@@ -1,7 +1,7 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { useTimeout } from '@hyperlane-xyz/widgets';
 import {
-  useAccountForChain,
+  useAccountAddressForChain,
   useConnectFns,
 } from '@hyperlane-xyz/widgets/walletIntegrations/multiProtocol';
 import { useFormikContext } from 'formik';
@@ -30,8 +30,8 @@ export function ConnectAwareSubmitButton<FormValues = any>({
   const connectFn = connectFns[protocol];
 
   const multiProvider = useMultiProvider();
-  const account = useAccountForChain(multiProvider, chainName);
-  const isAccountReady = account?.isReady;
+  const accountAddress = useAccountAddressForChain(multiProvider, chainName);
+  const isAccountReady = !!accountAddress;
 
   const { errors, setErrors, touched, setTouched } = useFormikContext<FormValues>();
 


### PR DESCRIPTION
## Summary

- Resolve wallet readiness against the selected chain address.
- Keep the connect action available when a Cosmos wallet is connected to another chain only.
- Add regression coverage for the partially connected Cosmos case.

Follow-up to #1199 and [this review comment](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/pull/1199#discussion_r3798616143).
