### PR TITLE
fix: accept trusted wrapped native bridge boundaries

### DIFF
--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -17,7 +17,7 @@ const BAD = '0x5555555555555555555555555555555555555555';
 const PERMIT2 = '0x6666666666666666666666666666666666666666';
 const BRIDGE_ROUTER = '0x7777777777777777777777777777777777777777';
 const DST_ROUTER = '0x8888888888888888888888888888888888888888';
-const ETH_WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const ETH_WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 const BASE_WETH = '0x4200000000000000000000000000000000000006';
 const STARKNET_ROUTER = '0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
 const STARKNET_TOKEN = '0x01a238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
@@ -77,6 +77,65 @@ describe('validateRouteSecurity', () => {
         context({ registryWarpRoutes: nativeUniversalRouterRoutes() }),
       ),
     ).toEqual({ valid: true });
+  });
+
+  test('accepts the native sentinel directly at native bridge boundaries', () => {
+    const route = wrappedNativeBridgeRoute();
+    if (route.steps[0].type !== 'swap') throw new Error('expected source swap');
+    if (route.steps[2].type !== 'swap') throw new Error('expected destination swap');
+    route.steps[0].tokenOut = NATIVE;
+    route.steps[0].path = [TOKEN, NATIVE];
+    route.steps[2].tokenIn = NATIVE;
+    route.steps[2].path = [NATIVE, DST_TOKEN];
+
+    expect(
+      validateRouteSecurity(route, context({ registryWarpRoutes: nativeUniversalRouterRoutes() })),
+    ).toEqual({ valid: true });
+  });
+
+  test('does not treat trusted wrapped native as a non-native bridge token', () => {
+    const route = universalRouterRoute();
+    if (route.steps[0].type !== 'swap') throw new Error('expected source swap');
+    route.steps[0].tokenOut = ETH_WETH;
+    route.steps[0].path = [TOKEN, ETH_WETH];
+
+    expect(validateRouteSecurity(route, context())).toMatchObject({
+      valid: false,
+      reason: 'Source token does not match registry route',
+    });
+  });
+
+  test('does not treat trusted wrapped native specially between ordinary swaps', () => {
+    const route = sameChainSwapRoute();
+    route.steps = [
+      {
+        type: 'swap',
+        chain: ETH,
+        dex: 'test',
+        tokenIn: TOKEN,
+        tokenOut: ETH_WETH,
+        amountIn: '100',
+        amountOut: '95',
+        path: [TOKEN, ETH_WETH],
+        poolCount: 1,
+      },
+      {
+        type: 'swap',
+        chain: ETH,
+        dex: 'test',
+        tokenIn: BAD,
+        tokenOut: DST_TOKEN,
+        amountIn: '95',
+        amountOut: '90',
+        path: [BAD, DST_TOKEN],
+        poolCount: 1,
+      },
+    ];
+
+    expect(validateRouteSecurity(route, context({ dstChain: ETH }))).toMatchObject({
+      valid: false,
+      reason: 'Route step tokens are discontinuous',
+    });
   });
 
   test('rejects an untrusted wrapped native token before a native bridge', () => {

--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -17,6 +17,7 @@ const BAD = '0x5555555555555555555555555555555555555555';
 const PERMIT2 = '0x6666666666666666666666666666666666666666';
 const BRIDGE_ROUTER = '0x7777777777777777777777777777777777777777';
 const DST_ROUTER = '0x8888888888888888888888888888888888888888';
+const ETH_WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
 const BASE_WETH = '0x4200000000000000000000000000000000000006';
 const STARKNET_ROUTER = '0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
 const STARKNET_TOKEN = '0x01a238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
@@ -67,6 +68,79 @@ const chainAddresses = {
 describe('validateRouteSecurity', () => {
   test('accepts a universal router swap and bridge route with matching approval and tx target', () => {
     expect(validateRouteSecurity(universalRouterRoute(), context())).toEqual({ valid: true });
+  });
+
+  test('accepts trusted wrapped native tokens around a native bridge', () => {
+    expect(
+      validateRouteSecurity(
+        wrappedNativeBridgeRoute(),
+        context({ registryWarpRoutes: nativeUniversalRouterRoutes() }),
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  test('rejects an untrusted wrapped native token before a native bridge', () => {
+    const route = wrappedNativeBridgeRoute();
+    if (route.steps[0].type !== 'swap') throw new Error('expected source swap');
+    route.steps[0].tokenOut = BAD;
+
+    expect(
+      validateRouteSecurity(route, context({ registryWarpRoutes: nativeUniversalRouterRoutes() })),
+    ).toMatchObject({
+      valid: false,
+      reason: 'Source token does not match registry route',
+    });
+  });
+
+  test('rejects an untrusted wrapped native token after a native bridge', () => {
+    const route = wrappedNativeBridgeRoute();
+    if (route.steps[2].type !== 'swap') throw new Error('expected destination swap');
+    route.steps[2].tokenIn = BAD;
+
+    expect(
+      validateRouteSecurity(route, context({ registryWarpRoutes: nativeUniversalRouterRoutes() })),
+    ).toMatchObject({
+      valid: false,
+      reason: 'Destination token does not match registry route',
+    });
+  });
+
+  test('rejects wrapped native bridge boundaries outside universal router execution', () => {
+    const route = wrappedNativeBridgeRoute();
+    route.executionKind = 'warpDirect';
+
+    expect(
+      validateRouteSecurity(route, context({ registryWarpRoutes: nativeUniversalRouterRoutes() })),
+    ).toMatchObject({
+      valid: false,
+      reason: 'Source token does not match registry route',
+    });
+  });
+
+  test('keeps native bridge assets restricted to the native sentinel', () => {
+    const route = wrappedNativeBridgeRoute();
+    if (route.steps[1].type !== 'bridge') throw new Error('expected bridge');
+    route.steps[1].asset = ETH_WETH;
+
+    expect(
+      validateRouteSecurity(route, context({ registryWarpRoutes: nativeUniversalRouterRoutes() })),
+    ).toMatchObject({
+      valid: false,
+      reason: 'Native bridge asset must be native sentinel',
+    });
+  });
+
+  test('keeps native bridge routers bound to the registry', () => {
+    const route = wrappedNativeBridgeRoute();
+    if (route.steps[1].type !== 'bridge') throw new Error('expected bridge');
+    route.steps[1].router = BAD;
+
+    expect(
+      validateRouteSecurity(route, context({ registryWarpRoutes: nativeUniversalRouterRoutes() })),
+    ).toMatchObject({
+      valid: false,
+      reason: 'Bridge router does not match registry route',
+    });
   });
 
   test('accepts a same-chain universal router swap route', () => {
@@ -809,6 +883,59 @@ function universalRouterRoute(
   };
 }
 
+function wrappedNativeBridgeRoute(): RouteResponse {
+  return {
+    steps: [
+      {
+        type: 'swap',
+        chain: ETH,
+        dex: 'test',
+        tokenIn: TOKEN,
+        tokenOut: ETH_WETH,
+        amountIn: '100',
+        amountOut: '90',
+        path: [TOKEN, ETH_WETH],
+        poolCount: 1,
+      },
+      {
+        type: 'bridge',
+        chain: ETH,
+        destChain: BASE,
+        asset: NATIVE,
+        router: BRIDGE_ROUTER,
+        amountIn: '90',
+        amountOut: '80',
+        bridgeSymbol: 'ETH',
+        warpRouteId: 'ETH/test',
+        fee: { tokenFee: '0', igpToken: NATIVE, igpAmount: '10', localNativeFee: '0' },
+      },
+      {
+        type: 'swap',
+        chain: BASE,
+        dex: 'test',
+        tokenIn: BASE_WETH,
+        tokenOut: DST_TOKEN,
+        amountIn: '80',
+        amountOut: '70',
+        path: [BASE_WETH, DST_TOKEN],
+        poolCount: 1,
+      },
+    ],
+    output: '70',
+    outputMin: '69',
+    executionKind: 'universalRouter',
+    connection: { symbol: 'ETH', warpRouteId: 'ETH/test' },
+    gas: { originGas: '0', destGas: '0' },
+    tx: { to: UNIVERSAL_ROUTER, data: '0x', value: '10' },
+    approval: {
+      token: TOKEN,
+      spender: UNIVERSAL_ROUTER,
+      amount: '100',
+      kind: 'erc20',
+    },
+  };
+}
+
 function sameChainSwapRoute(): RouteResponse {
   return {
     steps: [
@@ -1033,6 +1160,18 @@ function universalRouterRoutes(): RegistryWarpRouteMap {
           standard: 'EvmHypCollateral',
         },
         { chainName: 'base', addressOrDenom: DST_TOKEN, standard: 'EvmHypSynthetic' },
+      ],
+    },
+  };
+}
+
+function nativeUniversalRouterRoutes(): RegistryWarpRouteMap {
+  return {
+    'eth/test': {
+      id: 'ETH/test',
+      tokens: [
+        { chainName: 'ethereum', addressOrDenom: BRIDGE_ROUTER, standard: 'EvmHypNative' },
+        { chainName: 'base', addressOrDenom: DST_ROUTER, standard: 'EvmHypNative' },
       ],
     },
   };

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -2,6 +2,7 @@ import { isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { getRouteTxs, isChainRouteTx } from '../api/routeTx';
 import type { ChainDiscovery, QuoteStep, RouteResponse, RouteTx } from '../api/types';
+import { isTrustedWrappedNativeAddress } from '../tokens/wrappedNative';
 import { trustedUniversalRouterForChain } from './chainContracts';
 import { validateSdkRouteTx } from './sdk';
 import { validateSealevelRouteTx } from './svm';
@@ -97,7 +98,10 @@ function validateStepBindings(
     if (current.amountOut !== next.amountIn) {
       return { valid: false, reason: 'Route step amounts are discontinuous' };
     }
-    if (current.type === 'swap' && !sameTokenAddress(current.tokenOut, inputTokenForStep(next))) {
+    if (
+      current.type === 'swap' &&
+      !sameAdjacentStepToken(current.tokenOut, next, route.executionKind)
+    ) {
       return { valid: false, reason: 'Route step tokens are discontinuous' };
     }
   }
@@ -318,6 +322,20 @@ function spendTokenForStep(step: QuoteStep): string {
 
 function inputTokenForStep(step: QuoteStep): string {
   return step.type === 'swap' ? step.tokenIn : step.asset;
+}
+
+function sameAdjacentStepToken(
+  outputToken: string,
+  nextStep: QuoteStep,
+  executionKind: RouteResponse['executionKind'],
+): boolean {
+  if (sameTokenAddress(outputToken, inputTokenForStep(nextStep))) return true;
+  return (
+    executionKind === 'universalRouter' &&
+    nextStep.type === 'bridge' &&
+    isEngineNativeToken(nextStep.asset) &&
+    isTrustedWrappedNativeAddress(nextStep.chain, outputToken)
+  );
 }
 
 function sameRequestedToken(

--- a/src/features/routeSecurity/validateWarpRoute.ts
+++ b/src/features/routeSecurity/validateWarpRoute.ts
@@ -7,6 +7,7 @@ import {
 } from '@hyperlane-xyz/sdk';
 
 import type { ChainDiscovery, QuoteBridgeStep, RouteApproval, RouteResponse } from '../api/types';
+import { isTrustedWrappedNativeAddress } from '../tokens/wrappedNative';
 import {
   getRegistryWarpRoute,
   type RegistryWarpRoute,
@@ -97,6 +98,10 @@ export function validateWarpRoute(
           : nextStep?.type === 'swap'
             ? nextStep.tokenIn
             : undefined,
+      allowWrappedSource:
+        route.executionKind === 'universalRouter' && previousStep?.type === 'swap',
+      allowWrappedDestination:
+        route.executionKind === 'universalRouter' && nextStep?.type === 'swap',
       validateApproval: isBridgeOnly,
     });
     if (!validation.valid) return validation;
@@ -112,6 +117,8 @@ function validateBridgeStep(
   options: {
     sourceToken: string | undefined;
     destinationToken: string | undefined;
+    allowWrappedSource: boolean;
+    allowWrappedDestination: boolean;
     validateApproval: boolean;
   },
 ): WarpRouteValidationResult {
@@ -150,6 +157,8 @@ function validateBridgeStep(
     registryRoute,
     destinationChainName,
     options.destinationToken,
+    step.destChain,
+    options.allowWrappedDestination,
   );
   if (!origin || !destination) {
     return { valid: false, reason: 'Warp route endpoint missing from registry', warpRouteId };
@@ -157,13 +166,18 @@ function validateBridgeStep(
 
   if (
     options.sourceToken &&
-    !sameTokenAddress(options.sourceToken, expectedDiscoveryToken(origin))
+    !matchesDiscoveryToken(options.sourceToken, origin, step.chain, options.allowWrappedSource)
   ) {
     return { valid: false, reason: 'Source token does not match registry route', warpRouteId };
   }
   if (
     options.destinationToken &&
-    !sameTokenAddress(options.destinationToken, expectedDiscoveryToken(destination))
+    !matchesDiscoveryToken(
+      options.destinationToken,
+      destination,
+      step.destChain,
+      options.allowWrappedDestination,
+    )
   ) {
     return { valid: false, reason: 'Destination token does not match registry route', warpRouteId };
   }
@@ -237,11 +251,29 @@ function destinationTokenForContext(
   route: RegistryWarpRoute,
   chainName: string,
   dstToken: string | undefined,
+  chainId: number,
+  allowWrappedNative: boolean,
 ): RegistryWarpRouteToken | undefined {
   const candidates = tokensForChain(route, chainName);
   if (candidates.length <= 1) return candidates[0];
   if (!dstToken) return undefined;
-  return candidates.find((token) => sameTokenAddress(dstToken, expectedDiscoveryToken(token)));
+  return candidates.find((token) =>
+    matchesDiscoveryToken(dstToken, token, chainId, allowWrappedNative),
+  );
+}
+
+function matchesDiscoveryToken(
+  address: string,
+  token: RegistryWarpRouteToken,
+  chainId: number,
+  allowWrappedNative: boolean,
+): boolean {
+  if (sameTokenAddress(address, expectedDiscoveryToken(token))) return true;
+  return (
+    allowWrappedNative &&
+    isNativeWarpStandard(token.standard) &&
+    isTrustedWrappedNativeAddress(chainId, address)
+  );
 }
 
 function expectedSpendToken(token: RegistryWarpRouteToken): string {

--- a/src/features/tokens/wrappedNative.test.ts
+++ b/src/features/tokens/wrappedNative.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  isTrustedWrappedNativeAddress,
   trustedWrappedNativeAddressForToken,
   validateWrappedNativeMetadata,
   WRAPPED_NATIVE_TOKEN_BY_CHAIN_ID,
@@ -25,6 +26,16 @@ describe('trustedWrappedNativeAddressForToken', () => {
         isNative: false,
       }),
     ).toBeUndefined();
+  });
+
+  test('matches only the configured wrapped native address for a chain', () => {
+    expect(isTrustedWrappedNativeAddress(56, '0xbb4cdb9cbd36b01bd1cbaebf2de08d9173bc095c')).toBe(
+      true,
+    );
+    expect(isTrustedWrappedNativeAddress(8453, WRAPPED_NATIVE_TOKEN_BY_CHAIN_ID[56])).toBe(false);
+    expect(isTrustedWrappedNativeAddress(8453, '0x0000000000000000000000000000000000000000')).toBe(
+      false,
+    );
   });
 
   test('rejects native metadata when engine wrappedAddress differs from the local trusted address', () => {

--- a/src/features/tokens/wrappedNative.ts
+++ b/src/features/tokens/wrappedNative.ts
@@ -20,6 +20,11 @@ export function trustedWrappedNativeAddress(chainId: number | null | undefined) 
   return chainId == null ? undefined : WRAPPED_NATIVE_TOKEN_BY_CHAIN_ID[chainId];
 }
 
+export function isTrustedWrappedNativeAddress(chainId: number, address: string): boolean {
+  const trustedAddress = trustedWrappedNativeAddress(chainId);
+  return !!trustedAddress && tokenKey(chainId, address) === tokenKey(chainId, trustedAddress);
+}
+
 export function trustedWrappedNativeAddressForToken(
   token: Pick<UiToken, 'chainId' | 'address' | 'isNative'> | null | undefined,
 ) {
@@ -51,9 +56,7 @@ export function validateWrappedNativeMetadata(
   const trustedWrappedAddress = trustedWrappedNativeAddress(token.chainId);
   if (!trustedWrappedAddress) return { valid: true };
   if (!token.wrappedAddress) return { valid: true, trustedWrappedAddress };
-  if (
-    tokenKey(token.chainId, token.wrappedAddress) !== tokenKey(token.chainId, trustedWrappedAddress)
-  ) {
+  if (!isTrustedWrappedNativeAddress(token.chainId, token.wrappedAddress)) {
     return {
       valid: false,
       reason: 'Native token wrappedAddress does not match trusted local wrapped native',


### PR DESCRIPTION
## Summary

- accept locally trusted wrapped-native tokens at Universal Router swap boundaries around native Warp Routes
- preserve native-sentinel, registry-router, and non-native token validation
- add regression coverage for trusted and untrusted wrappers, execution mode, bridge asset, and router binding

## Checks

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`