### PR TITLE
fix: temporarily enable SOON withdrawals

### DIFF
--- a/src/consts/chains.ts
+++ b/src/consts/chains.ts
@@ -30,6 +30,8 @@ export const chains: ChainMap<ChainMetadata & { mailbox?: Address }> = {
   soon: {
     ...soon,
     mailbox: soonAddresses.mailbox,
+    // Temporarily restore withdrawals during the extended deprecation window.
+    availability: { status: ChainStatus.Live },
   },
   sonicsvm: {
     ...sonicsvm,


### PR DESCRIPTION
## Summary

- Override SOON availability to `live` on Nexus during the extended deprecation window.
- Restore SOON tokens and routes in the chain/token pickers and transfer validation.
- Preserve disabled-chain handling for every other deprecated chain.
- Declare the `long` runtime dependency imported by the pinned Cosmos Kit wallet packages so Vercel can resolve clean Nexus installs.

## Context

Registry `25.4.0` marks SOON as `disabled` with reason `deprecated`. Nexus honors that metadata throughout route selection and validation, which removed the withdrawal path even though the route configs and router service remain available.

This local, chain-specific override keeps withdrawals available through the August 28 extension. It should be removed after the window closes.

The first generic Vercel preview also exposed an existing strict dependency-resolution issue in the Nexus dependency set: five pinned Cosmos Kit packages import `long` without declaring it. Making the app dependency explicit fixes those Turbopack module-resolution failures.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test src/features/chains/hooks.test.ts src/features/transfer/engine/useFormInitialValues.test.ts src/features/transfer/engine/validate.test.ts` — 12 tests passed
- `pnpm lint` — 0 errors; 2 existing E2E mock warnings
- Live router verification: SOON chain and 15 bridge tokens are discoverable; a funded SOON to Solana SOL quote returned an executable SDK Warp transaction.