### PR TITLE
fix: wrap long recipient addresses

### DIFF
--- a/src/features/wallet/RecipientConfirmationModal.tsx
+++ b/src/features/wallet/RecipientConfirmationModal.tsx
@@ -31,7 +31,9 @@ export function RecipientConfirmationModal({
       <p className="text-center text-sm">
         The recipient address has no funds on {dst}. Is this address correct?
       </p>
-      <p className="rounded-lg bg-primary-500/5 p-2 text-center text-sm">{recipient}</p>
+      <p className="w-full min-w-0 break-all rounded-lg bg-primary-500/5 p-2 text-center text-sm">
+        {recipient}
+      </p>
       <div className="flex items-center justify-center gap-12">
         <SolidButton onClick={close} color="gray" className="min-w-24 px-4 py-1">
           Cancel


### PR DESCRIPTION
## Summary

- Constrain recipient addresses to the confirmation modal width.
- Allow character-level wrapping for long, unbroken addresses such as Aleo accounts.
- Keep the full address visible and selectable before the user confirms a fresh recipient.

## Root cause

The address paragraph was a centered flex child with its default intrinsic minimum width. Long Aleo addresses contain no natural break points, so the element overflowed both sides of the modal and hid the beginning of the address.

## Verification

- `pnpm typecheck`
- `pnpm test` — 304 tests passed
- `pnpm exec oxfmt --check src/features/wallet/RecipientConfirmationModal.tsx`
- `pnpm lint` — 0 errors; 2 existing E2E mock warnings