### PR TITLE
ci: migrate workflows to Depot CI

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -60,13 +60,13 @@ jobs:
     # TypeScript validation runs inside `next build`. Keep this dependent job
     # until the required `typecheck` branch-protection context is removed.
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Confirm build typechecked successfully
         run: echo "TypeScript validation completed in the required build job"
 
   format:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -100,7 +100,7 @@ jobs:
           fi
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -128,7 +128,7 @@ jobs:
         run: pnpm run lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -162,13 +162,13 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'merge_group' ||
       github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/e2e.yml
+    uses: ./.depot/workflows/e2e.yml
     secrets: inherit
 
   # Fast wallet-connected E2E subset, gates every PR.
   e2e-smoke:
     needs: [build]
-    uses: ./.github/workflows/e2e-smoke.yml
+    uses: ./.depot/workflows/e2e-smoke.yml
     secrets: inherit
 
   # Full wallet-connected E2E matrix (chromium/firefox/webkit). Main-only so
@@ -179,5 +179,5 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'merge_group' ||
       github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/e2e-wallet-full.yml
+    uses: ./.depot/workflows/e2e-wallet-full.yml
     secrets: inherit

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+  # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
+  WALLET_CONNECT_ID_CACHE_VERSION: v1
 
 jobs:
   build:
@@ -49,7 +51,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         run: pnpm run build

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+env:
+  NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+
 jobs:
   build:
     runs-on: depot-ubuntu-24.04
@@ -46,7 +49,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         run: pnpm run build

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         run: pnpm run build
@@ -63,13 +63,13 @@ jobs:
     # TypeScript validation runs inside `next build`. Keep this dependent job
     # until the required `typecheck` branch-protection context is removed.
     needs: [build]
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Confirm build typechecked successfully
         run: echo "TypeScript validation completed in the required build job"
 
   format:
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -103,7 +103,7 @@ jobs:
           fi
 
   lint:
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -131,7 +131,7 @@ jobs:
         run: pnpm run lint
 
   test:
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v4-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-build-v4-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-
 
       - name: build
         run: pnpm run build

--- a/.depot/workflows/e2e-smoke.yml
+++ b/.depot/workflows/e2e-smoke.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   e2e-smoke:
     timeout-minutes: 10
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'

--- a/.depot/workflows/e2e-smoke.yml
+++ b/.depot/workflows/e2e-smoke.yml
@@ -1,7 +1,7 @@
 name: e2e-smoke
 
 # Fast subset of the wallet-connected E2E suite. Runs on every PR as a gate.
-# The full wallet E2E matrix runs from .github/workflows/e2e-wallet-full.yml.
+# The full wallet E2E matrix runs from .depot/workflows/e2e-wallet-full.yml.
 
 on:
   workflow_call:
@@ -10,7 +10,7 @@ on:
 jobs:
   e2e-smoke:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/.depot/workflows/e2e-smoke.yml
+++ b/.depot/workflows/e2e-smoke.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v4-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ github.sha }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'

--- a/.depot/workflows/e2e-smoke.yml
+++ b/.depot/workflows/e2e-smoke.yml
@@ -7,6 +7,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+env:
+  NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+
 jobs:
   e2e-smoke:
     timeout-minutes: 10
@@ -35,10 +38,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore build cache
+        id: build-cache
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+
+      - name: Build on cache miss
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: pnpm run build
+        env:
+          NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_ID }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.depot/workflows/e2e-smoke.yml
+++ b/.depot/workflows/e2e-smoke.yml
@@ -9,6 +9,8 @@ on:
 
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+  # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
+  WALLET_CONNECT_ID_CACHE_VERSION: v1
 
 jobs:
   e2e-smoke:
@@ -42,7 +44,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'

--- a/.depot/workflows/e2e-wallet-full.yml
+++ b/.depot/workflows/e2e-wallet-full.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v4-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ github.sha }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -100,6 +100,11 @@ jobs:
     env:
       E2E_SLACK_WEBHOOK: ${{ secrets.E2E_SLACK_WEBHOOK }}
     steps:
+      - name: Capture Depot job URL
+        if: ${{ env.E2E_SLACK_WEBHOOK != '' }}
+        id: depot-job
+        run: echo "url=$DEPOT_JOB_URL" >> "$GITHUB_OUTPUT"
+
       - name: Notify Slack on e2e-wallet failure
         if: ${{ env.E2E_SLACK_WEBHOOK != '' }}
         uses: slackapi/slack-github-action@v3
@@ -112,4 +117,4 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: ":alert: *Warp UI e2e-wallet full matrix failed*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run #${{ github.run_number }}> on `${{ github.ref_name }}` @ ${{ github.sha }}"
+                  text: ":alert: *Warp UI e2e-wallet full matrix failed*\n<${{ steps.depot-job.outputs.url }}|View Depot job> on `${{ github.ref_name }}` @ ${{ github.sha }}"

--- a/.depot/workflows/e2e-wallet-full.yml
+++ b/.depot/workflows/e2e-wallet-full.yml
@@ -10,6 +10,8 @@ on:
 
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+  # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
+  WALLET_CONNECT_ID_CACHE_VERSION: v1
 
 jobs:
   e2e-wallet:
@@ -52,7 +54,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'

--- a/.depot/workflows/e2e-wallet-full.yml
+++ b/.depot/workflows/e2e-wallet-full.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   e2e-wallet:
     timeout-minutes: 25
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       fail-fast: false
       matrix:
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -94,7 +94,7 @@ jobs:
   notify-failure:
     if: ${{ always() && needs.e2e-wallet.result == 'failure' }}
     needs: [e2e-wallet]
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Notify Slack on e2e-wallet failure
         uses: slackapi/slack-github-action@v3

--- a/.depot/workflows/e2e-wallet-full.yml
+++ b/.depot/workflows/e2e-wallet-full.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   e2e-wallet:
     timeout-minutes: 25
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -84,7 +84,7 @@ jobs:
   notify-failure:
     if: ${{ always() && needs.e2e-wallet.result == 'failure' }}
     needs: [e2e-wallet]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Notify Slack on e2e-wallet failure
         uses: slackapi/slack-github-action@v3

--- a/.depot/workflows/e2e-wallet-full.yml
+++ b/.depot/workflows/e2e-wallet-full.yml
@@ -97,11 +97,14 @@ jobs:
     if: ${{ always() && needs.e2e-wallet.result == 'failure' }}
     needs: [e2e-wallet]
     runs-on: depot-ubuntu-24.04-4
+    env:
+      E2E_SLACK_WEBHOOK: ${{ secrets.E2E_SLACK_WEBHOOK }}
     steps:
       - name: Notify Slack on e2e-wallet failure
+        if: ${{ env.E2E_SLACK_WEBHOOK != '' }}
         uses: slackapi/slack-github-action@v3
         with:
-          webhook: ${{ secrets.E2E_SLACK_WEBHOOK }}
+          webhook: ${{ env.E2E_SLACK_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
             text: ":alert: Warp UI full e2e-wallet matrix failed — see workflow run for details"

--- a/.depot/workflows/e2e-wallet-full.yml
+++ b/.depot/workflows/e2e-wallet-full.yml
@@ -8,6 +8,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+env:
+  NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+
 jobs:
   e2e-wallet:
     timeout-minutes: 25
@@ -45,10 +48,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore build cache
+        id: build-cache
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+
+      - name: Build on cache miss
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: pnpm run build
+        env:
+          NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_ID }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+env:
+  NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+
 jobs:
   build:
     # Only build when triggered standalone (workflow_dispatch).
@@ -38,7 +41,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -80,10 +83,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore build cache
+        id: build-cache
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+
+      - name: Build on cache miss
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: pnpm run build
+        env:
+          NEXT_PUBLIC_WALLET_CONNECT_ID: ${{ secrets.NEXT_PUBLIC_WALLET_CONNECT_ID }}
 
       - name: Get Playwright version
         id: pw-version

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -6,6 +6,8 @@ on:
 
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+  # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
+  WALLET_CONNECT_ID_CACHE_VERSION: v1
 
 jobs:
   build:
@@ -41,7 +43,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -87,7 +89,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -9,7 +9,7 @@ jobs:
     # Only build when triggered standalone (workflow_dispatch).
     # When called from ci.yml (workflow_call), the build cache is already populated.
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 20
     needs: [build]
     if: ${{ !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -117,7 +117,7 @@ jobs:
   merge-reports:
     if: ${{ !cancelled() }}
     needs: [e2e]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -12,7 +12,7 @@ jobs:
     # Only build when triggered standalone (workflow_dispatch).
     # When called from ci.yml (workflow_call), the build cache is already populated.
     if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 20
     needs: [build]
     if: ${{ !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') }}
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +87,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -127,7 +127,7 @@ jobs:
   merge-reports:
     if: ${{ !cancelled() }}
     needs: [e2e]
-    runs-on: depot-ubuntu-24.04
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -43,7 +43,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v4-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-build-v4-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-
 
       - name: build
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -89,7 +91,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .next/
-          key: ${{ runner.os }}-nextjs-build-v3-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ hashFiles('src/**', 'pnpm-lock.yaml', 'next.config.js', 'tsconfig.json') }}
+          key: ${{ runner.os }}-nextjs-build-v4-${{ env.NEXT_PUBLIC_ROUTER_API_URL }}-${{ env.WALLET_CONNECT_ID_CACHE_VERSION }}-${{ github.sha }}
 
       - name: Build on cache miss
         if: steps.build-cache.outputs.cache-hit != 'true'

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ NEXT_PUBLIC_WALLET_CONNECT_ID=12345678901234567890123456789012
 NEXT_PUBLIC_RPC_OVERRIDES='{"chain1":{"http":"https://..."}}'
 
 # Transfer — Universal Router Engine
-NEXT_PUBLIC_ROUTER_API_URL=https://router.services.hyperlane.xyz
+NEXT_PUBLIC_ROUTER_API_URL=https://hyperswaps-api.hyperlane.xyz
 NEXT_PUBLIC_CCS_URL=https://offchain-lookup.services.hyperlane.xyz/callCommitments
 NEXT_PUBLIC_PERMIT2_EXPIRATION_SECONDS=31536000
 NEXT_PUBLIC_DEFAULT_SLIPPAGE_BPS=100

--- a/.github/workflows/ci-forks.yml
+++ b/.github/workflows/ci-forks.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -56,6 +58,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -81,6 +85,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -99,6 +105,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/ci-forks.yml
+++ b/.github/workflows/ci-forks.yml
@@ -1,0 +1,112 @@
+name: fork-ci
+
+on:
+  pull_request:
+    branches: [main, nautilus, nexus, injective, trump, ousdt]
+
+permissions:
+  contents: read
+
+env:
+  NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
+
+jobs:
+  build:
+    name: ${{ github.event.pull_request.head.repo.fork && 'ci / build' || 'fork-ci-disabled / build' }}
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: |
+          pnpm install --frozen-lockfile
+          CHANGES=$(git status -s)
+          if [[ -n $CHANGES ]]; then
+            echo "Changes found: $CHANGES"
+            git diff
+            exit 1
+          fi
+
+      # Fork pull_request workflows cannot access repository secrets. The app
+      # supports an empty WalletConnect ID for build-only validation.
+      - name: Build
+        run: pnpm run build
+
+      - name: Check bundle size
+        run: pnpm check:bundle
+
+  typecheck:
+    name: ${{ github.event.pull_request.head.repo.fork && 'ci / typecheck' || 'fork-ci-disabled / typecheck' }}
+    if: ${{ github.event.pull_request.head.repo.fork && needs.build.result == 'success' }}
+    needs: [build]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Confirm build typechecked successfully
+        run: echo "TypeScript validation completed in the required build job"
+
+  format:
+    name: ${{ github.event.pull_request.head.repo.fork && 'ci / format' || 'fork-ci-disabled / format' }}
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        run: |
+          pnpm run format
+          CHANGES=$(git status -s)
+          if [[ -n $CHANGES ]]; then
+            echo "Changes found: $CHANGES"
+            git diff
+            exit 1
+          fi
+
+  lint:
+    name: ${{ github.event.pull_request.head.repo.fork && 'ci / lint' || 'fork-ci-disabled / lint' }}
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+  test:
+    name: ${{ github.event.pull_request.head.repo.fork && 'ci / test' || 'fork-ci-disabled / test' }}
+    if: ${{ github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm run test

--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -16,7 +16,7 @@ const explorerApiUrl =
   process.env.NEXT_PUBLIC_EXPLORER_API_URL || 'https://explorer4.hasura.app/v1/graphql';
 const relayApiUrl = process.env.NEXT_PUBLIC_RELAY_API_URL || undefined;
 const routerApiUrl =
-  process.env.NEXT_PUBLIC_ROUTER_API_URL || 'https://router.services.hyperlane.xyz';
+  process.env.NEXT_PUBLIC_ROUTER_API_URL || 'https://hyperswaps-api.hyperlane.xyz';
 // CCS lives at the `/callCommitments` mount of the shared offchain-lookup
 // service. UI posts engine-emitted calldata to `/calldata` under this mount.
 const ccsUrl =


### PR DESCRIPTION
## Summary

- move the main CI workflow and all three reusable E2E workflows from `.github/workflows/` to `.depot/workflows/`
- run every migrated job on pinned Depot Ubuntu 24.04 sandboxes sized to match this public repo's GitHub-hosted runners (4 vCPU / 16 GB)
- preserve triggers, branch filters, dependencies, matrices, caches, artifacts, notifications, and required check names
- preserve required CI for fork PRs with an unprivileged GitHub Actions fallback
- build the Next.js app explicitly on E2E cache misses and key shared build caches by exact commit plus embedded config versions
- build and default the app to the current URE Cloudflare endpoint, `https://hyperswaps-api.hyperlane.xyz`; the retired `router.services.hyperlane.xyz` endpoint now resolves to `192.0.2.1`
- keep GitHub-native Claude review, branch-sync PR creation, and dependency-update automation in GitHub Actions

## Controlled benchmark

The benchmark used the same application tree and one identical serial workload on both providers: frozen install, format/diff check, lint, 403 unit tests, and production build. Both cold runs used the fresh `wui-depot-migration-20260827-v2` cache key and logged cache misses; both warm runs logged primary-key cache hits. The runners were resource-equivalent: public-repo GitHub `ubuntu-24.04` and Depot `depot-ubuntu-24.04-4` both provide 4 vCPU / 16 GB. Durations are workflow start-to-finish.

| Cache state | GitHub Actions | Depot CI | Depot speedup |
| --- | ---: | ---: | ---: |
| Cold | 2m53s | 1m39s | 1.75x |
| Warm | 1m53s | 0m59s | 1.92x |

The earlier `0.64x` cold result was invalid: the default Depot sandbox had 2 vCPU / 8 GB while this public repo's GitHub runner had 4 vCPU / 16 GB. Next.js exposed the mismatch directly by using one worker on Depot versus three on GitHub. The private reference repositories use 2 vCPU / 8 GB GitHub runners, so their default Depot label was equivalent; WUI required the `-4` label.

Exact corrected runs:

- GitHub Actions cold: [`33024586966`](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/actions/runs/33024586966)
- Depot CI cold: [`4ccs8n5tp9`](https://depot.dev/orgs/ptcjppsfhw/workflows/4ccs8n5tp9)
- GitHub Actions warm: [`33024757128`](https://github.com/hyperlane-xyz/hyperlane-warp-ui-template/actions/runs/33024757128)
- Depot CI warm: [`htfc17hg17`](https://depot.dev/orgs/ptcjppsfhw/workflows/htfc17hg17)

Benchmark branches were based on the same source tree as this PR: `pbio/gha-ci-benchmark` and `pbio/depot-ci-benchmark`.

## Validation

At exact head `9d9bccc6`:

- current-head run [`3fjv2dlxk0`](https://depot.dev/orgs/ptcjppsfhw/workflows/3fjv2dlxk0) passed every executed job: format, lint, 403 tests, typecheck, both 33-test E2E shards, 5-test smoke gate, and merged reports
- the most recent full migration run [`p5qv137ndc`](https://depot.dev/orgs/ptcjppsfhw/workflows/p5qv137ndc) also passed build and the Chromium and Firefox wallet matrices; those path-filtered jobs intentionally skipped on the checkout-only follow-up
- fork-only GitHub Actions build, typecheck, format, lint, and test jobs use read-only permissions and disable checkout credential persistence
- all five shared `.next/` consumer keys require the exact full commit SHA; producers may restore only a config-scoped prefix as a build warm start
- Slack failure alerts capture and link to `DEPOT_JOB_URL`
- `main`, `nautilus`, `nexus`, `injective`, `trump`, and `ousdt` use strict exact-name `ci / ...` required checks with no app pin, allowing Depot or the fork fallback to satisfy them
- the application fallback and `.env.example` use `https://hyperswaps-api.hyperlane.xyz`
- local production build, 403 tests, lint, actionlint, oxfmt, and `git diff --check` passed
- branch is zero commits behind current `origin/main`; no rebase required

## Remaining cutover gate

- An organization owner must accept the pending Depot Code Access permission update: https://github.com/organizations/hyperlane-xyz/settings/installations/110670256
- Then import the repository-scoped `E2E_SLACK_WEBHOOK`. The Slack notification step safely skips when no webhook is configured, so this does not block current checks, but the secret must be imported before merge to preserve failure notifications.
