### PR TITLE
fix(routeSecurity): support Starknet origin approvals

### DIFF
--- a/src/features/routeSecurity/sdk.ts
+++ b/src/features/routeSecurity/sdk.ts
@@ -3,7 +3,7 @@ import { decodeFunctionData, erc20Abi, type Hex } from 'viem';
 
 import type { QuoteBridgeStep, RouteResponse, RouteTx } from '../api/types';
 import type { RouteSecurityValidationResult } from './types';
-import { firstBridge, sameTokenAddress } from './utils';
+import { firstBridge, isEngineNativeToken, sameTokenAddress } from './utils';
 
 const SDK_APPROVAL_CATEGORY = 'approval';
 const SDK_REVOKE_CATEGORY = 'revoke';
@@ -13,6 +13,7 @@ export function validateSdkRouteTx(
   route: RouteResponse,
   tx: Extract<RouteTx, { protocol: string }>,
   srcProtocol: ProtocolType,
+  nativeTokenAddress?: string,
 ): RouteSecurityValidationResult {
   if (route.executionKind !== 'sdkWarp') {
     return { valid: false, reason: 'SDK transaction shape is only supported for sdkWarp routes' };
@@ -33,7 +34,7 @@ export function validateSdkRouteTx(
   }
 
   if (tx.category === SDK_APPROVAL_CATEGORY || tx.category === SDK_REVOKE_CATEGORY) {
-    return validateSdkApprovalTx(route, tx, srcProtocol);
+    return validateSdkApprovalTx(route, tx, srcProtocol, nativeTokenAddress);
   }
 
   if (tx.category !== SDK_TRANSFER_CATEGORY) {
@@ -55,12 +56,13 @@ function validateSdkApprovalTx(
   route: RouteResponse,
   tx: Extract<RouteTx, { protocol: string }>,
   srcProtocol: ProtocolType,
+  nativeTokenAddress?: string,
 ): RouteSecurityValidationResult {
   const bridge = firstBridge(route);
   if (!bridge) return { valid: false, reason: 'SDK approval transaction missing bridge step' };
 
   if (srcProtocol === ProtocolType.Starknet) {
-    return validateStarknetApprovalTx(bridge, tx);
+    return validateStarknetApprovalTx(bridge, tx, nativeTokenAddress);
   }
 
   const approval = decodeEvmApproval(tx.transaction);
@@ -90,13 +92,11 @@ function validateSdkApprovalTx(
   return { valid: true };
 }
 
-// Starknet routes emit two approvals: the bridged token (spent by the router)
-// and the IGP gas-fee token (also pulled by the router). Both target the same
-// warp router as spender. The engine encodes them as native Starknet calls
-// (`contractAddress`/`entrypoint`/`calldata`), not EVM `to`/`data`.
+// Starknet uses native calls and separately approves the bridge asset and native IGP token.
 function validateStarknetApprovalTx(
   bridge: QuoteBridgeStep,
   tx: Extract<RouteTx, { protocol: string }>,
+  nativeTokenAddress?: string,
 ): RouteSecurityValidationResult {
   const approval = decodeStarknetApproval(tx.transaction);
   if (!approval) return { valid: false, reason: 'SDK approval transaction is not supported' };
@@ -105,25 +105,31 @@ function validateStarknetApprovalTx(
     return { valid: false, reason: 'SDK approval spender does not match bridge router' };
   }
 
+  const assetToken = isEngineNativeToken(bridge.asset) ? nativeTokenAddress : bridge.asset;
+  const resolvedFeeToken = isEngineNativeToken(bridge.fee.igpToken)
+    ? nativeTokenAddress
+    : bridge.fee.igpToken;
+  const feeToken = [assetToken, nativeTokenAddress].find(
+    (token) => token && resolvedFeeToken && sameFelt(token, resolvedFeeToken),
+  );
+  const expectedApprovals: Array<[string | undefined, string]> = [
+    [assetToken, bridge.amountIn],
+    [feeToken, bridge.fee.igpAmount],
+  ];
+  const allowedAmounts = expectedApprovals.flatMap(([token, amount]) =>
+    token && sameFelt(approval.token, token) ? [parseAmount(amount)] : [],
+  );
+  if (!allowedAmounts.length) {
+    return { valid: false, reason: 'SDK approval token does not match route token' };
+  }
+
   if (tx.category === SDK_REVOKE_CATEGORY) {
     if (approval.amount !== 0n) return { valid: false, reason: 'SDK revoke amount must be zero' };
     return { valid: true };
   }
 
-  if (sameFelt(approval.token, bridge.asset)) {
-    const amountIn = parseAmount(bridge.amountIn);
-    if (amountIn == null || approval.amount !== amountIn) {
-      return { valid: false, reason: 'SDK approval amount does not match route input amount' };
-    }
-    return { valid: true };
-  }
-
-  const igpAmount = parseAmount(bridge.fee.igpAmount);
-  if (igpAmount == null || igpAmount === 0n) {
-    return { valid: false, reason: 'SDK approval token does not match route input token' };
-  }
-  if (approval.amount !== igpAmount) {
-    return { valid: false, reason: 'SDK approval amount does not match route fee amount' };
+  if (!allowedAmounts.includes(approval.amount)) {
+    return { valid: false, reason: 'SDK approval amount does not match route amount' };
   }
   return { valid: true };
 }

--- a/src/features/routeSecurity/sdk.ts
+++ b/src/features/routeSecurity/sdk.ts
@@ -1,7 +1,7 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { decodeFunctionData, erc20Abi, type Hex } from 'viem';
 
-import type { RouteResponse, RouteTx } from '../api/types';
+import type { QuoteBridgeStep, RouteResponse, RouteTx } from '../api/types';
 import type { RouteSecurityValidationResult } from './types';
 import { firstBridge, sameTokenAddress } from './utils';
 
@@ -33,7 +33,7 @@ export function validateSdkRouteTx(
   }
 
   if (tx.category === SDK_APPROVAL_CATEGORY || tx.category === SDK_REVOKE_CATEGORY) {
-    return validateSdkApprovalTx(route, tx);
+    return validateSdkApprovalTx(route, tx, srcProtocol);
   }
 
   if (tx.category !== SDK_TRANSFER_CATEGORY) {
@@ -54,9 +54,14 @@ export function validateSdkRouteTx(
 function validateSdkApprovalTx(
   route: RouteResponse,
   tx: Extract<RouteTx, { protocol: string }>,
+  srcProtocol: ProtocolType,
 ): RouteSecurityValidationResult {
   const bridge = firstBridge(route);
   if (!bridge) return { valid: false, reason: 'SDK approval transaction missing bridge step' };
+
+  if (srcProtocol === ProtocolType.Starknet) {
+    return validateStarknetApprovalTx(bridge, tx);
+  }
 
   const approval = decodeEvmApproval(tx.transaction);
   if (!approval) return { valid: false, reason: 'SDK approval transaction is not supported' };
@@ -83,6 +88,78 @@ function validateSdkApprovalTx(
   }
 
   return { valid: true };
+}
+
+// Starknet routes emit two approvals: the bridged token (spent by the router)
+// and the IGP gas-fee token (also pulled by the router). Both target the same
+// warp router as spender. The engine encodes them as native Starknet calls
+// (`contractAddress`/`entrypoint`/`calldata`), not EVM `to`/`data`.
+function validateStarknetApprovalTx(
+  bridge: QuoteBridgeStep,
+  tx: Extract<RouteTx, { protocol: string }>,
+): RouteSecurityValidationResult {
+  const approval = decodeStarknetApproval(tx.transaction);
+  if (!approval) return { valid: false, reason: 'SDK approval transaction is not supported' };
+
+  if (!sameFelt(approval.spender, bridge.router)) {
+    return { valid: false, reason: 'SDK approval spender does not match bridge router' };
+  }
+
+  if (tx.category === SDK_REVOKE_CATEGORY) {
+    if (approval.amount !== 0n) return { valid: false, reason: 'SDK revoke amount must be zero' };
+    return { valid: true };
+  }
+
+  if (sameFelt(approval.token, bridge.asset)) {
+    const amountIn = parseAmount(bridge.amountIn);
+    if (amountIn == null || approval.amount !== amountIn) {
+      return { valid: false, reason: 'SDK approval amount does not match route input amount' };
+    }
+    return { valid: true };
+  }
+
+  const igpAmount = parseAmount(bridge.fee.igpAmount);
+  if (igpAmount == null || igpAmount === 0n) {
+    return { valid: false, reason: 'SDK approval token does not match route input token' };
+  }
+  if (approval.amount !== igpAmount) {
+    return { valid: false, reason: 'SDK approval amount does not match route fee amount' };
+  }
+  return { valid: true };
+}
+
+function decodeStarknetApproval(
+  transaction: unknown,
+): { token: string; spender: string; amount: bigint } | undefined {
+  if (!isRecord(transaction)) return undefined;
+  const { contractAddress, entrypoint, calldata } = transaction;
+  if (typeof contractAddress !== 'string' || entrypoint !== 'approve') return undefined;
+  if (!Array.isArray(calldata) || calldata.length < 3) return undefined;
+  const [spender, amountLow, amountHigh] = calldata;
+  if (
+    typeof spender !== 'string' ||
+    typeof amountLow !== 'string' ||
+    typeof amountHigh !== 'string'
+  ) {
+    return undefined;
+  }
+  let amount: bigint;
+  try {
+    amount = BigInt(amountLow) + (BigInt(amountHigh) << 128n);
+  } catch {
+    return undefined;
+  }
+  return { token: contractAddress, spender, amount };
+}
+
+// Starknet felts compare by numeric value, independent of hex/decimal encoding
+// or leading-zero padding.
+function sameFelt(left: string, right: string): boolean {
+  try {
+    return BigInt(left) === BigInt(right);
+  } catch {
+    return false;
+  }
 }
 
 function decodeEvmApproval(

--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -39,7 +39,11 @@ const chainMetadata = {
   ethereum: { chainId: ETH, domainId: ETH },
   base: { chainId: BASE, domainId: BASE },
   solanamainnet: { chainId: SOL, domainId: SOL },
-  starknet: { chainId: STARKNET, domainId: STARKNET },
+  starknet: {
+    chainId: STARKNET,
+    domainId: STARKNET,
+    nativeToken: { denom: STARKNET_FEE_TOKEN },
+  },
 } as unknown as ChainMap<ChainMetadata>;
 
 const chains = [
@@ -553,9 +557,43 @@ describe('validateRouteSecurity', () => {
     expect(validateRouteSecurity(route, starknetContext())).toEqual({ valid: true });
   });
 
-  test('accepts a Starknet sdk warp route with bridge-asset and gas-fee approvals', () => {
-    expect(validateRouteSecurity(starknetApprovalRoute(), starknetContext())).toEqual({
-      valid: true,
+  test.each([{}, { feeToken: STARKNET_TOKEN, igpToken: STARKNET_TOKEN }])(
+    'accepts a Starknet sdk warp route with bridge-asset and gas-fee approvals',
+    (args) => {
+      expect(validateRouteSecurity(starknetApprovalRoute(args), starknetContext())).toEqual({
+        valid: true,
+      });
+    },
+  );
+
+  test('accepts a Starknet native-origin approval using the chain native token contract', () => {
+    expect(
+      validateRouteSecurity(
+        starknetApprovalRoute({ asset: NATIVE, assetToken: STARKNET_FEE_TOKEN }),
+        starknetContext({ registryWarpRoutes: starknetNativeRoutes(), srcToken: NATIVE }),
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  test('rejects a Starknet fee approval for an unrelated token', () => {
+    const route = starknetApprovalRoute({ feeToken: BAD });
+    if (route.steps[0].type !== 'bridge') throw new Error('expected bridge step');
+    route.steps[0].fee.igpToken = BAD;
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK approval token does not match route token',
+    });
+  });
+
+  test('rejects a Starknet revoke for an unrelated token', () => {
+    const route = starknetApprovalRoute({ assetAmount: 0n, assetToken: BAD });
+    if (!route.txs || !('category' in route.txs[0])) throw new Error('expected SDK tx');
+    route.txs[0].category = 'revoke';
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK approval token does not match route token',
     });
   });
 
@@ -568,23 +606,15 @@ describe('validateRouteSecurity', () => {
     });
   });
 
-  test('rejects a Starknet bridge-asset approval that does not match the input amount', () => {
-    const route = starknetApprovalRoute({ assetAmount: 999n });
-
-    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
-      valid: false,
-      reason: 'SDK approval amount does not match route input amount',
-    });
-  });
-
-  test('rejects a Starknet gas-fee approval that does not match the quoted fee', () => {
-    const route = starknetApprovalRoute({ feeAmount: 1n });
-
-    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
-      valid: false,
-      reason: 'SDK approval amount does not match route fee amount',
-    });
-  });
+  test.each([{ assetAmount: 999n }, { feeAmount: 1n }])(
+    'rejects a Starknet approval with a mismatched amount',
+    (args) => {
+      expect(validateRouteSecurity(starknetApprovalRoute(args), starknetContext())).toMatchObject({
+        valid: false,
+        reason: 'SDK approval amount does not match route amount',
+      });
+    },
+  );
 
   test('accepts SDK warp routes with an SDK approval tx before the transfer tx', () => {
     const route = evmSdkWarpRoute();
@@ -938,13 +968,14 @@ function context(routeOverrides: Partial<RouteSecurityTestContext> = {}) {
   };
 }
 
-function starknetContext() {
+function starknetContext(overrides: Partial<RouteSecurityTestContext> = {}) {
   return context({
     registryWarpRoutes: starknetRoutes(),
     srcChain: STARKNET,
     dstChain: ETH,
     srcToken: STARKNET_TOKEN,
     dstToken: DST_ROUTER,
+    ...overrides,
   });
 }
 
@@ -1268,69 +1299,42 @@ function starknetApprove(
 
 function starknetApprovalRoute(
   args: {
+    asset?: string;
     assetAmount?: bigint;
     assetSpender?: string;
+    assetToken?: string;
     feeAmount?: bigint;
+    feeToken?: string;
+    igpToken?: string;
   } = {},
 ): RouteResponse {
+  const route = starknetSdkWarpRoute();
+  const bridge = route.steps[0];
+  if (bridge.type !== 'bridge' || !route.tx) throw new Error('expected Starknet transfer');
+
   const warpRouteId = 'STRK/test';
   const igpAmount = '5000';
+  bridge.asset = args.asset ?? STARKNET_TOKEN;
+  bridge.fee.igpAmount = igpAmount;
+  bridge.fee.igpToken = args.igpToken ?? NATIVE;
   const txs: NonNullable<RouteResponse['txs']> = [
     starknetApprove(
-      STARKNET_TOKEN,
+      args.assetToken ?? STARKNET_TOKEN,
       args.assetSpender ?? STARKNET_ROUTER,
       args.assetAmount ?? 100n,
       warpRouteId,
     ),
     starknetApprove(
-      STARKNET_FEE_TOKEN,
+      args.feeToken ?? STARKNET_FEE_TOKEN,
       STARKNET_ROUTER,
       args.feeAmount ?? BigInt(igpAmount),
       warpRouteId,
     ),
-    {
-      protocol: ProtocolType.Starknet,
-      type: 'starknet',
-      category: 'transfer',
-      transaction: {
-        contractAddress: STARKNET_ROUTER,
-        entrypoint: 'transfer_remote',
-        calldata: [],
-      },
-      metadata: { warpRouteId },
-    },
+    route.tx,
   ];
-
-  return {
-    steps: [
-      {
-        type: 'bridge',
-        chain: STARKNET,
-        destChain: ETH,
-        asset: STARKNET_TOKEN,
-        router: STARKNET_ROUTER,
-        amountIn: '100',
-        amountOut: '100',
-        bridgeSymbol: 'STRK',
-        warpRouteId,
-        fee: {
-          tokenFee: '0',
-          igpToken: NATIVE,
-          igpAmount,
-          igpIncludedInAmountIn: false,
-          localNativeFee: '0',
-        },
-      },
-    ],
-    output: '100',
-    outputMin: '100',
-    executionKind: 'sdkWarp',
-    connection: { symbol: 'STRK', warpRouteId },
-    gas: { originGas: '0', destGas: '0' },
-    tx: txs[0],
-    txs,
-    approval: null,
-  };
+  route.tx = txs[0];
+  route.txs = txs;
+  return route;
 }
 
 function sealevelUniversalRouterRoute(
@@ -1399,6 +1403,16 @@ function starknetRoutes(): RegistryWarpRouteMap {
       ],
     },
   };
+}
+
+function starknetNativeRoutes(): RegistryWarpRouteMap {
+  const routes = starknetRoutes();
+  routes['strk/test'].tokens[0] = {
+    chainName: 'starknet',
+    addressOrDenom: STARKNET_ROUTER,
+    standard: 'StarknetHypNative',
+  };
+  return routes;
 }
 
 function universalRouterRoutes(): RegistryWarpRouteMap {

--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -23,6 +23,7 @@ const ETH_WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 const BASE_WETH = '0x4200000000000000000000000000000000000006';
 const STARKNET_ROUTER = '0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
 const STARKNET_TOKEN = '0x01a238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
+const STARKNET_FEE_TOKEN = '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
 const SOL_UNIVERSAL_ROUTER_PROGRAM = '2CttnaLkYbNHbaFDFnQ8PMCnzUwTGrKnskBxPM4TRWGp';
 const SOL_ROUTER = 'SolRouter1111111111111111111111111111111111';
 const SOL_MINT = 'So11111111111111111111111111111111111111112';
@@ -550,6 +551,39 @@ describe('validateRouteSecurity', () => {
     const route = starknetSdkWarpRoute({ transaction: { manifest: 'opaque' } });
 
     expect(validateRouteSecurity(route, starknetContext())).toEqual({ valid: true });
+  });
+
+  test('accepts a Starknet sdk warp route with bridge-asset and gas-fee approvals', () => {
+    expect(validateRouteSecurity(starknetApprovalRoute(), starknetContext())).toEqual({
+      valid: true,
+    });
+  });
+
+  test('rejects a Starknet approval whose spender is not the bridge router', () => {
+    const route = starknetApprovalRoute({ assetSpender: STARKNET_TOKEN });
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK approval spender does not match bridge router',
+    });
+  });
+
+  test('rejects a Starknet bridge-asset approval that does not match the input amount', () => {
+    const route = starknetApprovalRoute({ assetAmount: 999n });
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK approval amount does not match route input amount',
+    });
+  });
+
+  test('rejects a Starknet gas-fee approval that does not match the quoted fee', () => {
+    const route = starknetApprovalRoute({ feeAmount: 1n });
+
+    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
+      valid: false,
+      reason: 'SDK approval amount does not match route fee amount',
+    });
   });
 
   test('accepts SDK warp routes with an SDK approval tx before the transfer tx', () => {
@@ -1209,6 +1243,92 @@ function starknetSdkWarpRoute(
       },
       metadata: { warpRouteId: args.warpRouteId ?? 'STRK/test' },
     },
+    approval: null,
+  };
+}
+
+function starknetApprove(
+  token: string,
+  spender: string,
+  amount: bigint,
+  warpRouteId: string,
+): RouteTx {
+  return {
+    protocol: ProtocolType.Starknet,
+    type: 'starknet',
+    category: 'approval',
+    transaction: {
+      contractAddress: token,
+      entrypoint: 'approve',
+      calldata: [spender, (amount & ((1n << 128n) - 1n)).toString(), (amount >> 128n).toString()],
+    },
+    metadata: { warpRouteId },
+  };
+}
+
+function starknetApprovalRoute(
+  args: {
+    assetAmount?: bigint;
+    assetSpender?: string;
+    feeAmount?: bigint;
+  } = {},
+): RouteResponse {
+  const warpRouteId = 'STRK/test';
+  const igpAmount = '5000';
+  const txs: NonNullable<RouteResponse['txs']> = [
+    starknetApprove(
+      STARKNET_TOKEN,
+      args.assetSpender ?? STARKNET_ROUTER,
+      args.assetAmount ?? 100n,
+      warpRouteId,
+    ),
+    starknetApprove(
+      STARKNET_FEE_TOKEN,
+      STARKNET_ROUTER,
+      args.feeAmount ?? BigInt(igpAmount),
+      warpRouteId,
+    ),
+    {
+      protocol: ProtocolType.Starknet,
+      type: 'starknet',
+      category: 'transfer',
+      transaction: {
+        contractAddress: STARKNET_ROUTER,
+        entrypoint: 'transfer_remote',
+        calldata: [],
+      },
+      metadata: { warpRouteId },
+    },
+  ];
+
+  return {
+    steps: [
+      {
+        type: 'bridge',
+        chain: STARKNET,
+        destChain: ETH,
+        asset: STARKNET_TOKEN,
+        router: STARKNET_ROUTER,
+        amountIn: '100',
+        amountOut: '100',
+        bridgeSymbol: 'STRK',
+        warpRouteId,
+        fee: {
+          tokenFee: '0',
+          igpToken: NATIVE,
+          igpAmount,
+          igpIncludedInAmountIn: false,
+          localNativeFee: '0',
+        },
+      },
+    ],
+    output: '100',
+    outputMin: '100',
+    executionKind: 'sdkWarp',
+    connection: { symbol: 'STRK', warpRouteId },
+    gas: { originGas: '0', destGas: '0' },
+    tx: txs[0],
+    txs,
     approval: null,
   };
 }

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -193,16 +193,16 @@ function validateTxTargets(
   const txs = getRouteTxs(route);
   if (txs.length === 0) return { valid: false, reason: 'Route has no transactions' };
 
-  if (route.executionKind === 'sdkWarp') {
-    const txOrderValidation = validateSdkTxOrder(txs);
-    if (!txOrderValidation.valid) return txOrderValidation;
-  }
-
   const srcChain = chainForId(context.chains, context.srcChain);
   if (!srcChain) return { valid: false, reason: 'Route source chain unavailable' };
 
   const srcProtocol = protocolForChain(srcChain);
   if (!srcProtocol) return { valid: false, reason: 'Route source protocol unavailable' };
+
+  if (route.executionKind === 'sdkWarp') {
+    const txOrderValidation = validateSdkTxOrder(txs, srcProtocol);
+    if (!txOrderValidation.valid) return txOrderValidation;
+  }
 
   for (const tx of txs) {
     const validation = isChainRouteTx(tx)
@@ -214,7 +214,10 @@ function validateTxTargets(
   return { valid: true };
 }
 
-function validateSdkTxOrder(txs: RouteTx[]): RouteSecurityValidationResult {
+function validateSdkTxOrder(
+  txs: RouteTx[],
+  srcProtocol: ProtocolType,
+): RouteSecurityValidationResult {
   const categories = txs.map((tx) => (isChainRouteTx(tx) ? 'chain' : tx.category));
   const transferIndexes = categories.flatMap((category, index) =>
     category === 'transfer' ? [index] : [],
@@ -238,7 +241,10 @@ function validateSdkTxOrder(txs: RouteTx[]): RouteSecurityValidationResult {
   if (preTransfer.filter((category) => category === 'revoke').length > 1) {
     return { valid: false, reason: 'SDK route has multiple revoke transactions' };
   }
-  if (preTransfer.filter((category) => category === 'approval').length > 1) {
+  // Starknet routes add a second approval for the IGP gas-fee token alongside
+  // the bridged-token approval; each is bound to the router by validateSdkRouteTx.
+  const maxApprovals = srcProtocol === ProtocolType.Starknet ? 2 : 1;
+  if (preTransfer.filter((category) => category === 'approval').length > maxApprovals) {
     return { valid: false, reason: 'SDK route has multiple approval transactions' };
   }
   if (revokeIndex >= 0 && approvalIndex >= 0 && revokeIndex > approvalIndex) {

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -198,6 +198,7 @@ function validateTxTargets(
 
   const srcProtocol = protocolForChain(srcChain);
   if (!srcProtocol) return { valid: false, reason: 'Route source protocol unavailable' };
+  const nativeTokenAddress = context.chainMetadata[srcChain.chainName]?.nativeToken?.denom;
 
   if (route.executionKind === 'sdkWarp') {
     const txOrderValidation = validateSdkTxOrder(txs, srcProtocol);
@@ -207,7 +208,7 @@ function validateTxTargets(
   for (const tx of txs) {
     const validation = isChainRouteTx(tx)
       ? validateChainRouteTx(route, tx, srcChain, srcProtocol, context)
-      : validateSdkRouteTx(route, tx, srcProtocol);
+      : validateSdkRouteTx(route, tx, srcProtocol, nativeTokenAddress);
     if (!validation.valid) return validation;
   }
 


### PR DESCRIPTION
Mirrors #1214 onto main after it was merged directly into nexus.\n\nIncludes the reviewed follow-up that binds Starknet asset, fee, and revoke approvals to trusted tokens and supports native/asset-denominated IGP approvals.\n\nValidation:\n- 112 routeSecurity tests pass\n- routeSecurity lint passes\n- Typecheck has the existing unrelated sourceFee.ts ignoreSenderBalance error