### PR TITLE
revert: undo Starknet origin approval fix on nexus (#1214)

### DIFF
--- a/src/features/routeSecurity/sdk.ts
+++ b/src/features/routeSecurity/sdk.ts
@@ -1,9 +1,9 @@
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { decodeFunctionData, erc20Abi, type Hex } from 'viem';
 
-import type { QuoteBridgeStep, RouteResponse, RouteTx } from '../api/types';
+import type { RouteResponse, RouteTx } from '../api/types';
 import type { RouteSecurityValidationResult } from './types';
-import { firstBridge, isEngineNativeToken, sameTokenAddress } from './utils';
+import { firstBridge, sameTokenAddress } from './utils';
 
 const SDK_APPROVAL_CATEGORY = 'approval';
 const SDK_REVOKE_CATEGORY = 'revoke';
@@ -13,7 +13,6 @@ export function validateSdkRouteTx(
   route: RouteResponse,
   tx: Extract<RouteTx, { protocol: string }>,
   srcProtocol: ProtocolType,
-  nativeTokenAddress?: string,
 ): RouteSecurityValidationResult {
   if (route.executionKind !== 'sdkWarp') {
     return { valid: false, reason: 'SDK transaction shape is only supported for sdkWarp routes' };
@@ -34,7 +33,7 @@ export function validateSdkRouteTx(
   }
 
   if (tx.category === SDK_APPROVAL_CATEGORY || tx.category === SDK_REVOKE_CATEGORY) {
-    return validateSdkApprovalTx(route, tx, srcProtocol, nativeTokenAddress);
+    return validateSdkApprovalTx(route, tx);
   }
 
   if (tx.category !== SDK_TRANSFER_CATEGORY) {
@@ -55,15 +54,9 @@ export function validateSdkRouteTx(
 function validateSdkApprovalTx(
   route: RouteResponse,
   tx: Extract<RouteTx, { protocol: string }>,
-  srcProtocol: ProtocolType,
-  nativeTokenAddress?: string,
 ): RouteSecurityValidationResult {
   const bridge = firstBridge(route);
   if (!bridge) return { valid: false, reason: 'SDK approval transaction missing bridge step' };
-
-  if (srcProtocol === ProtocolType.Starknet) {
-    return validateStarknetApprovalTx(bridge, tx, nativeTokenAddress);
-  }
 
   const approval = decodeEvmApproval(tx.transaction);
   if (!approval) return { valid: false, reason: 'SDK approval transaction is not supported' };
@@ -90,82 +83,6 @@ function validateSdkApprovalTx(
   }
 
   return { valid: true };
-}
-
-// Starknet uses native calls and separately approves the bridge asset and native IGP token.
-function validateStarknetApprovalTx(
-  bridge: QuoteBridgeStep,
-  tx: Extract<RouteTx, { protocol: string }>,
-  nativeTokenAddress?: string,
-): RouteSecurityValidationResult {
-  const approval = decodeStarknetApproval(tx.transaction);
-  if (!approval) return { valid: false, reason: 'SDK approval transaction is not supported' };
-
-  if (!sameFelt(approval.spender, bridge.router)) {
-    return { valid: false, reason: 'SDK approval spender does not match bridge router' };
-  }
-
-  const assetToken = isEngineNativeToken(bridge.asset) ? nativeTokenAddress : bridge.asset;
-  const resolvedFeeToken = isEngineNativeToken(bridge.fee.igpToken)
-    ? nativeTokenAddress
-    : bridge.fee.igpToken;
-  const feeToken = [assetToken, nativeTokenAddress].find(
-    (token) => token && resolvedFeeToken && sameFelt(token, resolvedFeeToken),
-  );
-  const expectedApprovals: Array<[string | undefined, string]> = [
-    [assetToken, bridge.amountIn],
-    [feeToken, bridge.fee.igpAmount],
-  ];
-  const allowedAmounts = expectedApprovals.flatMap(([token, amount]) =>
-    token && sameFelt(approval.token, token) ? [parseAmount(amount)] : [],
-  );
-  if (!allowedAmounts.length) {
-    return { valid: false, reason: 'SDK approval token does not match route token' };
-  }
-
-  if (tx.category === SDK_REVOKE_CATEGORY) {
-    if (approval.amount !== 0n) return { valid: false, reason: 'SDK revoke amount must be zero' };
-    return { valid: true };
-  }
-
-  if (!allowedAmounts.includes(approval.amount)) {
-    return { valid: false, reason: 'SDK approval amount does not match route amount' };
-  }
-  return { valid: true };
-}
-
-function decodeStarknetApproval(
-  transaction: unknown,
-): { token: string; spender: string; amount: bigint } | undefined {
-  if (!isRecord(transaction)) return undefined;
-  const { contractAddress, entrypoint, calldata } = transaction;
-  if (typeof contractAddress !== 'string' || entrypoint !== 'approve') return undefined;
-  if (!Array.isArray(calldata) || calldata.length < 3) return undefined;
-  const [spender, amountLow, amountHigh] = calldata;
-  if (
-    typeof spender !== 'string' ||
-    typeof amountLow !== 'string' ||
-    typeof amountHigh !== 'string'
-  ) {
-    return undefined;
-  }
-  let amount: bigint;
-  try {
-    amount = BigInt(amountLow) + (BigInt(amountHigh) << 128n);
-  } catch {
-    return undefined;
-  }
-  return { token: contractAddress, spender, amount };
-}
-
-// Starknet felts compare by numeric value, independent of hex/decimal encoding
-// or leading-zero padding.
-function sameFelt(left: string, right: string): boolean {
-  try {
-    return BigInt(left) === BigInt(right);
-  } catch {
-    return false;
-  }
 }
 
 function decodeEvmApproval(

--- a/src/features/routeSecurity/validateRouteSecurity.test.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.test.ts
@@ -23,7 +23,6 @@ const ETH_WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 const BASE_WETH = '0x4200000000000000000000000000000000000006';
 const STARKNET_ROUTER = '0x074238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
 const STARKNET_TOKEN = '0x01a238dfa02063792077820584c925b679a013cbab38e5ca61af5627d1eda736';
-const STARKNET_FEE_TOKEN = '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
 const SOL_UNIVERSAL_ROUTER_PROGRAM = '2CttnaLkYbNHbaFDFnQ8PMCnzUwTGrKnskBxPM4TRWGp';
 const SOL_ROUTER = 'SolRouter1111111111111111111111111111111111';
 const SOL_MINT = 'So11111111111111111111111111111111111111112';
@@ -39,11 +38,7 @@ const chainMetadata = {
   ethereum: { chainId: ETH, domainId: ETH },
   base: { chainId: BASE, domainId: BASE },
   solanamainnet: { chainId: SOL, domainId: SOL },
-  starknet: {
-    chainId: STARKNET,
-    domainId: STARKNET,
-    nativeToken: { denom: STARKNET_FEE_TOKEN },
-  },
+  starknet: { chainId: STARKNET, domainId: STARKNET },
 } as unknown as ChainMap<ChainMetadata>;
 
 const chains = [
@@ -557,65 +552,6 @@ describe('validateRouteSecurity', () => {
     expect(validateRouteSecurity(route, starknetContext())).toEqual({ valid: true });
   });
 
-  test.each([{}, { feeToken: STARKNET_TOKEN, igpToken: STARKNET_TOKEN }])(
-    'accepts a Starknet sdk warp route with bridge-asset and gas-fee approvals',
-    (args) => {
-      expect(validateRouteSecurity(starknetApprovalRoute(args), starknetContext())).toEqual({
-        valid: true,
-      });
-    },
-  );
-
-  test('accepts a Starknet native-origin approval using the chain native token contract', () => {
-    expect(
-      validateRouteSecurity(
-        starknetApprovalRoute({ asset: NATIVE, assetToken: STARKNET_FEE_TOKEN }),
-        starknetContext({ registryWarpRoutes: starknetNativeRoutes(), srcToken: NATIVE }),
-      ),
-    ).toEqual({ valid: true });
-  });
-
-  test('rejects a Starknet fee approval for an unrelated token', () => {
-    const route = starknetApprovalRoute({ feeToken: BAD });
-    if (route.steps[0].type !== 'bridge') throw new Error('expected bridge step');
-    route.steps[0].fee.igpToken = BAD;
-
-    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
-      valid: false,
-      reason: 'SDK approval token does not match route token',
-    });
-  });
-
-  test('rejects a Starknet revoke for an unrelated token', () => {
-    const route = starknetApprovalRoute({ assetAmount: 0n, assetToken: BAD });
-    if (!route.txs || !('category' in route.txs[0])) throw new Error('expected SDK tx');
-    route.txs[0].category = 'revoke';
-
-    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
-      valid: false,
-      reason: 'SDK approval token does not match route token',
-    });
-  });
-
-  test('rejects a Starknet approval whose spender is not the bridge router', () => {
-    const route = starknetApprovalRoute({ assetSpender: STARKNET_TOKEN });
-
-    expect(validateRouteSecurity(route, starknetContext())).toMatchObject({
-      valid: false,
-      reason: 'SDK approval spender does not match bridge router',
-    });
-  });
-
-  test.each([{ assetAmount: 999n }, { feeAmount: 1n }])(
-    'rejects a Starknet approval with a mismatched amount',
-    (args) => {
-      expect(validateRouteSecurity(starknetApprovalRoute(args), starknetContext())).toMatchObject({
-        valid: false,
-        reason: 'SDK approval amount does not match route amount',
-      });
-    },
-  );
-
   test('accepts SDK warp routes with an SDK approval tx before the transfer tx', () => {
     const route = evmSdkWarpRoute();
 
@@ -968,14 +904,13 @@ function context(routeOverrides: Partial<RouteSecurityTestContext> = {}) {
   };
 }
 
-function starknetContext(overrides: Partial<RouteSecurityTestContext> = {}) {
+function starknetContext() {
   return context({
     registryWarpRoutes: starknetRoutes(),
     srcChain: STARKNET,
     dstChain: ETH,
     srcToken: STARKNET_TOKEN,
     dstToken: DST_ROUTER,
-    ...overrides,
   });
 }
 
@@ -1278,65 +1213,6 @@ function starknetSdkWarpRoute(
   };
 }
 
-function starknetApprove(
-  token: string,
-  spender: string,
-  amount: bigint,
-  warpRouteId: string,
-): RouteTx {
-  return {
-    protocol: ProtocolType.Starknet,
-    type: 'starknet',
-    category: 'approval',
-    transaction: {
-      contractAddress: token,
-      entrypoint: 'approve',
-      calldata: [spender, (amount & ((1n << 128n) - 1n)).toString(), (amount >> 128n).toString()],
-    },
-    metadata: { warpRouteId },
-  };
-}
-
-function starknetApprovalRoute(
-  args: {
-    asset?: string;
-    assetAmount?: bigint;
-    assetSpender?: string;
-    assetToken?: string;
-    feeAmount?: bigint;
-    feeToken?: string;
-    igpToken?: string;
-  } = {},
-): RouteResponse {
-  const route = starknetSdkWarpRoute();
-  const bridge = route.steps[0];
-  if (bridge.type !== 'bridge' || !route.tx) throw new Error('expected Starknet transfer');
-
-  const warpRouteId = 'STRK/test';
-  const igpAmount = '5000';
-  bridge.asset = args.asset ?? STARKNET_TOKEN;
-  bridge.fee.igpAmount = igpAmount;
-  bridge.fee.igpToken = args.igpToken ?? NATIVE;
-  const txs: NonNullable<RouteResponse['txs']> = [
-    starknetApprove(
-      args.assetToken ?? STARKNET_TOKEN,
-      args.assetSpender ?? STARKNET_ROUTER,
-      args.assetAmount ?? 100n,
-      warpRouteId,
-    ),
-    starknetApprove(
-      args.feeToken ?? STARKNET_FEE_TOKEN,
-      STARKNET_ROUTER,
-      args.feeAmount ?? BigInt(igpAmount),
-      warpRouteId,
-    ),
-    route.tx,
-  ];
-  route.tx = txs[0];
-  route.txs = txs;
-  return route;
-}
-
 function sealevelUniversalRouterRoute(
   args: {
     accounts?: Array<{ pubkey: string; isSigner?: boolean; isWritable?: boolean }>;
@@ -1403,16 +1279,6 @@ function starknetRoutes(): RegistryWarpRouteMap {
       ],
     },
   };
-}
-
-function starknetNativeRoutes(): RegistryWarpRouteMap {
-  const routes = starknetRoutes();
-  routes['strk/test'].tokens[0] = {
-    chainName: 'starknet',
-    addressOrDenom: STARKNET_ROUTER,
-    standard: 'StarknetHypNative',
-  };
-  return routes;
 }
 
 function universalRouterRoutes(): RegistryWarpRouteMap {

--- a/src/features/routeSecurity/validateRouteSecurity.ts
+++ b/src/features/routeSecurity/validateRouteSecurity.ts
@@ -193,32 +193,28 @@ function validateTxTargets(
   const txs = getRouteTxs(route);
   if (txs.length === 0) return { valid: false, reason: 'Route has no transactions' };
 
+  if (route.executionKind === 'sdkWarp') {
+    const txOrderValidation = validateSdkTxOrder(txs);
+    if (!txOrderValidation.valid) return txOrderValidation;
+  }
+
   const srcChain = chainForId(context.chains, context.srcChain);
   if (!srcChain) return { valid: false, reason: 'Route source chain unavailable' };
 
   const srcProtocol = protocolForChain(srcChain);
   if (!srcProtocol) return { valid: false, reason: 'Route source protocol unavailable' };
-  const nativeTokenAddress = context.chainMetadata[srcChain.chainName]?.nativeToken?.denom;
-
-  if (route.executionKind === 'sdkWarp') {
-    const txOrderValidation = validateSdkTxOrder(txs, srcProtocol);
-    if (!txOrderValidation.valid) return txOrderValidation;
-  }
 
   for (const tx of txs) {
     const validation = isChainRouteTx(tx)
       ? validateChainRouteTx(route, tx, srcChain, srcProtocol, context)
-      : validateSdkRouteTx(route, tx, srcProtocol, nativeTokenAddress);
+      : validateSdkRouteTx(route, tx, srcProtocol);
     if (!validation.valid) return validation;
   }
 
   return { valid: true };
 }
 
-function validateSdkTxOrder(
-  txs: RouteTx[],
-  srcProtocol: ProtocolType,
-): RouteSecurityValidationResult {
+function validateSdkTxOrder(txs: RouteTx[]): RouteSecurityValidationResult {
   const categories = txs.map((tx) => (isChainRouteTx(tx) ? 'chain' : tx.category));
   const transferIndexes = categories.flatMap((category, index) =>
     category === 'transfer' ? [index] : [],
@@ -242,10 +238,7 @@ function validateSdkTxOrder(
   if (preTransfer.filter((category) => category === 'revoke').length > 1) {
     return { valid: false, reason: 'SDK route has multiple revoke transactions' };
   }
-  // Starknet routes add a second approval for the IGP gas-fee token alongside
-  // the bridged-token approval; each is bound to the router by validateSdkRouteTx.
-  const maxApprovals = srcProtocol === ProtocolType.Starknet ? 2 : 1;
-  if (preTransfer.filter((category) => category === 'approval').length > maxApprovals) {
+  if (preTransfer.filter((category) => category === 'approval').length > 1) {
     return { valid: false, reason: 'SDK route has multiple approval transactions' };
   }
   if (revokeIndex >= 0 && approvalIndex >= 0 && revokeIndex > approvalIndex) {


### PR DESCRIPTION
Reverts #1214, which was merged directly into nexus. nexus should only receive changes via main-to-nexus merges.

Re-landed on main in the companion PR so it flows to nexus normally.