### PR TITLE
fix: handle RPCs without gas state overrides

### DIFF
--- a/src/features/transfer/engine/sourceFee.test.ts
+++ b/src/features/transfer/engine/sourceFee.test.ts
@@ -164,6 +164,30 @@ describe('estimateRouteSourceFee', () => {
     ).resolves.toBe(0n);
   });
 
+  test('uses quoted gas when an EVM RPC rejects the balance override argument', async () => {
+    prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
+    const rpcError = new Error('too many arguments, want at most 2');
+    const estimateTransactionFee = vi
+      .fn()
+      .mockRejectedValue(new Error('All providers failed', { cause: rpcError }));
+    const fallbackRoute = route();
+    fallbackRoute.gas.originGas = '250000';
+
+    await expect(
+      estimateRouteSourceFee({
+        multiProvider: provider(ProtocolType.Ethereum, estimateTransactionFee, {
+          gasPrice: 2n,
+        }),
+        chainName: 'kiichain',
+        sender: '0xsender',
+        route: fallbackRoute,
+        approvalTransactionCount: 0,
+      }),
+    ).resolves.toBe(500_000n);
+
+    expect(estimateTransactionFee).toHaveBeenCalledOnce();
+  });
+
   test('adds revoke and approval gas after the full EVM-like route budget', async () => {
     const estimateTransactionFee = vi.fn();
     const multiProvider = provider(ProtocolType.Ethereum, estimateTransactionFee, {

--- a/src/features/transfer/engine/sourceFee.ts
+++ b/src/features/transfer/engine/sourceFee.ts
@@ -1,5 +1,5 @@
 import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
-import { type HexString, isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
+import { formatError, type HexString, isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { getRouteTxs } from '../../api/routeTx';
 import type { RouteResponse } from '../../api/types';
@@ -92,20 +92,31 @@ export async function estimateRouteSourceFee({
     routeTxs,
   });
   const publicKey = (await senderPubKey)?.replace(/^0x/, '');
-  const estimates = await Promise.all(
-    transactions.map((transaction) =>
-      multiProvider.estimateTransactionFee({
-        chainNameOrId: chainName,
-        transaction,
-        sender,
-        senderPubKey: publicKey,
-        // Fee estimation must succeed even when validation is about to prove
-        // that the sender cannot afford the transaction.
-        ignoreSenderBalance: true,
-      }),
-    ),
-  );
-  return estimates.reduce((sum, estimate) => sum + BigInt(estimate.fee), 0n);
+  try {
+    const estimates = await Promise.all(
+      transactions.map((transaction) =>
+        multiProvider.estimateTransactionFee({
+          chainNameOrId: chainName,
+          transaction,
+          sender,
+          senderPubKey: publicKey,
+          // Fee estimation must succeed even when validation is about to prove
+          // that the sender cannot afford the transaction.
+          ignoreSenderBalance: true,
+        }),
+      ),
+    );
+    return estimates.reduce((sum, estimate) => sum + BigInt(estimate.fee), 0n);
+  } catch (error) {
+    if (isEVMLike(protocol) && isUnsupportedStateOverrideError(error)) {
+      return estimateEvmLikeFeeForGasUnits(multiProvider, chainName, BigInt(route.gas.originGas));
+    }
+    throw error;
+  }
+}
+
+function isUnsupportedStateOverrideError(error: unknown): boolean {
+  return formatError(error).toLowerCase().includes('too many arguments, want at most 2');
 }
 
 async function estimateEvmLikeFeeForGasUnits(


### PR DESCRIPTION
## Summary

- detect EVM RPCs that reject the third `eth_estimateGas` state-override argument
- fall back to the quote-provided origin gas budget and current fee data
- preserve balance-independent SDK estimation on compatible RPCs and surface unrelated errors

## Root cause

WUI requests `ignoreSenderBalance: true` from SDK 42.0.0. For EVM transactions this sends `eth_estimateGas(transaction, "latest", stateOverride)`. KiiChain RPC accepts at most two arguments, so source-fee estimation fails before transfer validation.

Live probe against `https://json-rpc.kiivalidator.com` with the reported transaction:

- two arguments: success, `0x329da` gas
- three arguments with balance override: `-32602 too many arguments, want at most 2`

## Verification

- `pnpm vitest src/features/transfer/engine/sourceFee.test.ts --run` (13 passed)
- `pnpm test` (48 files, 412 tests passed)
- `pnpm typecheck`
- `pnpm lint` (passes with two pre-existing console warnings)
- `pnpm exec oxfmt --check src/features/transfer/engine/sourceFee.ts src/features/transfer/engine/sourceFee.test.ts`
- `git diff --check`

Validated with Node 26.6.0.