### PR TITLE
fix(transfer): fall back to route gas budget when EVM estimate reverts

### DIFF
--- a/src/features/transfer/engine/sourceFee.test.ts
+++ b/src/features/transfer/engine/sourceFee.test.ts
@@ -284,6 +284,48 @@ describe('estimateRouteSourceFee', () => {
       }),
     ).rejects.toThrow('insufficient funds');
   });
+
+  test('falls back to the route gas budget when an EVM-like estimate reverts', async () => {
+    prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
+    const estimateTransactionFee = vi.fn().mockRejectedValue({
+      code: 'UNPREDICTABLE_GAS_LIMIT',
+      reason: 'execution reverted: ERC20: burn amount exceeds balance',
+    });
+    const revertRoute = route();
+    revertRoute.gas.originGas = '700000';
+
+    await expect(
+      estimateRouteSourceFee({
+        multiProvider: provider(ProtocolType.Ethereum, estimateTransactionFee, {
+          maxFeePerGas: 2n,
+        }),
+        chainName: 'ethereum',
+        sender: '0xsender',
+        route: revertRoute,
+        approvalTransactionCount: 0,
+      }),
+    ).resolves.toBe(1_400_000n);
+
+    expect(estimateTransactionFee).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fall back on non-EVM estimation reverts', async () => {
+    prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.SolanaWeb3));
+    const estimateTransactionFee = vi.fn().mockRejectedValue({
+      code: 'CALL_EXCEPTION',
+      reason: 'execution reverted',
+    });
+
+    await expect(
+      estimateRouteSourceFee({
+        multiProvider: provider(ProtocolType.Sealevel, estimateTransactionFee),
+        chainName: 'solanamainnet',
+        sender: 'sender',
+        route: route(),
+        approvalTransactionCount: 0,
+      }),
+    ).rejects.toMatchObject({ code: 'CALL_EXCEPTION' });
+  });
 });
 
 describe('withEstimatedSourceFee', () => {

--- a/src/features/transfer/engine/sourceFee.ts
+++ b/src/features/transfer/engine/sourceFee.ts
@@ -75,13 +75,11 @@ export async function estimateRouteSourceFee({
     embeddedApprovalTransactionCount(routeTxs),
   );
   if (isEVMLike(protocol) && approvalCount > 0) {
-    const routeGasUnits = BigInt(route.gas.originGas);
-    const gasUnits =
-      (routeGasUnits > EVM_LIKE_MIN_ROUTE_GAS_UNITS
-        ? routeGasUnits
-        : EVM_LIKE_MIN_ROUTE_GAS_UNITS) +
-      BigInt(approvalCount) * EVM_LIKE_APPROVAL_GAS_UNITS;
-    return estimateEvmLikeFeeForGasUnits(multiProvider, chainName, gasUnits);
+    return estimateEvmLikeFeeForGasUnits(
+      multiProvider,
+      chainName,
+      evmLikeRouteGasUnits(route, approvalCount),
+    );
   }
 
   const transactions = await prepareSourceTransactions({
@@ -108,8 +106,25 @@ export async function estimateRouteSourceFee({
     );
     return estimates.reduce((sum, estimate) => sum + BigInt(estimate.fee), 0n);
   } catch (error) {
-    if (isEVMLike(protocol) && isUnsupportedStateOverrideError(error)) {
+    if (!isEVMLike(protocol)) throw error;
+    // KiiChain-style RPCs reject the balance state-override argument, so fall
+    // back to the quote's raw origin gas budget for the whole estimate.
+    if (isUnsupportedStateOverrideError(error)) {
       return estimateEvmLikeFeeForGasUnits(multiProvider, chainName, BigInt(route.gas.originGas));
+    }
+    // A synthetic/collateral transferRemote reverts in estimateGas when the
+    // sender does not yet hold the token to burn or transfer. The balance
+    // override only funds native gas, not the ERC20 balance, so on EVM-like
+    // chains fall back to the quote's origin gas budget instead of surfacing a
+    // fee-estimate error for an otherwise valid quote. Separate transfer
+    // validation still blocks the send. Non-revert errors keep propagating so
+    // real estimation failures stay visible.
+    if (isExecutionRevertError(error)) {
+      return estimateEvmLikeFeeForGasUnits(
+        multiProvider,
+        chainName,
+        evmLikeRouteGasUnits(route, approvalCount),
+      );
     }
     throw error;
   }
@@ -117,6 +132,40 @@ export async function estimateRouteSourceFee({
 
 function isUnsupportedStateOverrideError(error: unknown): boolean {
   return formatError(error).toLowerCase().includes('too many arguments, want at most 2');
+}
+
+function evmLikeRouteGasUnits(route: RouteResponse, approvalCount: number): bigint {
+  const routeGasUnits = BigInt(route.gas.originGas);
+  return (
+    (routeGasUnits > EVM_LIKE_MIN_ROUTE_GAS_UNITS ? routeGasUnits : EVM_LIKE_MIN_ROUTE_GAS_UNITS) +
+    BigInt(approvalCount) * EVM_LIKE_APPROVAL_GAS_UNITS
+  );
+}
+
+function isExecutionRevertError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    const record = current as Record<string, unknown>;
+    const code = record.code;
+    if (
+      code === 'UNPREDICTABLE_GAS_LIMIT' ||
+      code === 'CALL_EXCEPTION' ||
+      code === 3 ||
+      code === '3'
+    ) {
+      return true;
+    }
+    for (const key of ['message', 'reason', 'body'] as const) {
+      const value = record[key];
+      if (typeof value === 'string' && value.toLowerCase().includes('execution reverted')) {
+        return true;
+      }
+    }
+    current = record.error ?? record.cause;
+  }
+  return false;
 }
 
 async function estimateEvmLikeFeeForGasUnits(


### PR DESCRIPTION
## Summary
- Ethereum -> KiiChain (and any synthetic/collateral) quotes threw a misleading `Network fee estimate failed ... execution reverted: ERC20: burn amount exceeds balance` toast even though the quote and bridging legs rendered correctly.
- Root cause: synthetic warp routes burn the sender token inside `transferRemote`, so `eth_estimateGas` reverts whenever the sender does not yet hold the token. The native balance state-override funds gas only, never the ERC20 balance, so a valid quote still failed fee estimation.
- On EVM-like chains, an execution-revert during source fee estimation now falls back to the quote's `originGas` budget (`estimateEvmLikeFeeForGasUnits`) instead of surfacing the error.

## Safety / no regression
- Fallback is scoped to `isEVMLike(protocol) && isExecutionRevertError(error)`. Non-EVM protocols and non-revert errors (e.g. `insufficient funds`, RPC transport failures) keep propagating, so real estimation failures stay visible.
- Successful native/ERC20 estimates are unchanged — the fallback only runs in the catch path.
- Separate transfer validation still blocks the actual send when the sender cannot afford it.

## Test plan
- [x] `pnpm vitest src/features/transfer/engine/sourceFee.test.ts --run` (14 passed)
- [x] Added test: EVM-like revert -> route gas budget fee
- [x] Added test: non-EVM revert still throws
- [x] Existing "does not hide SDK estimation failures" test still green
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format`