### PR TITLE
fix: handle synthetic balance fee estimation

### DIFF
--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -212,6 +212,7 @@ function TransferFormContent() {
       'source-fee',
       srcChainName ?? null,
       sender ?? null,
+      srcToken?.standard ?? null,
       sourceFeeKey,
       approvalTransactionCount,
     ],
@@ -224,6 +225,7 @@ function TransferFormContent() {
         chainName: srcChainName,
         sender,
         senderPubKey,
+        sourceTokenStandard: srcToken?.standard,
         route: bestRoute.raw,
         approvalTransactionCount,
       });
@@ -362,6 +364,7 @@ function TransferFormContent() {
             chainName: srcChainName,
             sender,
             senderPubKey,
+            sourceTokenStandard: srcToken?.standard,
             route: bestRoute.raw,
             approvalTransactionCount: approvalCount,
           });

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -1,3 +1,4 @@
+import { TokenStandard } from '@hyperlane-xyz/sdk';
 import { eqAddress, isValidAddressEvm, objLength, ProtocolType } from '@hyperlane-xyz/utils';
 import { useDebounce, useModal } from '@hyperlane-xyz/widgets';
 import {
@@ -131,6 +132,12 @@ function TransferFormContent() {
       : undefined;
   const srcToken = getTokenByKeyFromMap(tokenMap, srcTokenKey);
   const dstToken = getTokenByKeyFromMap(tokenMap, dstTokenKey);
+  const sourceTokenStandard =
+    srcToken?.standard === TokenStandard.EvmHypSynthetic
+      ? TokenStandard.EvmHypSynthetic
+      : srcToken?.standard === TokenStandard.EvmHypSyntheticRebase
+        ? TokenStandard.EvmHypSyntheticRebase
+        : undefined;
   const { data: srcBalance } = useTokenBalance(srcToken, sender);
 
   const [isReview, setIsReview] = useState(false);
@@ -225,7 +232,7 @@ function TransferFormContent() {
         chainName: srcChainName,
         sender,
         senderPubKey,
-        sourceTokenStandard: srcToken?.standard,
+        sourceTokenStandard,
         route: bestRoute.raw,
         approvalTransactionCount,
       });
@@ -364,7 +371,7 @@ function TransferFormContent() {
             chainName: srcChainName,
             sender,
             senderPubKey,
-            sourceTokenStandard: srcToken?.standard,
+            sourceTokenStandard,
             route: bestRoute.raw,
             approvalTransactionCount: approvalCount,
           });
@@ -408,6 +415,7 @@ function TransferFormContent() {
       srcChainInfo?.protocol,
       srcChainName,
       srcToken,
+      sourceTokenStandard,
       starknetAccount,
       values,
     ],

--- a/src/features/transfer/engine/sourceFee.test.ts
+++ b/src/features/transfer/engine/sourceFee.test.ts
@@ -1,4 +1,4 @@
-import { ProviderType } from '@hyperlane-xyz/sdk';
+import { ProviderType, TokenStandard } from '@hyperlane-xyz/sdk';
 import { ProtocolType } from '@hyperlane-xyz/utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -204,12 +204,39 @@ describe('estimateRouteSourceFee', () => {
         }),
         chainName: 'ethereum',
         sender: '0xsender',
+        sourceTokenStandard: TokenStandard.EvmHypSynthetic,
         route: syntheticRoute,
         approvalTransactionCount: 0,
       }),
     ).resolves.toBe(500_000n);
 
     expect(estimateTransactionFee).toHaveBeenCalledOnce();
+  });
+
+  test.each([
+    TokenStandard.EvmHypXERC20,
+    TokenStandard.EvmHypCollateral,
+    TokenStandard.EvmHypNative,
+    TokenStandard.EvmHypOwnerCollateral,
+    TokenStandard.EvmHypSyntheticRebase,
+  ])('does not hide burn failures for %s sources', async (sourceTokenStandard) => {
+    prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
+    const estimateTransactionFee = vi
+      .fn()
+      .mockRejectedValue(new Error('execution reverted: ERC20: burn amount exceeds balance'));
+
+    await expect(
+      estimateRouteSourceFee({
+        multiProvider: provider(ProtocolType.Ethereum, estimateTransactionFee, {
+          gasPrice: 2n,
+        }),
+        chainName: 'ethereum',
+        sender: '0xsender',
+        sourceTokenStandard,
+        route: route(),
+        approvalTransactionCount: 0,
+      }),
+    ).rejects.toThrow('burn amount exceeds balance');
   });
 
   test('adds revoke and approval gas after the full EVM-like route budget', async () => {

--- a/src/features/transfer/engine/sourceFee.test.ts
+++ b/src/features/transfer/engine/sourceFee.test.ts
@@ -188,9 +188,39 @@ describe('estimateRouteSourceFee', () => {
     expect(estimateTransactionFee).toHaveBeenCalledOnce();
   });
 
-  test('uses quoted gas when a synthetic token burn exceeds the sender balance', async () => {
+  test.each([TokenStandard.EvmHypSynthetic, TokenStandard.EvmHypSyntheticRebase])(
+    'uses quoted gas when a %s token burn exceeds the sender balance',
+    async (sourceTokenStandard) => {
+      prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
+      const rpcError = new Error('execution reverted: ERC20: burn amount exceeds balance');
+      const estimateTransactionFee = vi
+        .fn()
+        .mockRejectedValue(new Error('All providers failed', { cause: rpcError }));
+      const syntheticRoute = route();
+      syntheticRoute.gas.originGas = '250000';
+
+      await expect(
+        estimateRouteSourceFee({
+          multiProvider: provider(ProtocolType.Ethereum, estimateTransactionFee, {
+            gasPrice: 2n,
+          }),
+          chainName: 'ethereum',
+          sender: '0xsender',
+          sourceTokenStandard,
+          route: syntheticRoute,
+          approvalTransactionCount: 0,
+        }),
+      ).resolves.toBe(500_000n);
+
+      expect(estimateTransactionFee).toHaveBeenCalledOnce();
+    },
+  );
+
+  test('uses quoted gas for the OpenZeppelin v5 insufficient-balance custom error', async () => {
     prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
-    const rpcError = new Error('execution reverted: ERC20: burn amount exceeds balance');
+    const rpcError = Object.assign(new Error('execution reverted'), {
+      data: '0xe450d38c00000000',
+    });
     const estimateTransactionFee = vi
       .fn()
       .mockRejectedValue(new Error('All providers failed', { cause: rpcError }));
@@ -213,12 +243,31 @@ describe('estimateRouteSourceFee', () => {
     expect(estimateTransactionFee).toHaveBeenCalledOnce();
   });
 
+  test('does not hide unrelated nested errors for synthetic sources', async () => {
+    prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
+    const rpcError = new Error('execution reverted: route is paused');
+    const estimationError = new Error('All providers failed', { cause: rpcError });
+    const estimateTransactionFee = vi.fn().mockRejectedValue(estimationError);
+
+    await expect(
+      estimateRouteSourceFee({
+        multiProvider: provider(ProtocolType.Ethereum, estimateTransactionFee, {
+          gasPrice: 2n,
+        }),
+        chainName: 'ethereum',
+        sender: '0xsender',
+        sourceTokenStandard: TokenStandard.EvmHypSynthetic,
+        route: route(),
+        approvalTransactionCount: 0,
+      }),
+    ).rejects.toBe(estimationError);
+  });
+
   test.each([
     TokenStandard.EvmHypXERC20,
     TokenStandard.EvmHypCollateral,
     TokenStandard.EvmHypNative,
     TokenStandard.EvmHypOwnerCollateral,
-    TokenStandard.EvmHypSyntheticRebase,
   ])('does not hide burn failures for %s sources', async (sourceTokenStandard) => {
     prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
     const estimateTransactionFee = vi

--- a/src/features/transfer/engine/sourceFee.test.ts
+++ b/src/features/transfer/engine/sourceFee.test.ts
@@ -188,6 +188,30 @@ describe('estimateRouteSourceFee', () => {
     expect(estimateTransactionFee).toHaveBeenCalledOnce();
   });
 
+  test('uses quoted gas when a synthetic token burn exceeds the sender balance', async () => {
+    prepareRouteTransactionMock.mockResolvedValue(typedTransaction(ProviderType.EthersV5));
+    const rpcError = new Error('execution reverted: ERC20: burn amount exceeds balance');
+    const estimateTransactionFee = vi
+      .fn()
+      .mockRejectedValue(new Error('All providers failed', { cause: rpcError }));
+    const syntheticRoute = route();
+    syntheticRoute.gas.originGas = '250000';
+
+    await expect(
+      estimateRouteSourceFee({
+        multiProvider: provider(ProtocolType.Ethereum, estimateTransactionFee, {
+          gasPrice: 2n,
+        }),
+        chainName: 'ethereum',
+        sender: '0xsender',
+        route: syntheticRoute,
+        approvalTransactionCount: 0,
+      }),
+    ).resolves.toBe(500_000n);
+
+    expect(estimateTransactionFee).toHaveBeenCalledOnce();
+  });
+
   test('adds revoke and approval gas after the full EVM-like route budget', async () => {
     const estimateTransactionFee = vi.fn();
     const multiProvider = provider(ProtocolType.Ethereum, estimateTransactionFee, {

--- a/src/features/transfer/engine/sourceFee.ts
+++ b/src/features/transfer/engine/sourceFee.ts
@@ -8,6 +8,7 @@ import type { FeeBreakdown } from './types';
 
 const EVM_LIKE_MIN_ROUTE_GAS_UNITS = 600_000n;
 const EVM_LIKE_APPROVAL_GAS_UNITS = 55_000n;
+const ERC20_INSUFFICIENT_BALANCE_SELECTOR = '0xe450d38c';
 const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 export function sourceFeeRouteKey(route: RouteResponse): string {
@@ -52,7 +53,7 @@ export async function estimateRouteSourceFee({
   chainName: string;
   sender: string;
   senderPubKey?: Promise<HexString | undefined> | HexString;
-  sourceTokenStandard?: string;
+  sourceTokenStandard?: TokenStandard;
   route: RouteResponse;
   approvalTransactionCount: number;
 }): Promise<bigint> {
@@ -117,14 +118,31 @@ export async function estimateRouteSourceFee({
   }
 }
 
-function shouldUseQuotedGasFallback(error: unknown, sourceTokenStandard?: string): boolean {
+function shouldUseQuotedGasFallback(error: unknown, sourceTokenStandard?: TokenStandard): boolean {
   const message = formatError(error).toLowerCase();
+  const isSyntheticStandard =
+    sourceTokenStandard === TokenStandard.EvmHypSynthetic ||
+    sourceTokenStandard === TokenStandard.EvmHypSyntheticRebase;
+  const isInsufficientBurnBalance =
+    message.includes('burn amount exceeds balance') ||
+    errorContainsText(error, ERC20_INSUFFICIENT_BALANCE_SELECTOR);
   return (
     message.includes('too many arguments, want at most 2') ||
-    // A native balance override cannot fund a synthetic token burn. Balance
-    // validation reports the actual token deficit after this fee fallback.
-    (sourceTokenStandard === TokenStandard.EvmHypSynthetic &&
-      message.includes('burn amount exceeds balance'))
+    // A native balance override cannot fund synthetic token storage. Match
+    // both OpenZeppelin v4's revert string and v5's custom error selector.
+    (isSyntheticStandard && isInsufficientBurnBalance)
+  );
+}
+
+function errorContainsText(error: unknown, text: string, depth = 0): boolean {
+  if (typeof error === 'string') return error.toLowerCase().includes(text);
+  if (depth >= 6 || typeof error !== 'object' || error === null) return false;
+
+  const message = Reflect.get(error, 'message');
+  if (typeof message === 'string' && message.toLowerCase().includes(text)) return true;
+
+  return ['error', 'cause', 'data'].some((field) =>
+    errorContainsText(Reflect.get(error, field), text, depth + 1),
   );
 }
 

--- a/src/features/transfer/engine/sourceFee.ts
+++ b/src/features/transfer/engine/sourceFee.ts
@@ -108,15 +108,21 @@ export async function estimateRouteSourceFee({
     );
     return estimates.reduce((sum, estimate) => sum + BigInt(estimate.fee), 0n);
   } catch (error) {
-    if (isEVMLike(protocol) && isUnsupportedStateOverrideError(error)) {
+    if (isEVMLike(protocol) && shouldUseQuotedGasFallback(error)) {
       return estimateEvmLikeFeeForGasUnits(multiProvider, chainName, BigInt(route.gas.originGas));
     }
     throw error;
   }
 }
 
-function isUnsupportedStateOverrideError(error: unknown): boolean {
-  return formatError(error).toLowerCase().includes('too many arguments, want at most 2');
+function shouldUseQuotedGasFallback(error: unknown): boolean {
+  const message = formatError(error).toLowerCase();
+  return (
+    message.includes('too many arguments, want at most 2') ||
+    // A native balance override cannot fund a synthetic token burn. Balance
+    // validation reports the actual token deficit after this fee fallback.
+    message.includes('burn amount exceeds balance')
+  );
 }
 
 async function estimateEvmLikeFeeForGasUnits(

--- a/src/features/transfer/engine/sourceFee.ts
+++ b/src/features/transfer/engine/sourceFee.ts
@@ -1,4 +1,4 @@
-import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
+import { type MultiProtocolProvider, TokenStandard } from '@hyperlane-xyz/sdk';
 import { formatError, type HexString, isEVMLike, ProtocolType } from '@hyperlane-xyz/utils';
 
 import { getRouteTxs } from '../../api/routeTx';
@@ -44,6 +44,7 @@ export async function estimateRouteSourceFee({
   chainName,
   sender,
   senderPubKey,
+  sourceTokenStandard,
   route,
   approvalTransactionCount,
 }: {
@@ -51,6 +52,7 @@ export async function estimateRouteSourceFee({
   chainName: string;
   sender: string;
   senderPubKey?: Promise<HexString | undefined> | HexString;
+  sourceTokenStandard?: string;
   route: RouteResponse;
   approvalTransactionCount: number;
 }): Promise<bigint> {
@@ -108,20 +110,21 @@ export async function estimateRouteSourceFee({
     );
     return estimates.reduce((sum, estimate) => sum + BigInt(estimate.fee), 0n);
   } catch (error) {
-    if (isEVMLike(protocol) && shouldUseQuotedGasFallback(error)) {
+    if (isEVMLike(protocol) && shouldUseQuotedGasFallback(error, sourceTokenStandard)) {
       return estimateEvmLikeFeeForGasUnits(multiProvider, chainName, BigInt(route.gas.originGas));
     }
     throw error;
   }
 }
 
-function shouldUseQuotedGasFallback(error: unknown): boolean {
+function shouldUseQuotedGasFallback(error: unknown, sourceTokenStandard?: string): boolean {
   const message = formatError(error).toLowerCase();
   return (
     message.includes('too many arguments, want at most 2') ||
     // A native balance override cannot fund a synthetic token burn. Balance
     // validation reports the actual token deficit after this fee fallback.
-    message.includes('burn amount exceeds balance')
+    (sourceTokenStandard === TokenStandard.EvmHypSynthetic &&
+      message.includes('burn amount exceeds balance'))
   );
 }
 


### PR DESCRIPTION
## Summary

- fall back to the route's quoted EVM gas only when an `EvmHypSynthetic` or `EvmHypSyntheticRebase` source burn exceeds the sender balance
- recognize both OpenZeppelin v4's revert string and v5's `ERC20InsufficientBalance` custom error
- let transfer validation report the actual token deficit instead of showing a network-fee toast
- preserve existing estimation behavior for native, ERC-20 collateral, xERC20, owner-collateral/yield, and unrelated RPC or contract errors

## Root cause

`ignoreSenderBalance` gives the sender enough native currency through an `eth_estimateGas` state override, but it cannot change ERC-20 storage. Estimating a synthetic Warp transfer still executes `_burn`, so an amount above the sender's token balance reverts before form validation can report the balance error.
