### PR TITLE
feat: block transfers with high price impact

### DIFF
--- a/src/features/balances/utils.test.ts
+++ b/src/features/balances/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import type { BalanceToken } from './types';
-import { getTotalFeeUsd, resolveCoinGeckoId } from './utils';
+import { getPriceImpactPercentage, getTotalFeeUsd, resolveCoinGeckoId } from './utils';
 
 const TOKEN_ADDRESS = '0x1234567890123456789012345678901234567890';
 const OTHER_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
@@ -118,5 +118,23 @@ describe('getTotalFeeUsd', () => {
     });
 
     expect(total).toBeCloseTo(2469135.7802469134);
+  });
+});
+
+describe('getPriceImpactPercentage', () => {
+  test('returns the signed USD value change', () => {
+    expect(getPriceImpactPercentage(100, 90)).toBeCloseTo(-10);
+    expect(getPriceImpactPercentage(100, 105)).toBeCloseTo(5);
+  });
+
+  test('treats zero output as a complete loss', () => {
+    expect(getPriceImpactPercentage(100, 0)).toBe(-100);
+  });
+
+  test('returns null when price impact is unavailable', () => {
+    expect(getPriceImpactPercentage(null, 90)).toBeNull();
+    expect(getPriceImpactPercentage(100, null)).toBeNull();
+    expect(getPriceImpactPercentage(0, 0)).toBeNull();
+    expect(getPriceImpactPercentage(Number.POSITIVE_INFINITY, 90)).toBeNull();
   });
 });

--- a/src/features/balances/utils.test.ts
+++ b/src/features/balances/utils.test.ts
@@ -122,7 +122,7 @@ describe('getTotalFeeUsd', () => {
 });
 
 describe('getPriceImpactPercentage', () => {
-  test('returns the signed USD value change', () => {
+  test('returns the signed USD percentage change', () => {
     expect(getPriceImpactPercentage(100, 90)).toBeCloseTo(-10);
     expect(getPriceImpactPercentage(100, 105)).toBeCloseTo(5);
   });
@@ -136,5 +136,11 @@ describe('getPriceImpactPercentage', () => {
     expect(getPriceImpactPercentage(100, null)).toBeNull();
     expect(getPriceImpactPercentage(0, 0)).toBeNull();
     expect(getPriceImpactPercentage(Number.POSITIVE_INFINITY, 90)).toBeNull();
+  });
+
+  test('returns null for non-finite or negative output', () => {
+    expect(getPriceImpactPercentage(100, Number.POSITIVE_INFINITY)).toBeNull();
+    expect(getPriceImpactPercentage(100, Number.NaN)).toBeNull();
+    expect(getPriceImpactPercentage(100, -50)).toBeNull();
   });
 });

--- a/src/features/balances/utils.ts
+++ b/src/features/balances/utils.ts
@@ -65,8 +65,9 @@ export function getFeePercentage(totalFeesUsd: number, transferUsd: number): str
   return `${pct.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%`;
 }
 
-// Signed value change from source to destination. Negative means value lost
-// to fees, swap slippage, or spread. Missing prices stay unknown.
+// Signed percentage change from source to destination. Negative means value
+// lost to fees, swap slippage, or spread. Returns null when either value is
+// missing, non-finite, or outside the domain of a meaningful percentage.
 export function getPriceImpactPercentage(
   inputUsd: number | null,
   outputUsd: number | null,

--- a/src/features/balances/utils.ts
+++ b/src/features/balances/utils.ts
@@ -1,5 +1,5 @@
 import type { MultiProtocolProvider } from '@hyperlane-xyz/sdk';
-import { fromWei, fromWeiRounded } from '@hyperlane-xyz/utils';
+import { fromWei, fromWeiRounded, isNullish } from '@hyperlane-xyz/utils';
 
 import type { BalanceToken } from './types';
 import { balanceTokenKey, getBalanceTokenKey } from './types';
@@ -72,8 +72,8 @@ export function getPriceImpactPercentage(
   outputUsd: number | null,
 ): number | null {
   if (
-    inputUsd == null ||
-    outputUsd == null ||
+    isNullish(inputUsd) ||
+    isNullish(outputUsd) ||
     !Number.isFinite(inputUsd) ||
     !Number.isFinite(outputUsd) ||
     inputUsd <= 0 ||

--- a/src/features/balances/utils.ts
+++ b/src/features/balances/utils.ts
@@ -65,6 +65,25 @@ export function getFeePercentage(totalFeesUsd: number, transferUsd: number): str
   return `${pct.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%`;
 }
 
+// Signed value change from source to destination. Negative means value lost
+// to fees, swap slippage, or spread. Missing prices stay unknown.
+export function getPriceImpactPercentage(
+  inputUsd: number | null,
+  outputUsd: number | null,
+): number | null {
+  if (
+    inputUsd == null ||
+    outputUsd == null ||
+    !Number.isFinite(inputUsd) ||
+    !Number.isFinite(outputUsd) ||
+    inputUsd <= 0 ||
+    outputUsd < 0
+  ) {
+    return null;
+  }
+  return ((outputUsd - inputUsd) / inputUsd) * 100;
+}
+
 export function getNativeTokenDenom(
   multiProvider: MultiProtocolProvider,
   chainName: string | undefined,

--- a/src/features/store.test.ts
+++ b/src/features/store.test.ts
@@ -4,6 +4,7 @@ import type { RouteResponse } from './api/types';
 import {
   mergeMigrationChainMetadata,
   mergeKnownTokens,
+  mergeTokenPriceCache,
   mergeTransferTransactionUpdate,
   migratePersistedAppState,
   removeFinalTransferRoute,
@@ -116,6 +117,32 @@ describe('removeFinalTransferRoute', () => {
     expect(next).not.toBe(routes);
     expect(next.has('tx-1')).toBe(false);
     expect(next.has('tx-2')).toBe(true);
+  });
+});
+
+describe('mergeTokenPriceCache', () => {
+  test('retains the cached price and records a failed refresh', () => {
+    const cache = { ethereum: { usd: 2, fetchedAt: 1_000 } };
+
+    expect(mergeTokenPriceCache(cache, [], {}, ['ethereum'], 2_000)).toEqual({
+      ethereum: { usd: 2, fetchedAt: 1_000, failedAt: 2_000 },
+    });
+  });
+
+  test('replaces a failed entry after a successful refresh', () => {
+    const cache = { ethereum: { usd: 2, fetchedAt: 1_000, failedAt: 2_000 } };
+
+    expect(mergeTokenPriceCache(cache, ['ethereum'], { ethereum: 3 }, [], 3_000)).toEqual({
+      ethereum: { usd: 3, fetchedAt: 3_000 },
+    });
+  });
+
+  test('treats a successful response with no price as a failed refresh', () => {
+    const cache = { ethereum: { usd: 2, fetchedAt: 1_000 } };
+
+    expect(mergeTokenPriceCache(cache, ['ethereum'], {}, [], 2_000)).toEqual({
+      ethereum: { usd: 2, fetchedAt: 1_000, failedAt: 2_000 },
+    });
   });
 });
 

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -1,7 +1,7 @@
 import { GithubRegistry, PartialRegistry } from '@hyperlane-xyz/registry';
 import type { ChainAddresses, IRegistry } from '@hyperlane-xyz/registry';
 import { ChainMap, ChainMetadata, ChainName, MultiProtocolProvider } from '@hyperlane-xyz/sdk';
-import { objFilter } from '@hyperlane-xyz/utils';
+import { isNullish, objFilter } from '@hyperlane-xyz/utils';
 import { toast } from 'react-toastify';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
@@ -72,6 +72,37 @@ interface AppContext {
   registryWarpRoutes: RegistryWarpRouteMap;
   multiProvider: MultiProtocolProvider;
 }
+
+export interface TokenPriceCacheEntry {
+  usd?: number;
+  fetchedAt?: number;
+  failedAt?: number;
+}
+
+export type TokenPriceCache = Record<string, TokenPriceCacheEntry>;
+
+export function mergeTokenPriceCache(
+  cache: TokenPriceCache,
+  succeededIds: string[],
+  fetched: Record<string, number>,
+  failedIds: string[],
+  now = Date.now(),
+): TokenPriceCache {
+  const next = { ...cache };
+  for (const id of succeededIds) {
+    const price = fetched[id];
+    if (isNullish(price) || !Number.isFinite(price) || price <= 0) {
+      next[id] = { ...next[id], failedAt: now };
+    } else {
+      next[id] = { usd: price, fetchedAt: now };
+    }
+  }
+  for (const id of failedIds) {
+    next[id] = { ...next[id], failedAt: now };
+  }
+  return next;
+}
+
 // Keeping everything here for now as state is simple
 // Will refactor into slices as necessary
 export interface AppState {
@@ -133,7 +164,7 @@ export interface AppState {
   setIsTipCardActionTriggered: (isTipCardActionTriggered: boolean) => void;
   // Session-scoped USD price cache, keyed by coinGeckoId. `failedAt`
   // backs off retries after rate-limit / network failures.
-  tokenPrices: Record<string, { usd?: number; fetchedAt?: number; failedAt?: number }>;
+  tokenPrices: TokenPriceCache;
   mergeTokenPrices: (
     succeededIds: string[],
     fetched: Record<string, number>,
@@ -255,17 +286,9 @@ export const useStore = create<AppState>()(
 
       tokenPrices: {},
       mergeTokenPrices: (succeededIds, fetched, failedIds) => {
-        set((state) => {
-          const now = Date.now();
-          const next = { ...state.tokenPrices };
-          for (const id of succeededIds) {
-            next[id] = { usd: fetched[id], fetchedAt: now };
-          }
-          for (const id of failedIds) {
-            next[id] = { ...next[id], failedAt: now };
-          }
-          return { tokenPrices: next };
-        });
+        set((state) => ({
+          tokenPrices: mergeTokenPriceCache(state.tokenPrices, succeededIds, fetched, failedIds),
+        }));
       },
 
       // Shared component state

--- a/src/features/tokens/useTokenPrice.test.ts
+++ b/src/features/tokens/useTokenPrice.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { useStore } from '../store';
+import { getFreshTokenUsdValue } from './useTokenPrice';
+
+const NOW = 2_000_000_000_000;
+const initialTokenPrices = useStore.getState().tokenPrices;
+
+afterEach(() => {
+  useStore.setState({ tokenPrices: initialTokenPrices });
+  vi.restoreAllMocks();
+});
+
+describe('getFreshTokenUsdValue', () => {
+  test('returns the USD value for a fresh price', () => {
+    expect(getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - 1_000 }, '3', NOW)).toBe(6);
+  });
+
+  test('returns null for a stale price', () => {
+    expect(getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - 16 * 60_000 }, '3', NOW)).toBeNull();
+  });
+
+  test('returns null after a failed refresh retains the cached price', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW);
+    useStore.setState({
+      tokenPrices: { ethereum: { usd: 2, fetchedAt: NOW - 1_000 } },
+    });
+
+    useStore.getState().mergeTokenPrices([], {}, ['ethereum']);
+
+    const entry = useStore.getState().tokenPrices.ethereum;
+    expect(entry).toEqual({ usd: 2, fetchedAt: NOW - 1_000, failedAt: NOW });
+    expect(getFreshTokenUsdValue(entry, '3', NOW)).toBeNull();
+  });
+});

--- a/src/features/tokens/useTokenPrice.test.ts
+++ b/src/features/tokens/useTokenPrice.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { useStore } from '../store';
-import { getFreshTokenUsdValue } from './useTokenPrice';
+import { getFreshTokenUsdValue, schedulePriceExpiry } from './useTokenPrice';
 
 const NOW = 2_000_000_000_000;
 const initialTokenPrices = useStore.getState().tokenPrices;
 
 afterEach(() => {
   useStore.setState({ tokenPrices: initialTokenPrices });
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -31,5 +32,21 @@ describe('getFreshTokenUsdValue', () => {
     const entry = useStore.getState().tokenPrices.ethereum;
     expect(entry).toEqual({ usd: 2, fetchedAt: NOW - 1_000, failedAt: NOW });
     expect(getFreshTokenUsdValue(entry, '3', NOW)).toBeNull();
+  });
+
+  test('expires a fresh value without a price-entry mutation', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const entry = { usd: 2, fetchedAt: NOW };
+    let value = getFreshTokenUsdValue(entry, '3');
+
+    schedulePriceExpiry(entry.fetchedAt, () => {
+      value = getFreshTokenUsdValue(entry, '3');
+    });
+    vi.advanceTimersByTime(15 * 60_000 - 1);
+    expect(value).toBe(6);
+
+    vi.advanceTimersByTime(1);
+    expect(value).toBeNull();
   });
 });

--- a/src/features/tokens/useTokenPrice.test.ts
+++ b/src/features/tokens/useTokenPrice.test.ts
@@ -1,13 +1,10 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { useStore } from '../store';
-import { getFreshTokenUsdValue, schedulePriceExpiry } from './useTokenPrice';
+import { getFreshTokenUsdValue, PRICE_CACHE_MS, schedulePriceExpiry } from './useTokenPrice';
 
 const NOW = 2_000_000_000_000;
-const initialTokenPrices = useStore.getState().tokenPrices;
 
 afterEach(() => {
-  useStore.setState({ tokenPrices: initialTokenPrices });
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -17,21 +14,32 @@ describe('getFreshTokenUsdValue', () => {
     expect(getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - 1_000 }, '3', NOW)).toBe(6);
   });
 
-  test('returns null for a stale price', () => {
-    expect(getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - 16 * 60_000 }, '3', NOW)).toBeNull();
+  test('expires exactly at the freshness boundary', () => {
+    expect(getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - PRICE_CACHE_MS + 1 }, '3', NOW)).toBe(
+      6,
+    );
+    expect(getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - PRICE_CACHE_MS }, '3', NOW)).toBeNull();
   });
 
-  test('returns null after a failed refresh retains the cached price', () => {
-    vi.spyOn(Date, 'now').mockReturnValue(NOW);
-    useStore.setState({
-      tokenPrices: { ethereum: { usd: 2, fetchedAt: NOW - 1_000 } },
-    });
+  test('rejects a failed refresh and allows a later successful refresh', () => {
+    expect(
+      getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - 1_000, failedAt: NOW - 1_000 }, '3', NOW),
+    ).toBeNull();
+    expect(
+      getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - 1_000, failedAt: NOW - 90_000 }, '3', NOW),
+    ).toBe(6);
+  });
 
-    useStore.getState().mergeTokenPrices([], {}, ['ethereum']);
+  test('returns null when the price entry or price is unavailable', () => {
+    expect(getFreshTokenUsdValue(undefined, '3', NOW)).toBeNull();
+    expect(getFreshTokenUsdValue({ fetchedAt: NOW - 1_000 }, '3', NOW)).toBeNull();
+    expect(getFreshTokenUsdValue({ usd: 0, fetchedAt: NOW - 1_000 }, '3', NOW)).toBeNull();
+  });
 
-    const entry = useStore.getState().tokenPrices.ethereum;
-    expect(entry).toEqual({ usd: 2, fetchedAt: NOW - 1_000, failedAt: NOW });
-    expect(getFreshTokenUsdValue(entry, '3', NOW)).toBeNull();
+  test('prices amounts containing grouping separators', () => {
+    expect(getFreshTokenUsdValue({ usd: 2, fetchedAt: NOW - 1_000 }, '1,234.56', NOW)).toBe(
+      2_469.12,
+    );
   });
 
   test('expires a fresh value without a price-entry mutation', () => {
@@ -43,7 +51,7 @@ describe('getFreshTokenUsdValue', () => {
     schedulePriceExpiry(entry.fetchedAt, () => {
       value = getFreshTokenUsdValue(entry, '3');
     });
-    vi.advanceTimersByTime(15 * 60_000 - 1);
+    vi.advanceTimersByTime(PRICE_CACHE_MS - 1);
     expect(value).toBe(6);
 
     vi.advanceTimersByTime(1);

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -1,7 +1,7 @@
 import { isNullish } from '@hyperlane-xyz/utils';
 import { useDebounce } from '@hyperlane-xyz/widgets';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useReducer } from 'react';
 
 import { logger } from '../../utils/logger';
 import { useStore } from '../store';
@@ -149,7 +149,14 @@ export function useTokenUsdValue(token: UiToken | undefined, amount: string): nu
 export function useFreshTokenUsdValue(token: UiToken | undefined, amount: string): number | null {
   const id = token?.coinGeckoId;
   const entry = useStore((s) => (id ? s.tokenPrices[id] : undefined));
-  return useMemo(() => getFreshTokenUsdValue(entry, amount), [amount, entry]);
+  const [, invalidateFreshness] = useReducer((version: number) => version + 1, 0);
+
+  useEffect(
+    () => schedulePriceExpiry(entry?.fetchedAt, invalidateFreshness),
+    [entry?.fetchedAt, invalidateFreshness],
+  );
+
+  return getFreshTokenUsdValue(entry, amount);
 }
 
 function getTokenUsdValue(price: number | undefined, amount: string): number | null {
@@ -167,4 +174,16 @@ export function getFreshTokenUsdValue(
   if (isNullish(entry?.fetchedAt) || now - entry.fetchedAt >= PRICE_CACHE_MS) return null;
   if (!isNullish(entry.failedAt) && entry.failedAt >= entry.fetchedAt) return null;
   return getTokenUsdValue(entry.usd, amount);
+}
+
+export function schedulePriceExpiry(
+  fetchedAt: number | undefined,
+  onExpire: () => void,
+  now = Date.now(),
+): (() => void) | undefined {
+  if (isNullish(fetchedAt)) return undefined;
+  const delay = fetchedAt + PRICE_CACHE_MS - now;
+  if (delay <= 0) return undefined;
+  const timeoutId = setTimeout(onExpire, delay);
+  return () => clearTimeout(timeoutId);
 }

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -4,23 +4,16 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useReducer } from 'react';
 
 import { logger } from '../../utils/logger';
-import { useStore } from '../store';
+import { type TokenPriceCache, type TokenPriceCacheEntry, useStore } from '../store';
 import type { UiToken } from './types';
 
-interface PriceCacheEntry {
-  usd?: number;
-  fetchedAt?: number;
-  failedAt?: number;
-}
-
-type PriceCache = Record<string, PriceCacheEntry>;
 type MergeFn = (
   succeededIds: string[],
   fetched: Record<string, number>,
   failedIds: string[],
 ) => void;
 
-const PRICE_CACHE_MS = 15 * 60_000;
+export const PRICE_CACHE_MS = 15 * 60_000;
 const FAILED_BACKOFF_MS = 90_000;
 const COINGECKO_BATCH = 100;
 const CHUNK_DELAY_MS = 200;
@@ -70,7 +63,11 @@ async function fetchPricesBatched(ids: string[]): Promise<BatchedFetchResult> {
   return { requestedIds, prices };
 }
 
-async function fetchTokenPrices(ids: string[], cache: PriceCache, merge: MergeFn): Promise<null> {
+async function fetchTokenPrices(
+  ids: string[],
+  cache: TokenPriceCache,
+  merge: MergeFn,
+): Promise<null> {
   const now = Date.now();
   const idsToFetch = ids.filter((id) => {
     const entry = cache[id];
@@ -162,12 +159,20 @@ export function useFreshTokenUsdValue(token: UiToken | undefined, amount: string
 function getTokenUsdValue(price: number | undefined, amount: string): number | null {
   // Strip grouping separators — parseFloat("1,234.56") returns 1 otherwise.
   const parsedAmount = parseFloat(String(amount ?? '').replace(/,/g, ''));
-  if (!price || !Number.isFinite(parsedAmount)) return null;
+  if (
+    isNullish(price) ||
+    !Number.isFinite(price) ||
+    price <= 0 ||
+    !Number.isFinite(parsedAmount) ||
+    parsedAmount < 0
+  ) {
+    return null;
+  }
   return parsedAmount * price;
 }
 
 export function getFreshTokenUsdValue(
-  entry: PriceCacheEntry | undefined,
+  entry: TokenPriceCacheEntry | undefined,
   amount: string,
   now = Date.now(),
 ): number | null {

--- a/src/features/tokens/useTokenPrice.tsx
+++ b/src/features/tokens/useTokenPrice.tsx
@@ -1,3 +1,4 @@
+import { isNullish } from '@hyperlane-xyz/utils';
 import { useDebounce } from '@hyperlane-xyz/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
@@ -6,7 +7,13 @@ import { logger } from '../../utils/logger';
 import { useStore } from '../store';
 import type { UiToken } from './types';
 
-type PriceCache = Record<string, { usd?: number; fetchedAt?: number; failedAt?: number }>;
+interface PriceCacheEntry {
+  usd?: number;
+  fetchedAt?: number;
+  failedAt?: number;
+}
+
+type PriceCache = Record<string, PriceCacheEntry>;
 type MergeFn = (
   succeededIds: string[],
   fetched: Record<string, number>,
@@ -134,10 +141,30 @@ export function useTokenPrices(): { prices: Record<string, number>; isLoading: b
 export function useTokenUsdValue(token: UiToken | undefined, amount: string): number | null {
   const id = token?.coinGeckoId;
   const price = useStore((s) => (id ? s.tokenPrices[id]?.usd : undefined));
-  return useMemo(() => {
-    // Strip grouping separators — parseFloat("1,234.56") returns 1 otherwise.
-    const a = parseFloat(String(amount ?? '').replace(/,/g, ''));
-    if (!price || !Number.isFinite(a)) return null;
-    return a * price;
-  }, [amount, price]);
+  return useMemo(() => getTokenUsdValue(price, amount), [amount, price]);
+}
+
+// Enforcement must fail open when the cached price is stale or its latest
+// refresh failed. Display-only callers can continue using useTokenUsdValue.
+export function useFreshTokenUsdValue(token: UiToken | undefined, amount: string): number | null {
+  const id = token?.coinGeckoId;
+  const entry = useStore((s) => (id ? s.tokenPrices[id] : undefined));
+  return useMemo(() => getFreshTokenUsdValue(entry, amount), [amount, entry]);
+}
+
+function getTokenUsdValue(price: number | undefined, amount: string): number | null {
+  // Strip grouping separators — parseFloat("1,234.56") returns 1 otherwise.
+  const parsedAmount = parseFloat(String(amount ?? '').replace(/,/g, ''));
+  if (!price || !Number.isFinite(parsedAmount)) return null;
+  return parsedAmount * price;
+}
+
+export function getFreshTokenUsdValue(
+  entry: PriceCacheEntry | undefined,
+  amount: string,
+  now = Date.now(),
+): number | null {
+  if (isNullish(entry?.fetchedAt) || now - entry.fetchedAt >= PRICE_CACHE_MS) return null;
+  if (!isNullish(entry.failedAt) && entry.failedAt >= entry.fetchedAt) return null;
+  return getTokenUsdValue(entry.usd, amount);
 }

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -41,7 +41,11 @@ import { TransactionHistoryItemType, useStore } from '../../store';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from '../../tokens/hooks';
 import { TokenSelectField } from '../../tokens/TokenSelectField';
 import type { UiToken } from '../../tokens/types';
-import { useTokenPrices, useTokenUsdValue } from '../../tokens/useTokenPrice';
+import {
+  useFreshTokenUsdValue,
+  useTokenPrices,
+  useTokenUsdValue,
+} from '../../tokens/useTokenPrice';
 import { tokenKey } from '../../tokens/utils';
 import { RecipientConfirmationModal } from '../../wallet/RecipientConfirmationModal';
 import { WalletConnectionWarning } from '../../wallet/WalletConnectionWarning';
@@ -201,19 +205,25 @@ function TransferFormContent() {
     [approval],
   );
 
-  // Input USD — used by the fee % calculation in FeeSectionButton.
+  // Cached prices remain display-only; fresh prices enforce the loss limit below.
   const amountUsd = useTokenUsdValue(srcToken, values.amount);
-  const outputAmount = useMemo(() => {
-    if (!bestRoute || !dstToken) return '';
+  const [outputAmount, minimumOutputAmount] = useMemo<[string, string]>(() => {
+    if (!bestRoute || !dstToken) return ['', ''];
     try {
-      return formatUnits(BigInt(bestRoute.raw.output), dstToken.decimals);
+      return [
+        formatUnits(BigInt(bestRoute.raw.output), dstToken.decimals),
+        formatUnits(BigInt(bestRoute.raw.outputMin), dstToken.decimals),
+      ];
     } catch {
-      return '';
+      return ['', ''];
     }
   }, [bestRoute, dstToken]);
   const outputUsd = useTokenUsdValue(dstToken, outputAmount);
   const priceImpactPct = getPriceImpactPercentage(amountUsd, outputUsd);
-  const hasExcessivePriceImpact = isPriceImpactTooHigh(priceImpactPct);
+  const freshAmountUsd = useFreshTokenUsdValue(srcToken, values.amount);
+  const freshMinimumOutputUsd = useFreshTokenUsdValue(dstToken, minimumOutputAmount);
+  const minimumPriceImpactPct = getPriceImpactPercentage(freshAmountUsd, freshMinimumOutputUsd);
+  const hasExcessivePriceImpact = isPriceImpactTooHigh(minimumPriceImpactPct);
 
   const approvalArgs = useMemo(
     () => ({

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -1,5 +1,11 @@
 import { TokenStandard } from '@hyperlane-xyz/sdk';
-import { eqAddress, isValidAddressEvm, objLength, ProtocolType } from '@hyperlane-xyz/utils';
+import {
+  eqAddress,
+  isNullish,
+  isValidAddressEvm,
+  objLength,
+  ProtocolType,
+} from '@hyperlane-xyz/utils';
 import { useDebounce, useModal } from '@hyperlane-xyz/widgets';
 import {
   getAccountAddressAndPubKey,
@@ -61,7 +67,11 @@ import {
 } from './approval';
 import { FeeSectionButton } from './FeeSectionButton';
 import { MaxButton } from './MaxButton';
-import { isPriceImpactTooHigh, PRICE_IMPACT_BLOCK_MESSAGE } from './priceImpact';
+import {
+  getPriceImpactBlockMessage,
+  getRouteOutputAmounts,
+  isPriceImpactTooHigh,
+} from './priceImpact';
 import { emptyRouteMessageForRejections } from './rejections';
 import { RouteSelectionModal } from './routeSelection/RouteSelectionModal';
 import { SlippagePanel } from './SlippagePanel';
@@ -207,23 +217,45 @@ function TransferFormContent() {
 
   // Cached prices remain display-only; fresh prices enforce the loss limit below.
   const amountUsd = useTokenUsdValue(srcToken, values.amount);
-  const [outputAmount, minimumOutputAmount] = useMemo<[string, string]>(() => {
-    if (!bestRoute || !dstToken) return ['', ''];
-    try {
-      return [
-        formatUnits(BigInt(bestRoute.raw.output), dstToken.decimals),
-        formatUnits(BigInt(bestRoute.raw.outputMin), dstToken.decimals),
-      ];
-    } catch {
-      return ['', ''];
-    }
-  }, [bestRoute, dstToken]);
+  const [outputAmount, minimumOutputAmount] = useMemo(
+    () => getRouteOutputAmounts(bestRoute?.raw, dstToken?.decimals),
+    [bestRoute, dstToken],
+  );
   const outputUsd = useTokenUsdValue(dstToken, outputAmount);
   const priceImpactPct = getPriceImpactPercentage(amountUsd, outputUsd);
   const freshAmountUsd = useFreshTokenUsdValue(srcToken, values.amount);
   const freshMinimumOutputUsd = useFreshTokenUsdValue(dstToken, minimumOutputAmount);
   const minimumPriceImpactPct = getPriceImpactPercentage(freshAmountUsd, freshMinimumOutputUsd);
   const hasExcessivePriceImpact = isPriceImpactTooHigh(minimumPriceImpactPct);
+  const priceImpactBlockMessage = getPriceImpactBlockMessage(minimumPriceImpactPct);
+
+  useEffect(() => {
+    if (!isReview || !hasExcessivePriceImpact) return;
+    const validationResult = { form: `Price moved — ${priceImpactBlockMessage}.` };
+    trackTransferValidationFailed({
+      errors: validationResult,
+      values,
+      srcToken,
+      dstToken,
+      sender,
+      recipient: effectiveRecipient,
+    });
+    // Return to edit mode so route and slippage controls are available.
+    // Form-level errors are rendered by WarningBanners.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setErrors(validationResult as any);
+    setIsReview(false);
+  }, [
+    dstToken,
+    effectiveRecipient,
+    hasExcessivePriceImpact,
+    isReview,
+    priceImpactBlockMessage,
+    sender,
+    setErrors,
+    srcToken,
+    values,
+  ]);
 
   const approvalArgs = useMemo(
     () => ({
@@ -810,6 +842,7 @@ function TransferFormContent() {
           quoteLoading={quoteLoading}
           outputUsd={outputUsd}
           priceImpactPct={priceImpactPct}
+          minimumPriceImpactPct={minimumPriceImpactPct}
           hasSelectedDestinationTokenRef={hasSelectedDestinationTokenRef}
         />
       </TransferSection>
@@ -888,6 +921,7 @@ function TransferFormContent() {
         isQuoteSettled={isQuoteSettled}
         isValidating={isValidating}
         hasExcessivePriceImpact={hasExcessivePriceImpact}
+        priceImpactBlockMessage={priceImpactBlockMessage}
         onSendTransactions={onSendTransactions}
         sendPending={isActiveTransferInFlight}
         recipientConfirmed={addressConfirmed}
@@ -1110,6 +1144,7 @@ function DestinationTokenCard({
   quoteLoading,
   outputUsd,
   priceImpactPct,
+  minimumPriceImpactPct,
   hasSelectedDestinationTokenRef,
 }: {
   isReview: boolean;
@@ -1120,6 +1155,7 @@ function DestinationTokenCard({
   quoteLoading: boolean;
   outputUsd: number | null;
   priceImpactPct: number | null;
+  minimumPriceImpactPct: number | null;
   hasSelectedDestinationTokenRef: React.MutableRefObject<boolean>;
 }) {
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
@@ -1167,7 +1203,11 @@ function DestinationTokenCard({
         </div>
         <div className="transfer-balance mt-1 flex items-center justify-between text-xs leading-[18px] text-gray-450 dark:text-foreground-secondary">
           <span>
-            {!outputUsd ? '$0.00' : formatUsd(outputUsd)}
+            {!bestRoute
+              ? '$0.00'
+              : isNullish(outputUsd)
+                ? 'Price unavailable'
+                : formatUsd(outputUsd)}
             {priceImpactPct != null && (
               <span
                 className={`ml-1 ${
@@ -1180,6 +1220,17 @@ function DestinationTokenCard({
               >
                 ({priceImpactPct >= 0 ? '+' : ''}
                 {priceImpactPct.toLocaleString('en-US', PCT_FORMAT_OPTIONS)}%)
+              </span>
+            )}
+            {bestRoute && !bestRoute.hasFixedOutput && (
+              <span className="ml-1">
+                · Minimum:{' '}
+                {isNullish(minimumPriceImpactPct)
+                  ? 'unavailable'
+                  : `${minimumPriceImpactPct >= 0 ? '+' : ''}${minimumPriceImpactPct.toLocaleString(
+                      'en-US',
+                      PCT_FORMAT_OPTIONS,
+                    )}%`}
               </span>
             )}
           </span>
@@ -1392,6 +1443,7 @@ function ButtonSection({
   isQuoteSettled,
   isValidating,
   hasExcessivePriceImpact,
+  priceImpactBlockMessage,
   onSendTransactions,
   sendPending,
   recipientConfirmed,
@@ -1412,6 +1464,7 @@ function ButtonSection({
   isQuoteSettled: boolean;
   isValidating: boolean;
   hasExcessivePriceImpact: boolean;
+  priceImpactBlockMessage: string;
   onSendTransactions: () => Promise<void>;
   sendPending: boolean;
   recipientConfirmed: boolean;
@@ -1445,7 +1498,7 @@ function ButtonSection({
       text = 'Fetching quote…';
       disabled = true;
     } else if (hasExcessivePriceImpact) {
-      text = PRICE_IMPACT_BLOCK_MESSAGE;
+      text = priceImpactBlockMessage;
       disabled = true;
     } else if (!isApprovalReady) {
       text = 'Fetching quote…';
@@ -1476,6 +1529,10 @@ function ButtonSection({
     );
   }
 
+  let sendText = `Send to ${dstDisplay}`;
+  if (sendPending) sendText = 'Sending…';
+  if (hasExcessivePriceImpact) sendText = priceImpactBlockMessage;
+
   return (
     <div className="mb-4 mt-4 flex items-center justify-between space-x-4">
       <SolidButton
@@ -1494,11 +1551,7 @@ function ButtonSection({
         disabled={sendPending || !recipientConfirmed || hasExcessivePriceImpact}
         className="flex-1 px-3 py-1.5 font-secondary text-white"
       >
-        {hasExcessivePriceImpact
-          ? PRICE_IMPACT_BLOCK_MESSAGE
-          : sendPending
-            ? 'Sending…'
-            : `Send to ${dstDisplay}`}
+        {sendText}
       </SolidButton>
     </div>
   );

--- a/src/features/transfer/engine/TransferForm.tsx
+++ b/src/features/transfer/engine/TransferForm.tsx
@@ -30,7 +30,12 @@ import { useChains } from '../../api/hooks';
 import type { RouteTx } from '../../api/types';
 import { useTokenBalance } from '../../balances/hooks';
 import { readBalance } from '../../balances/read';
-import { formatDisplayAmount, formatFeeAmount, formatUsd } from '../../balances/utils';
+import {
+  formatDisplayAmount,
+  formatFeeAmount,
+  formatUsd,
+  getPriceImpactPercentage,
+} from '../../balances/utils';
 import { useMultiProvider } from '../../chains/hooks';
 import { TransactionHistoryItemType, useStore } from '../../store';
 import { getTokenByKeyFromMap, useTokenByKeyMap } from '../../tokens/hooks';
@@ -52,6 +57,7 @@ import {
 } from './approval';
 import { FeeSectionButton } from './FeeSectionButton';
 import { MaxButton } from './MaxButton';
+import { isPriceImpactTooHigh, PRICE_IMPACT_BLOCK_MESSAGE } from './priceImpact';
 import { emptyRouteMessageForRejections } from './rejections';
 import { RouteSelectionModal } from './routeSelection/RouteSelectionModal';
 import { SlippagePanel } from './SlippagePanel';
@@ -197,6 +203,17 @@ function TransferFormContent() {
 
   // Input USD — used by the fee % calculation in FeeSectionButton.
   const amountUsd = useTokenUsdValue(srcToken, values.amount);
+  const outputAmount = useMemo(() => {
+    if (!bestRoute || !dstToken) return '';
+    try {
+      return formatUnits(BigInt(bestRoute.raw.output), dstToken.decimals);
+    } catch {
+      return '';
+    }
+  }, [bestRoute, dstToken]);
+  const outputUsd = useTokenUsdValue(dstToken, outputAmount);
+  const priceImpactPct = getPriceImpactPercentage(amountUsd, outputUsd);
+  const hasExcessivePriceImpact = isPriceImpactTooHigh(priceImpactPct);
 
   const approvalArgs = useMemo(
     () => ({
@@ -422,7 +439,9 @@ function TransferFormContent() {
   );
 
   const onContinue = useCallback(async () => {
-    if (isAmountDebouncing || !isApprovalReady || !isSourceFeeReady) return;
+    if (isAmountDebouncing || !isApprovalReady || !isSourceFeeReady || hasExcessivePriceImpact) {
+      return;
+    }
     const snapshot = values;
     setIsValidating(true);
     try {
@@ -476,6 +495,7 @@ function TransferFormContent() {
     isAmountDebouncing,
     isApprovalReady,
     isSourceFeeReady,
+    hasExcessivePriceImpact,
     approvalTransactionCount,
     sourceFeeQuery.data,
     validateCurrentForm,
@@ -534,6 +554,10 @@ function TransferFormContent() {
 
   const onSendTransactions = useCallback(async () => {
     if (!sender || !srcToken || !dstToken || !bestRoute || !values.srcChain || !values.dstChain) {
+      return;
+    }
+    if (hasExcessivePriceImpact) {
+      setIsReview(false);
       return;
     }
 
@@ -680,6 +704,7 @@ function TransferFormContent() {
     srcToken,
     dstToken,
     bestRoute,
+    hasExcessivePriceImpact,
     values,
     effectiveRecipient,
     validateCurrentForm,
@@ -773,7 +798,8 @@ function TransferFormContent() {
           recipient={effectiveRecipient}
           bestRoute={bestRoute}
           quoteLoading={quoteLoading}
-          inputUsd={amountUsd}
+          outputUsd={outputUsd}
+          priceImpactPct={priceImpactPct}
           hasSelectedDestinationTokenRef={hasSelectedDestinationTokenRef}
         />
       </TransferSection>
@@ -851,6 +877,7 @@ function TransferFormContent() {
         isApprovalReady={isApprovalReady && isSourceFeeReady}
         isQuoteSettled={isQuoteSettled}
         isValidating={isValidating}
+        hasExcessivePriceImpact={hasExcessivePriceImpact}
         onSendTransactions={onSendTransactions}
         sendPending={isActiveTransferInFlight}
         recipientConfirmed={addressConfirmed}
@@ -1071,7 +1098,8 @@ function DestinationTokenCard({
   recipient,
   bestRoute,
   quoteLoading,
-  inputUsd,
+  outputUsd,
+  priceImpactPct,
   hasSelectedDestinationTokenRef,
 }: {
   isReview: boolean;
@@ -1080,20 +1108,13 @@ function DestinationTokenCard({
   recipient: string;
   bestRoute: AugmentedRoute | undefined;
   quoteLoading: boolean;
-  inputUsd: number | null;
+  outputUsd: number | null;
+  priceImpactPct: number | null;
   hasSelectedDestinationTokenRef: React.MutableRefObject<boolean>;
 }) {
   const { values, setFieldValue } = useFormikContext<TransferFormValues>();
   const { data: balance } = useTokenBalance(dstToken, recipient);
 
-  const outputExact = useMemo(() => {
-    if (!bestRoute || !dstToken) return '';
-    try {
-      return formatUnits(BigInt(bestRoute.raw.output), dstToken.decimals);
-    } catch {
-      return '';
-    }
-  }, [bestRoute, dstToken]);
   const outputDisplay = useMemo(() => {
     if (!bestRoute || !dstToken) return '';
     try {
@@ -1102,14 +1123,6 @@ function DestinationTokenCard({
       return '';
     }
   }, [bestRoute, dstToken]);
-  const outputUsd = useTokenUsdValue(dstToken, outputExact);
-  // Price impact = how much value the transfer loses to fees + slippage + spread.
-  // Only meaningful when both sides have USD prices.
-  const priceImpactPct = useMemo(() => {
-    if (!inputUsd || !outputUsd) return null;
-    return ((outputUsd - inputUsd) / inputUsd) * 100;
-  }, [inputUsd, outputUsd]);
-
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
@@ -1368,6 +1381,7 @@ function ButtonSection({
   isApprovalReady,
   isQuoteSettled,
   isValidating,
+  hasExcessivePriceImpact,
   onSendTransactions,
   sendPending,
   recipientConfirmed,
@@ -1387,6 +1401,7 @@ function ButtonSection({
   isApprovalReady: boolean;
   isQuoteSettled: boolean;
   isValidating: boolean;
+  hasExcessivePriceImpact: boolean;
   onSendTransactions: () => Promise<void>;
   sendPending: boolean;
   recipientConfirmed: boolean;
@@ -1418,6 +1433,9 @@ function ButtonSection({
       disabled = true;
     } else if (isAmountDebouncing) {
       text = 'Fetching quote…';
+      disabled = true;
+    } else if (hasExcessivePriceImpact) {
+      text = PRICE_IMPACT_BLOCK_MESSAGE;
       disabled = true;
     } else if (!isApprovalReady) {
       text = 'Fetching quote…';
@@ -1463,10 +1481,14 @@ function ButtonSection({
         type="button"
         color="accent"
         onClick={onSendTransactions}
-        disabled={sendPending || !recipientConfirmed}
+        disabled={sendPending || !recipientConfirmed || hasExcessivePriceImpact}
         className="flex-1 px-3 py-1.5 font-secondary text-white"
       >
-        {sendPending ? 'Sending…' : `Send to ${dstDisplay}`}
+        {hasExcessivePriceImpact
+          ? PRICE_IMPACT_BLOCK_MESSAGE
+          : sendPending
+            ? 'Sending…'
+            : `Send to ${dstDisplay}`}
       </SolidButton>
     </div>
   );

--- a/src/features/transfer/engine/priceImpact.test.ts
+++ b/src/features/transfer/engine/priceImpact.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from 'vitest';
 
 import { getPriceImpactPercentage } from '../../balances/utils';
-import { isPriceImpactTooHigh } from './priceImpact';
+import {
+  getPriceImpactBlockMessage,
+  getRouteOutputAmounts,
+  isPriceImpactTooHigh,
+} from './priceImpact';
 
 describe('isPriceImpactTooHigh', () => {
   test('blocks losses at or above 10%', () => {
@@ -19,10 +23,21 @@ describe('isPriceImpactTooHigh', () => {
   });
 
   test('blocks when the executable minimum crosses the threshold', () => {
-    const expectedImpact = getPriceImpactPercentage(100, 91);
-    const minimumImpact = getPriceImpactPercentage(100, 88.27);
+    const [expectedOutput, minimumOutput] = getRouteOutputAmounts(
+      { output: '9100', outputMin: '8827' },
+      2,
+    );
+    const expectedImpact = getPriceImpactPercentage(100, Number(expectedOutput));
+    const minimumImpact = getPriceImpactPercentage(100, Number(minimumOutput));
 
     expect(isPriceImpactTooHigh(expectedImpact)).toBe(false);
     expect(isPriceImpactTooHigh(minimumImpact)).toBe(true);
+    expect(getPriceImpactBlockMessage(minimumImpact)).toBe(
+      'Minimum received is 11.73% below input value',
+    );
+  });
+
+  test('fails loudly for malformed route output amounts', () => {
+    expect(() => getRouteOutputAmounts({ output: '9100', outputMin: 'invalid' }, 2)).toThrow();
   });
 });

--- a/src/features/transfer/engine/priceImpact.test.ts
+++ b/src/features/transfer/engine/priceImpact.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
+import { getPriceImpactPercentage } from '../../balances/utils';
 import { isPriceImpactTooHigh } from './priceImpact';
 
 describe('isPriceImpactTooHigh', () => {
@@ -15,5 +16,13 @@ describe('isPriceImpactTooHigh', () => {
 
   test('allows transfers when price impact is unavailable', () => {
     expect(isPriceImpactTooHigh(null)).toBe(false);
+  });
+
+  test('blocks when the executable minimum crosses the threshold', () => {
+    const expectedImpact = getPriceImpactPercentage(100, 91);
+    const minimumImpact = getPriceImpactPercentage(100, 88.27);
+
+    expect(isPriceImpactTooHigh(expectedImpact)).toBe(false);
+    expect(isPriceImpactTooHigh(minimumImpact)).toBe(true);
   });
 });

--- a/src/features/transfer/engine/priceImpact.test.ts
+++ b/src/features/transfer/engine/priceImpact.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+
+import { isPriceImpactTooHigh } from './priceImpact';
+
+describe('isPriceImpactTooHigh', () => {
+  test('blocks losses at or above 10%', () => {
+    expect(isPriceImpactTooHigh(-10)).toBe(true);
+    expect(isPriceImpactTooHigh(-25)).toBe(true);
+  });
+
+  test('allows losses below 10% and positive impact', () => {
+    expect(isPriceImpactTooHigh(-9.99)).toBe(false);
+    expect(isPriceImpactTooHigh(5)).toBe(false);
+  });
+
+  test('allows transfers when price impact is unavailable', () => {
+    expect(isPriceImpactTooHigh(null)).toBe(false);
+  });
+});

--- a/src/features/transfer/engine/priceImpact.ts
+++ b/src/features/transfer/engine/priceImpact.ts
@@ -1,0 +1,6 @@
+export const MAX_PRICE_IMPACT_PCT = 10;
+export const PRICE_IMPACT_BLOCK_MESSAGE = `Price impact is ${MAX_PRICE_IMPACT_PCT}% or higher`;
+
+export function isPriceImpactTooHigh(priceImpactPct: number | null): boolean {
+  return priceImpactPct != null && priceImpactPct <= -MAX_PRICE_IMPACT_PCT;
+}

--- a/src/features/transfer/engine/priceImpact.ts
+++ b/src/features/transfer/engine/priceImpact.ts
@@ -1,6 +1,8 @@
+import { isNullish } from '@hyperlane-xyz/utils';
+
 export const MAX_PRICE_IMPACT_PCT = 10;
 export const PRICE_IMPACT_BLOCK_MESSAGE = `Price impact is ${MAX_PRICE_IMPACT_PCT}% or higher`;
 
 export function isPriceImpactTooHigh(priceImpactPct: number | null): boolean {
-  return priceImpactPct != null && priceImpactPct <= -MAX_PRICE_IMPACT_PCT;
+  return !isNullish(priceImpactPct) && priceImpactPct <= -MAX_PRICE_IMPACT_PCT;
 }

--- a/src/features/transfer/engine/priceImpact.ts
+++ b/src/features/transfer/engine/priceImpact.ts
@@ -1,8 +1,28 @@
 import { isNullish } from '@hyperlane-xyz/utils';
+import { formatUnits } from 'viem';
+
+import type { RouteResponse } from '../../api/types';
 
 export const MAX_PRICE_IMPACT_PCT = 10;
-export const PRICE_IMPACT_BLOCK_MESSAGE = `Price impact is ${MAX_PRICE_IMPACT_PCT}% or higher`;
 
 export function isPriceImpactTooHigh(priceImpactPct: number | null): boolean {
   return !isNullish(priceImpactPct) && priceImpactPct <= -MAX_PRICE_IMPACT_PCT;
+}
+
+export function getPriceImpactBlockMessage(priceImpactPct: number | null): string {
+  const lossPct = Math.abs(priceImpactPct ?? MAX_PRICE_IMPACT_PCT).toLocaleString('en-US', {
+    maximumFractionDigits: 2,
+  });
+  return `Minimum received is ${lossPct}% below input value`;
+}
+
+export function getRouteOutputAmounts(
+  route: Pick<RouteResponse, 'output' | 'outputMin'> | undefined,
+  decimals: number | undefined,
+): [expected: string, minimum: string] {
+  if (!route || isNullish(decimals)) return ['', ''];
+  return [
+    formatUnits(BigInt(route.output), decimals),
+    formatUnits(BigInt(route.outputMin), decimals),
+  ];
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npx --yes pnpm@11.20.0 install --frozen-lockfile",
+  "buildCommand": "npx --yes pnpm@11.20.0 run build"
+}


### PR DESCRIPTION
## Summary

- calculate expected price impact from input and output USD values
- block Continue and Send when fresh minimum-output pricing implies a 10% or greater loss
- fail open when current pricing is unavailable, stale, or failed while retaining cached display values
- add unit coverage for the calculation, minimum-output threshold, and failed-refresh behavior
- pin Vercel install and build commands to the repository's pnpm 11.20.0
