### PR TITLE
feat: support hiding configured warp routes

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -45,6 +45,7 @@ interface Config {
   version: string; // App release version shown in metadata/analytics
   walletConnectProjectId: string; // Project ID provided by walletconnect
   walletProtocols: ProtocolType[] | undefined; // Wallet Protocols to show in the wallet connect modal. Leave undefined to include all of them
+  warpRouteDenylist: string[]; // Route IDs hidden from this UI only; the router API and contracts remain public
   rpcOverrides: string; // JSON string containing a map of chain names to an object with an URL for RPC overrides (For an example check the .env.example file)
   enableTrackingEvents: boolean; // Allow tracking events to happen on some actions;
   featuredChains: string[]; // Chains to pin at the top of the default chain picker sort
@@ -83,6 +84,7 @@ export const config: Config = Object.freeze({
     ProtocolType.Tron,
     ProtocolType.Aleo,
   ],
+  warpRouteDenylist: [],
   shouldDisableChains: false,
   rpcOverrides,
   enableTrackingEvents: false,

--- a/src/features/api/RouterClient.test.ts
+++ b/src/features/api/RouterClient.test.ts
@@ -262,6 +262,51 @@ describe('RouterClient route denylist', () => {
       }),
     ).resolves.toEqual({ routes: [baseRoute], expiresAt: 1, rejections: [] });
   });
+
+  test('cannot bypass the denylist with a missing route connection', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          routes: [
+            {
+              ...baseRoute,
+              connection: null,
+              steps: [
+                {
+                  type: 'bridge',
+                  chain: 56,
+                  destChain: 41444,
+                  asset: baseToken.address,
+                  router: baseToken.address,
+                  amountIn: '1',
+                  amountOut: '1',
+                  warpRouteId: 'NES/bsc',
+                  fee: {
+                    tokenFee: '0',
+                    igpToken: baseToken.address,
+                    igpAmount: '0',
+                    localNativeFee: '0',
+                  },
+                },
+              ],
+            },
+          ],
+          expiresAt: 1,
+        }),
+      ),
+    );
+
+    await expect(
+      new RouterClient('https://router.test', ['NES/bsc']).quote({
+        srcChain: 56,
+        dstChain: 41444,
+        srcToken: baseToken.address,
+        dstToken: baseToken.address,
+        amount: 1n,
+        sender: '0x1111111111111111111111111111111111111111',
+      }),
+    ).resolves.toEqual({ routes: [], expiresAt: 1 });
+  });
 });
 
 describe('ChainsResponseSchema', () => {

--- a/src/features/api/RouterClient.test.ts
+++ b/src/features/api/RouterClient.test.ts
@@ -16,6 +16,31 @@ const baseChain = {
   supportsNative: true,
 };
 
+const baseToken = {
+  chainId: 56,
+  address: '0x2222222222222222222222222222222222222222',
+  symbol: 'TEST',
+  decimals: 18,
+  isNative: false,
+  isBridgeToken: true,
+  isPoolToken: false,
+  canBridge: true,
+  canSwap: false,
+  bridgeSymbols: ['TEST'],
+  warpRouteIds: ['TEST/route'],
+};
+
+const baseRoute = {
+  steps: [],
+  output: '100',
+  outputMin: '99',
+  executionKind: 'warpDirect',
+  connection: { symbol: 'TEST', warpRouteId: 'TEST/route' },
+  gas: { originGas: '1', destGas: '1' },
+  tx: null,
+  approval: null,
+};
+
 describe('RouterClient.availableRoutes', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -153,6 +178,89 @@ describe('RouterClient.tokens', () => {
       'https://router.test/v1/tokens?chain=ethereum',
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
+  });
+
+  test('hides tokens available only through denied routes', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          baseToken,
+          { ...baseToken, symbol: 'HIDDEN', warpRouteIds: ['NES/bsc'] },
+          { ...baseToken, symbol: 'SHARED', warpRouteIds: ['NES/bsc', 'TEST/route'] },
+        ]),
+      ),
+    );
+
+    await expect(new RouterClient('https://router.test', ['NES/bsc']).tokens()).resolves.toEqual({
+      tokens: [
+        baseToken,
+        { ...baseToken, symbol: 'SHARED', warpRouteIds: ['NES/bsc', 'TEST/route'] },
+      ],
+    });
+  });
+});
+
+describe('RouterClient route denylist', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('hides denied available-route tokens', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          direction: 'fromSource',
+          tokens: [baseToken, { ...baseToken, symbol: 'HIDDEN', warpRouteIds: ['NES/bsc'] }],
+        }),
+      ),
+    );
+
+    await expect(
+      new RouterClient('https://router.test', ['NES/bsc']).availableRoutes({
+        srcChain: 56,
+        srcToken: baseToken.address,
+      }),
+    ).resolves.toEqual({ direction: 'fromSource', tokens: [baseToken] });
+  });
+
+  test('hides denied quote routes and their rejections', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          routes: [
+            baseRoute,
+            {
+              ...baseRoute,
+              connection: { symbol: 'NES', warpRouteId: 'NES/bsc' },
+            },
+          ],
+          expiresAt: 1,
+          rejections: [
+            {
+              code: 'NO_ROUTE',
+              message: 'hidden',
+              srcChain: 56,
+              dstChain: 41444,
+              srcToken: baseToken.address,
+              dstToken: baseToken.address,
+              amount: '1',
+              warpRouteId: 'NES/bsc',
+            },
+          ],
+        }),
+      ),
+    );
+
+    await expect(
+      new RouterClient('https://router.test', ['NES/bsc']).quote({
+        srcChain: 56,
+        dstChain: 41444,
+        srcToken: baseToken.address,
+        dstToken: baseToken.address,
+        amount: 1n,
+        sender: '0x1111111111111111111111111111111111111111',
+      }),
+    ).resolves.toEqual({ routes: [baseRoute], expiresAt: 1, rejections: [] });
   });
 });
 

--- a/src/features/api/RouterClient.ts
+++ b/src/features/api/RouterClient.ts
@@ -51,7 +51,10 @@ const REQUEST_TIMEOUT_MS = 15_000;
 const MAX_QUOTE_TIMEOUT_MS = 30_000;
 
 export class RouterClient {
-  constructor(private baseUrl: string) {}
+  constructor(
+    private baseUrl: string,
+    private warpRouteDenylist: readonly string[] = [],
+  ) {}
 
   async health(options: RequestOptions = {}): Promise<boolean> {
     try {
@@ -78,7 +81,7 @@ export class RouterClient {
   //   { search }      → cross-chain search
   //   { ids }         → explicit lookups (repeated &ids=, max 5)
   // ?ids is mutually exclusive with chain/search.
-  tokens(query: TokensQuery = {}, options: RequestOptions = {}): Promise<TokensResponse> {
+  async tokens(query: TokensQuery = {}, options: RequestOptions = {}): Promise<TokensResponse> {
     const params = new URLSearchParams();
     if (query.ids?.length) {
       for (const id of query.ids) params.append('ids', id);
@@ -87,7 +90,12 @@ export class RouterClient {
       if (query.search) params.set('search', query.search);
     }
     const qs = params.toString();
-    return this.get(`/v1/tokens${qs ? `?${qs}` : ''}`, TokensResponseSchema, options);
+    const response = await this.get(
+      `/v1/tokens${qs ? `?${qs}` : ''}`,
+      TokensResponseSchema,
+      options,
+    );
+    return { ...response, tokens: response.tokens.filter((token) => !this.isDeniedToken(token)) };
   }
 
   availableRoutes(
@@ -126,11 +134,14 @@ export class RouterClient {
       `/v1/available-routes?${search.toString()}`,
       AvailableRoutesResponseSchema,
       options,
-    );
+    ).then((response) => ({
+      ...response,
+      tokens: response.tokens.filter((token) => !this.isDeniedToken(token)),
+    }));
   }
 
   async quote(params: QuoteParams, options: RequestOptions = {}): Promise<QuoteResponse> {
-    return this.request(
+    const response = await this.request(
       '/v1/quote',
       QuoteResponseSchema,
       {
@@ -150,10 +161,11 @@ export class RouterClient {
       },
       options,
     );
+    return this.filterQuoteResponse(response);
   }
 
   async maxQuote(params: MaxQuoteParams, options: RequestOptions = {}): Promise<MaxQuoteResponse> {
-    return this.request(
+    const response = await this.request(
       '/v1/quote/max',
       MaxQuoteResponseSchema,
       {
@@ -173,6 +185,30 @@ export class RouterClient {
       },
       { ...options, timeoutMs: options.timeoutMs ?? MAX_QUOTE_TIMEOUT_MS },
     );
+    return this.filterQuoteResponse(response);
+  }
+
+  private isDeniedRoute(routeId: string | undefined): boolean {
+    return !!routeId && this.warpRouteDenylist.includes(routeId);
+  }
+
+  private isDeniedToken(token: { warpRouteIds: string[] }): boolean {
+    return (
+      token.warpRouteIds.length > 0 &&
+      token.warpRouteIds.every((routeId) => this.isDeniedRoute(routeId))
+    );
+  }
+
+  private filterQuoteResponse<T extends QuoteResponse | MaxQuoteResponse>(response: T): T {
+    return {
+      ...response,
+      routes: response.routes.filter((route) => !this.isDeniedRoute(route.connection?.warpRouteId)),
+      ...(response.rejections && {
+        rejections: response.rejections.filter(
+          (rejection) => !this.isDeniedRoute(rejection.warpRouteId),
+        ),
+      }),
+    };
   }
 
   private async get<T>(
@@ -213,4 +249,4 @@ export class RouterClient {
 }
 
 // Singleton — keep the same client across hooks/queries.
-export const routerClient = new RouterClient(config.routerApiUrl);
+export const routerClient = new RouterClient(config.routerApiUrl, config.warpRouteDenylist);

--- a/src/features/api/RouterClient.ts
+++ b/src/features/api/RouterClient.ts
@@ -14,6 +14,7 @@ import {
   type MaxQuoteResponse,
   type QuoteResponse,
   type ReadinessResponse,
+  type RouteResponse,
   type TokensQuery,
   type TokensResponse,
 } from './types';
@@ -202,13 +203,20 @@ export class RouterClient {
   private filterQuoteResponse<T extends QuoteResponse | MaxQuoteResponse>(response: T): T {
     return {
       ...response,
-      routes: response.routes.filter((route) => !this.isDeniedRoute(route.connection?.warpRouteId)),
+      routes: response.routes.filter((route) => !this.isDeniedQuoteRoute(route)),
       ...(response.rejections && {
         rejections: response.rejections.filter(
           (rejection) => !this.isDeniedRoute(rejection.warpRouteId),
         ),
       }),
     };
+  }
+
+  private isDeniedQuoteRoute(route: RouteResponse): boolean {
+    if (this.isDeniedRoute(route.connection?.warpRouteId)) return true;
+    return route.steps.some(
+      (step) => step.type === 'bridge' && this.isDeniedRoute(step.warpRouteId),
+    );
   }
 
   private async get<T>(

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "npx --yes pnpm@11.20.0 install --frozen-lockfile",
+  "buildCommand": "npx --yes pnpm@11.20.0 run build"
+}


### PR DESCRIPTION
## Summary

- add an empty, configurable UI-only Warp route denylist
- hide denied-only tokens and available-route results
- remove denied routes and rejections from normal and max quotes
- validate both route connection and bridge-step IDs
- pin Vercel install/build commands to pnpm 11.20.0

This adds generic presentation gating only. No route is denied on `main`; URE and on-chain contracts remain public.

## Validation

- `pnpm test` (423 passed before final hardening)
- `pnpm vitest src/features/api/RouterClient.test.ts` (11 passed after final hardening)
- `pnpm typecheck`
- `pnpm lint` (2 existing console warnings)
- `pnpm exec oxfmt --check src/consts/config.ts src/features/api/RouterClient.ts src/features/api/RouterClient.test.ts vercel.json`