### PR TITLE
feat: hide NES route on Nexus

### DIFF
--- a/src/consts/config.ts
+++ b/src/consts/config.ts
@@ -84,7 +84,7 @@ export const config: Config = Object.freeze({
     ProtocolType.Tron,
     ProtocolType.Aleo,
   ],
-  warpRouteDenylist: [],
+  warpRouteDenylist: ['NES/bsc'],
   shouldDisableChains: true,
   rpcOverrides,
   enableTrackingEvents: true,


### PR DESCRIPTION
Adds the NES/bsc Warp route to the Nexus UI denylist. The route remains available through URE and onchain; Nexus omits it from tokens, available routes, quotes, and quote rejections.