### PR TITLE
fix: restore wallet E2E smoke CI

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
   # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
-  WALLET_CONNECT_ID_CACHE_VERSION: v1
+  WALLET_CONNECT_ID_CACHE_VERSION: v2
 
 jobs:
   build:

--- a/.depot/workflows/e2e-smoke.yml
+++ b/.depot/workflows/e2e-smoke.yml
@@ -10,7 +10,7 @@ on:
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
   # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
-  WALLET_CONNECT_ID_CACHE_VERSION: v1
+  WALLET_CONNECT_ID_CACHE_VERSION: v2
 
 jobs:
   e2e-smoke:

--- a/.depot/workflows/e2e-wallet-full.yml
+++ b/.depot/workflows/e2e-wallet-full.yml
@@ -11,7 +11,7 @@ on:
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
   # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
-  WALLET_CONNECT_ID_CACHE_VERSION: v1
+  WALLET_CONNECT_ID_CACHE_VERSION: v2
 
 jobs:
   e2e-wallet:

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 env:
   NEXT_PUBLIC_ROUTER_API_URL: https://hyperswaps-api.hyperlane.xyz
   # Bump when NEXT_PUBLIC_WALLET_CONNECT_ID changes.
-  WALLET_CONNECT_ID_CACHE_VERSION: v1
+  WALLET_CONNECT_ID_CACHE_VERSION: v2
 
 jobs:
   build:

--- a/src/features/wallet/context/EvmWalletContext.tsx
+++ b/src/features/wallet/context/EvmWalletContext.tsx
@@ -29,23 +29,21 @@ import { isE2EMode } from '../_e2e/isE2E';
 function initWagmi(multiProvider: MultiProtocolProvider, e2e: boolean) {
   const chains = getWagmiChainConfigs(multiProvider);
 
-  const baseConnectors = connectorsForWallets(
-    [
-      {
-        groupName: 'Recommended',
-        wallets: [metaMaskWallet, injectedWallet, walletConnectWallet, ledgerWallet],
-      },
-      {
-        groupName: 'More',
-        wallets: [binanceWallet, coinbaseWallet, rainbowWallet, trustWallet, argentWallet],
-      },
-    ],
-    { appName: APP_NAME, projectId: config.walletConnectProjectId },
-  );
-
   const connectors = e2e
     ? [mock({ accounts: [MOCK_EVM_ADDRESS], features: { reconnect: true } })]
-    : baseConnectors;
+    : connectorsForWallets(
+        [
+          {
+            groupName: 'Recommended',
+            wallets: [metaMaskWallet, injectedWallet, walletConnectWallet, ledgerWallet],
+          },
+          {
+            groupName: 'More',
+            wallets: [binanceWallet, coinbaseWallet, rainbowWallet, trustWallet, argentWallet],
+          },
+        ],
+        { appName: APP_NAME, projectId: config.walletConnectProjectId },
+      );
 
   const wagmiConfig = createConfig({
     // Splice to make annoying wagmi type happy


### PR DESCRIPTION
## Summary

- invalidate cached Next builds after the WalletConnect project ID secret changed
- avoid constructing production WalletConnect connectors in gated E2E mode
- preserve the existing live engine/registry smoke coverage

## Root cause

The failed smoke job restored build output created with an empty/stale `NEXT_PUBLIC_WALLET_CONNECT_ID`. RainbowKit eagerly constructed `walletConnectWallet` even though E2E mode uses only the mock connector, so every smoke page hit the fatal missing-project-ID boundary.

## Validation

- `pnpm typecheck`
- `pnpm lint` (existing console warnings only)
- `pnpm test` (442 passed)
- clean production `pnpm build` with WalletConnect ID
- `pnpm check:bundle`
- `CI=1 E2E_USE_PROD=1 pnpm run test:e2e:wallet:smoke` (green; live coverage unchanged)