### PR TITLE
fix: disable unsafe iframe wallet integrations

### DIFF
--- a/src/features/wallet/context/CosmosWalletContext.test.tsx
+++ b/src/features/wallet/context/CosmosWalletContext.test.tsx
@@ -1,0 +1,60 @@
+import { Logger, WalletManager } from '@cosmos-kit/core';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { CosmosWalletContext } from './CosmosWalletContext';
+
+const chainProviderSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('@chakra-ui/react', () => ({
+  ChakraProvider: ({ children }: { children: ReactNode }) => children,
+  extendTheme: () => ({}),
+}));
+
+vi.mock('@cosmos-kit/cosmostation', () => ({ wallets: [] }));
+vi.mock('@cosmos-kit/keplr', () => ({ wallets: [] }));
+vi.mock('@cosmos-kit/leap', () => ({ wallets: [] }));
+vi.mock('@cosmos-kit/react', () => ({
+  ChainProvider: (props: { children: ReactNode }) => {
+    chainProviderSpy(props);
+    return props.children;
+  },
+}));
+
+vi.mock('@hyperlane-xyz/widgets/walletIntegrations/cosmos', () => ({
+  getCosmosKitChainConfigs: () => ({ chains: [], assets: [] }),
+}));
+
+vi.mock('../../chains/hooks', () => ({
+  useMultiProvider: () => ({ metadata: {} }),
+}));
+
+vi.mock('../_e2e/isE2E', () => ({ isE2EMode: () => false }));
+
+describe('CosmosWalletContext', () => {
+  beforeEach(() => chainProviderSpy.mockClear());
+  afterEach(() => vi.unstubAllGlobals());
+
+  test('disables parent-provided Cosmiframe wallets', () => {
+    renderToStaticMarkup(
+      <CosmosWalletContext>
+        <div />
+      </CosmosWalletContext>,
+    );
+
+    expect(chainProviderSpy).toHaveBeenCalledOnce();
+    expect(chainProviderSpy.mock.calls[0][0]).toMatchObject({
+      allowedIframeParentOrigins: [],
+    });
+  });
+
+  test('the empty allowlist disables Cosmiframe inside an iframe', () => {
+    vi.stubGlobal('window', { self: {}, parent: {} });
+
+    const walletManager = new WalletManager([], [], new Logger('NONE'), false, true, []);
+
+    expect(walletManager.cosmiframeEnabled).toBe(false);
+    expect(walletManager.mainWallets).toHaveLength(0);
+  });
+});

--- a/src/features/wallet/context/CosmosWalletContext.tsx
+++ b/src/features/wallet/context/CosmosWalletContext.tsx
@@ -49,6 +49,9 @@ export function CosmosWalletContext({ children }: PropsWithChildren<unknown>) {
         chains={chains}
         assetLists={assets}
         wallets={walletsList}
+        // Parent-provided wallets are unsupported; opt out of cosmos-kit's
+        // default Cosmiframe integration.
+        allowedIframeParentOrigins={[]}
         throwErrors={false}
         walletConnectOptions={{
           signClient: {

--- a/src/features/wallet/context/SolanaWalletContext.test.tsx
+++ b/src/features/wallet/context/SolanaWalletContext.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { SolanaWalletContext } from './SolanaWalletContext';
+
+const { legacySolflareSpy, walletProviderSpy } = vi.hoisted(() => ({
+  legacySolflareSpy: vi.fn(),
+  walletProviderSpy: vi.fn(),
+}));
+
+function wallet(name: string) {
+  return class {
+    name = name;
+  };
+}
+
+vi.mock('@drift-labs/snap-wallet-adapter', () => ({
+  SnapWalletAdapter: wallet('MetaMask'),
+}));
+
+vi.mock('@solana/wallet-adapter-backpack', () => ({
+  BackpackWalletAdapter: wallet('Backpack'),
+}));
+
+vi.mock('@solana/wallet-adapter-react', () => ({
+  ConnectionProvider: ({ children }: { children: ReactNode }) => children,
+  WalletProvider: (props: { children: ReactNode; wallets: { name: string }[] }) => {
+    walletProviderSpy(props);
+    return props.children;
+  },
+}));
+
+vi.mock('@solana/wallet-adapter-react-ui', () => ({
+  WalletModalProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('@solana/wallet-adapter-wallets', () => ({
+  LedgerWalletAdapter: wallet('Ledger'),
+  PhantomWalletAdapter: wallet('Phantom'),
+  SalmonWalletAdapter: wallet('Salmon'),
+  SolflareWalletAdapter: class {
+    name = 'Solflare';
+
+    constructor() {
+      legacySolflareSpy();
+    }
+  },
+  TrustWalletAdapter: wallet('Trust'),
+}));
+
+vi.mock('@solana/web3.js', () => ({ clusterApiUrl: () => 'http://localhost' }));
+vi.mock('react-toastify', () => ({ toast: { error: vi.fn() } }));
+vi.mock('../_e2e/isE2E', () => ({ isE2EMode: () => false }));
+
+describe('SolanaWalletContext', () => {
+  beforeEach(() => {
+    legacySolflareSpy.mockClear();
+    walletProviderSpy.mockClear();
+  });
+
+  test('does not register the legacy Solflare iframe adapter', () => {
+    renderToStaticMarkup(
+      <SolanaWalletContext>
+        <div />
+      </SolanaWalletContext>,
+    );
+
+    expect(legacySolflareSpy).not.toHaveBeenCalled();
+    expect(walletProviderSpy).toHaveBeenCalledOnce();
+    expect(walletProviderSpy.mock.calls[0][0].wallets).not.toContainEqual(
+      expect.objectContaining({ name: 'Solflare' }),
+    );
+  });
+});

--- a/src/features/wallet/context/SolanaWalletContext.tsx
+++ b/src/features/wallet/context/SolanaWalletContext.tsx
@@ -8,7 +8,6 @@ import '@solana/wallet-adapter-react-ui/styles.css';
 import {
   LedgerWalletAdapter,
   SalmonWalletAdapter,
-  SolflareWalletAdapter,
   TrustWalletAdapter,
   PhantomWalletAdapter,
 } from '@solana/wallet-adapter-wallets';
@@ -28,10 +27,11 @@ export function SolanaWalletContext({ children }: PropsWithChildren<unknown>) {
   const e2e = isE2EMode();
   const wallets = useMemo(
     () => {
+      // WalletProvider discovers Wallet Standard wallets automatically; avoid
+      // legacy hosted-iframe adapters here.
       const real = [
         new PhantomWalletAdapter(),
         new BackpackWalletAdapter(),
-        new SolflareWalletAdapter(),
         new SalmonWalletAdapter(),
         new SnapWalletAdapter(),
         new TrustWalletAdapter(),

--- a/tests/wallet-connect/protocol-wallet-modals.spec.ts
+++ b/tests/wallet-connect/protocol-wallet-modals.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+
 import { selectOriginTokenOnChain } from '../e2e-wallet/helpers/formFlow';
 
 test.describe('Wallet Connect - Protocol Modals', () => {
@@ -16,18 +17,10 @@ test.describe('Wallet Connect - Protocol Modals', () => {
 
     const dialog = page.getByRole('dialog', { name: 'Connect a Wallet' });
     await expect(dialog).toBeVisible();
-    await expect(
-      dialog.getByRole('heading', { name: 'Connect a Wallet' }),
-    ).toBeVisible();
-    await expect(
-      dialog.getByRole('button', { name: 'MetaMask' }),
-    ).toBeVisible();
-    await expect(
-      dialog.getByRole('button', { name: 'WalletConnect' }),
-    ).toBeVisible();
-    await expect(
-      dialog.getByRole('button', { name: 'Coinbase Wallet' }),
-    ).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Connect a Wallet' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'MetaMask' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'WalletConnect' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Coinbase Wallet' })).toBeVisible();
 
     // Close
     await dialog.getByRole('button', { name: 'Close' }).click();
@@ -45,12 +38,8 @@ test.describe('Wallet Connect - Protocol Modals', () => {
     // Solana wallet modal
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
-    await expect(
-      dialog.getByText('Connect a wallet on Solana to continue'),
-    ).toBeVisible();
-    await expect(
-      dialog.getByRole('button', { name: 'Solflare' }),
-    ).toBeVisible();
+    await expect(dialog.getByText('Connect a wallet on Solana to continue')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Phantom' })).toBeVisible();
 
     await page.keyboard.press('Escape');
     await expect(dialog).not.toBeVisible();


### PR DESCRIPTION
## Summary

Disable two unused or legacy iframe-wallet paths that let an embedding parent influence the wallet address used by the transfer form:

- opt out of cosmos-kit's default Cosmiframe integration with an explicit empty parent-origin allowlist
- remove the legacy hosted-iframe Solflare adapter; installed Solflare extensions remain available through Wallet Standard discovery
- add focused regression coverage for both mitigations

## Investigation

### Cosmos / Cosmiframe

`CosmosWalletContext` previously omitted `allowedIframeParentOrigins`. The installed provider chain forwards that omission from `@cosmos-kit/react` through `react-lite` to `@cosmos-kit/core@2.18.1`, whose `WalletManager` supplies a default regular-expression allowlist and enables Cosmiframe whenever the app is framed.

Those dependency defaults use prefix-only regular expressions. A parent origin matching an allowed prefix could therefore satisfy the trust check, provide a Cosmos wallet address, and have that connected destination address used as the transfer recipient.

Runtime probes confirmed the intended hard-disable behavior:

- omitted allowlist inside an iframe: Cosmiframe enabled and injected
- explicit `[]` inside an iframe: Cosmiframe disabled and no Cosmiframe wallet injected

A cross-origin browser comparison also confirmed that the current Nexus deployment emits the parent-wallet handshake while this PR's preview does not. The preview continues to emit the documented widget `ready` event.

### Wallet-provider variant analysis

An active-provider sweep found the same trust-boundary class in the legacy Solflare web fallback. `@solflare-wallet/sdk@1.4.2` installs a message listener that selects messages by channel but does not validate `event.origin` or `event.source`. A forged connect event was reproduced against the installed artifact and caused it to report an arbitrary supplied Solana public key as connected.

The app explicitly instantiated that legacy adapter. Removing it closes the hosted-iframe path. `WalletProvider` already discovers Wallet Standard implementations, so an installed Solflare extension remains available without this fallback.

The sweep found no other active parent-wallet message path:

- the embed page's wildcard message is outbound-only and contains only readiness metadata
- the Firefox MetaMask compatibility stream requires its configured target window as the message source
- other active Solana wallet paths either use injected providers or validate popup/source identity
- Safe Apps and Starknet controller message paths are present only transitively and are not instantiated by this app

## Why this diff

- An empty Cosmos parent-origin list is the dependency's supported opt-out and fails closed before Cosmiframe wallet construction.
- No trusted Cosmiframe parent integration is configured or supported by this template, so an exact allowlist would retain unnecessary attack surface.
- Removing the legacy Solflare adapter is smaller and safer than monkey-patching a dependency-private handler; current upstream/npm `@solflare-wallet/sdk` still lacks the required source/origin validation.
- Public iframe embedding remains intentional and unchanged. Embedding permission and permission to act as a wallet source are separate controls.
- Recipient warnings are not a substitute: the attacker-controlled value is presented as a connected destination wallet before transfer construction.

## Validation

- focused wallet-context tests: 3 passed
- full unit suite: 52 files / 445 tests passed
- `pnpm typecheck`
- `pnpm lint` (2 pre-existing `no-console` warnings)
- `pnpm exec oxfmt --check` on changed files
- `NEXT_PUBLIC_WALLET_CONNECT_ID=test pnpm build`
- `git diff --check`
- exact installed-artifact runtime probes for both Cosmos disablement and Solflare message acceptance
- cross-origin live-versus-preview browser handshake comparison
- built client chunks contain neither the Solflare iframe URL nor its message channel
- exact-head CI: 18 successful checks, including both full E2E shards and E2E smoke

## Rollout

Merging this PR does not remediate the current Nexus deployment by itself. After merge:

1. propagate `main` into `nexus` and resolve the existing sync conflict
2. merge the Nexus sync only after its required checks pass
3. deploy the resulting exact `nexus` SHA to `nexus.hyperlane.xyz`
4. verify from a fresh framed browser that neither parent-wallet handshake/address adoption path is reachable and that the normal embed `ready` event still works

Keep the incident open until that production verification is complete. Existing tabs running an older bundle must reload to receive the fix.
